### PR TITLE
Fix fresh observer checkpoint fallback

### DIFF
--- a/crates/oasis7_node/src/error.rs
+++ b/crates/oasis7_node/src/error.rs
@@ -2,16 +2,41 @@ use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeError {
-    InvalidRole { role: String },
-    InvalidConfig { reason: String },
-    Consensus { reason: String },
-    Gossip { reason: String },
-    Replication { reason: String },
-    Execution { reason: String },
-    AlreadyRunning { node_id: String },
-    NotRunning { node_id: String },
-    ThreadSpawnFailed { reason: String },
-    ThreadJoinFailed { node_id: String },
+    InvalidRole {
+        role: String,
+    },
+    InvalidConfig {
+        reason: String,
+    },
+    Consensus {
+        reason: String,
+    },
+    Gossip {
+        reason: String,
+    },
+    Replication {
+        reason: String,
+    },
+    ExecutionMismatchRollbackUnavailable {
+        payload_height: u64,
+        rollback_height: u64,
+        reason: String,
+    },
+    Execution {
+        reason: String,
+    },
+    AlreadyRunning {
+        node_id: String,
+    },
+    NotRunning {
+        node_id: String,
+    },
+    ThreadSpawnFailed {
+        reason: String,
+    },
+    ThreadJoinFailed {
+        node_id: String,
+    },
 }
 
 impl fmt::Display for NodeError {
@@ -24,6 +49,15 @@ impl fmt::Display for NodeError {
             NodeError::Consensus { reason } => write!(f, "node consensus error: {}", reason),
             NodeError::Gossip { reason } => write!(f, "node gossip error: {}", reason),
             NodeError::Replication { reason } => write!(f, "node replication error: {}", reason),
+            NodeError::ExecutionMismatchRollbackUnavailable {
+                payload_height,
+                rollback_height,
+                reason,
+            } => write!(
+                f,
+                "node replication error: synced replication height {} execution hash validation failed: {}; rollback record for height {} is unavailable",
+                payload_height, reason, rollback_height
+            ),
             NodeError::Execution { reason } => write!(f, "node execution error: {}", reason),
             NodeError::AlreadyRunning { node_id } => {
                 write!(f, "node runtime already running: {}", node_id)
@@ -40,3 +74,9 @@ impl fmt::Display for NodeError {
 }
 
 impl std::error::Error for NodeError {}
+
+impl NodeError {
+    pub(crate) fn is_fresh_observer_checkpoint_fallback_eligible(&self) -> bool {
+        matches!(self, Self::ExecutionMismatchRollbackUnavailable { .. })
+    }
+}

--- a/crates/oasis7_node/src/node_engine_network.rs
+++ b/crates/oasis7_node/src/node_engine_network.rs
@@ -548,6 +548,7 @@ impl PosNodeEngine {
                 previous_execution_block_hash.as_deref(),
                 previous_execution_state_root.as_deref(),
                 execution_hook.as_deref_mut(),
+                peer_mismatch,
                 &err,
             )?;
             if !peer_mismatch {
@@ -578,6 +579,7 @@ impl PosNodeEngine {
                 previous_execution_block_hash.as_deref(),
                 previous_execution_state_root.as_deref(),
                 execution_hook.as_deref_mut(),
+                true,
                 &err,
             )?;
             return Err(err);
@@ -607,6 +609,7 @@ impl PosNodeEngine {
         previous_execution_block_hash: Option<&str>,
         previous_execution_state_root: Option<&str>,
         execution_hook: Option<&mut (dyn NodeExecutionHook + '_)>,
+        execution_mismatch: bool,
         err: &NodeError,
     ) -> Result<(), NodeError> {
         self.last_execution_height = previous_execution_height;
@@ -625,6 +628,13 @@ impl PosNodeEngine {
                 },
             )?;
             if !restored {
+                if execution_mismatch {
+                    return Err(NodeError::ExecutionMismatchRollbackUnavailable {
+                        payload_height,
+                        rollback_height: previous_execution_height,
+                        reason: err.to_string(),
+                    });
+                }
                 return Err(NodeError::Replication {
                     reason: format!(
                         "synced replication height {} execution hash validation failed: {}; rollback record for height {} is unavailable",

--- a/crates/oasis7_node/src/node_engine_replication.rs
+++ b/crates/oasis7_node/src/node_engine_replication.rs
@@ -962,6 +962,18 @@ impl PosNodeEngine {
                 let (block_hash, committed_at_ms) = match execution_result {
                     Ok(result) => result,
                     Err(err) => {
+                        if self.try_fresh_observer_checkpoint_fallback_after_execution_mismatch(
+                            endpoint,
+                            node_id,
+                            world_id,
+                            replication_runtime,
+                            next_height,
+                            &mut execution_hook,
+                            &mut progress_callback,
+                            &err,
+                        )? {
+                            return Ok(());
+                        }
                         self.record_replication_gap_sync_local_state_block(
                             next_height,
                             advertised_network_height,

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -288,6 +288,89 @@ impl PosNodeEngine {
         })
     }
 
+    pub(super) fn try_fresh_observer_checkpoint_fallback_after_execution_mismatch(
+        &mut self,
+        endpoint: &ReplicationNetworkEndpoint,
+        node_id: &str,
+        world_id: &str,
+        replication_runtime: &mut ReplicationRuntime,
+        next_height: u64,
+        execution_hook: &mut Option<&mut dyn NodeExecutionHook>,
+        progress_callback: &mut Option<
+            &mut dyn FnMut(NodeConsensusSnapshot) -> Result<(), NodeError>,
+        >,
+        err: &NodeError,
+    ) -> Result<bool, NodeError> {
+        // A fresh observer may have a valid successor commit in transport while its
+        // clean local execution disagrees with the peer binding.  If height-zero
+        // rollback is unavailable, only the authenticated retained-checkpoint path
+        // can recover; unrelated execution failures must stay fail-closed.
+        let reason = err.to_string();
+        let fresh_observer = self.checkpoint_bootstrap_enabled
+            && self.committed_height == 0
+            && self.replication_persisted_height == 0
+            && self.last_execution_height == 0
+            && next_height == 1;
+        let execution_mismatch = reason.contains("execution hash validation failed")
+            || reason.contains("execution driver peer mismatch");
+        let rollback_unavailable = reason.contains("rollback record for height 0 is unavailable");
+        if !fresh_observer
+            || !execution_mismatch
+            || !rollback_unavailable
+            || !Self::replication_gap_sync_local_state_blocked_reason(reason.as_str())
+        {
+            return Ok(false);
+        }
+
+        let Some(cached_head) = self.cached_high_checkpoint_head(world_id) else {
+            return Ok(false);
+        };
+        let now_ms = crate::runtime_util::now_unix_ms();
+        let mut retry_pending = false;
+        for checkpoint_candidate in
+            Self::high_replication_checkpoint_candidates(cached_head.height, next_height)
+        {
+            let expected_candidate_head =
+                (checkpoint_candidate == cached_head.height).then_some(&cached_head);
+            match self.try_sync_high_replication_checkpoint_boundary(
+                endpoint,
+                node_id,
+                world_id,
+                replication_runtime,
+                checkpoint_candidate,
+                next_height,
+                expected_candidate_head,
+                execution_hook,
+                progress_callback,
+            ) {
+                Ok(true) => return Ok(true),
+                Ok(false) => {}
+                Err(probe_err)
+                    if Self::high_replication_checkpoint_probe_can_continue(&probe_err) =>
+                {
+                    retry_pending = true;
+                    self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+                    if self.record_high_replication_checkpoint_probe_failure(
+                        next_height,
+                        checkpoint_candidate,
+                        now_ms,
+                        &probe_err,
+                    ) {
+                        return Ok(false);
+                    }
+                }
+                Err(probe_err) => return Err(probe_err),
+            }
+        }
+        self.fresh_observer_checkpoint_bootstrap_retry_pending = true;
+        if retry_pending {
+            self.last_replication_gap_sync_repair_attempt_summary = Some(
+                "fresh observer execution mismatch retained checkpoint retry pending".to_string(),
+            );
+        }
+        Ok(false)
+    }
+
     pub(super) fn validate_world_head_checkpoint_payload(
         world_id: &str,
         payload: &ReplicationCommitPayload,

--- a/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
+++ b/crates/oasis7_node/src/node_engine_replication_checkpoint.rs
@@ -305,20 +305,12 @@ impl PosNodeEngine {
         // clean local execution disagrees with the peer binding.  If height-zero
         // rollback is unavailable, only the authenticated retained-checkpoint path
         // can recover; unrelated execution failures must stay fail-closed.
-        let reason = err.to_string();
         let fresh_observer = self.checkpoint_bootstrap_enabled
             && self.committed_height == 0
             && self.replication_persisted_height == 0
             && self.last_execution_height == 0
             && next_height == 1;
-        let execution_mismatch = reason.contains("execution hash validation failed")
-            || reason.contains("execution driver peer mismatch");
-        let rollback_unavailable = reason.contains("rollback record for height 0 is unavailable");
-        if !fresh_observer
-            || !execution_mismatch
-            || !rollback_unavailable
-            || !Self::replication_gap_sync_local_state_blocked_reason(reason.as_str())
-        {
+        if !fresh_observer || !err.is_fresh_observer_checkpoint_fallback_eligible() {
             return Ok(false);
         }
 

--- a/crates/oasis7_node/src/node_engine_replication_local_state_block.rs
+++ b/crates/oasis7_node/src/node_engine_replication_local_state_block.rs
@@ -2,6 +2,14 @@ use super::*;
 
 impl PosNodeEngine {
     pub(super) fn replication_gap_sync_local_state_blocked_reason(reason: &str) -> bool {
+        // A rendered rollback-unavailable diagnostic is not a checkpoint
+        // authority signal.  The fresh-observer fallback consumes the
+        // structured NodeError variant directly; keeping this generic state
+        // marker from recognizing the legacy phrase prevents callers from
+        // turning arbitrary Display text into recovery authority.
+        if reason.contains("rollback record for height") {
+            return false;
+        }
         reason.contains("execution hash validation failed")
             || reason.contains("execution driver peer mismatch")
             || reason.contains("forced execution failure")

--- a/crates/oasis7_node/src/tests_storage_replication.rs
+++ b/crates/oasis7_node/src/tests_storage_replication.rs
@@ -8,6 +8,8 @@ mod storage_replication_core_tests;
 mod storage_replication_high_checkpoint_tests;
 #[path = "tests_storage_replication_first_ready_checkpoint.rs"]
 mod storage_replication_first_ready_checkpoint_tests;
+#[path = "tests_storage_replication_checkpoint_fallback.rs"]
+mod storage_replication_checkpoint_fallback_tests;
 #[path = "tests_storage_replication_high_checkpoint_retained.rs"]
 mod storage_replication_high_checkpoint_retained_tests;
 #[path = "tests_storage_replication_live_retained_boundary.rs"]

--- a/crates/oasis7_node/src/tests_storage_replication_checkpoint_fallback.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_checkpoint_fallback.rs
@@ -19,7 +19,7 @@ fn fresh_observer_execution_mismatch_falls_back_to_authenticated_retained_checkp
     let (_, public_key_a) = deterministic_keypair_hex(192);
     let (_, public_key_b) = deterministic_keypair_hex(193);
     let checkpoint_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
-    let peer_head_height = checkpoint_height + 36;
+    let peer_head_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL + 36;
     let pos_config = signed_pos_config_with_signer_seeds(
         vec![PosValidator {
             validator_id: "node-a".to_string(),
@@ -204,4 +204,182 @@ fn fresh_observer_execution_mismatch_falls_back_to_authenticated_retained_checkp
     );
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
+}
+
+#[test]
+fn rendered_replication_or_execution_error_cannot_qualify_checkpoint_fallback() {
+    // The recovery decision must consume a structured execution outcome.  A
+    // caller-controlled Display string that happens to contain the old
+    // diagnostic phrases must not become checkpoint authority.
+    let rendered_errors = [
+        NodeError::Replication {
+            reason: "execution hash validation failed; rollback record for height 0 is unavailable"
+                .to_string(),
+        },
+        NodeError::Execution {
+            reason: "execution driver peer mismatch; rollback record for height 0 is unavailable"
+                .to_string(),
+        },
+    ];
+
+    for error in rendered_errors {
+        assert!(
+            !PosNodeEngine::replication_gap_sync_local_state_blocked_reason(
+                error.to_string().as_str()
+            ),
+            "rendered error text must not qualify checkpoint recovery: {error}"
+        );
+    }
+}
+
+struct FreshObserverWithoutCheckpointFixture {
+    world_id: String,
+    dir_a: std::path::PathBuf,
+    dir_b: std::path::PathBuf,
+    endpoint_b: ReplicationNetworkEndpoint,
+    replication_b: ReplicationRuntime,
+    engine_b: PosNodeEngine,
+}
+
+fn fresh_observer_without_authenticated_checkpoint_fixture() ->
+    FreshObserverWithoutCheckpointFixture {
+    let world_id = "world-fresh-observer-no-authenticated-checkpoint".to_string();
+    let dir_a = temp_dir("fresh-observer-no-authenticated-checkpoint-a");
+    let dir_b = temp_dir("fresh-observer-no-authenticated-checkpoint-b");
+    let (_, public_key_a) = deterministic_keypair_hex(194);
+    let (_, public_key_b) = deterministic_keypair_hex(195);
+    let peer_head_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL + 36;
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 194)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 194)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 195)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone()])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id.as_str(), NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id.as_str(), NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("remote replication runtime");
+    replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id.as_str(),
+            7_100,
+            &committed_decision(1),
+            Some("peer-execution-block-1"),
+            Some("peer-execution-state-1"),
+        )
+        .expect("build valid height-one commit")
+        .expect("height-one commit");
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(FirstReadyHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id.as_str(),
+        &config_a.network_policy,
+    )
+    .expect("register authenticated provider without checkpoint");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id.as_str(), true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("fresh observer replication runtime");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    engine_b.network_committed_height = 1;
+    engine_b.peer_heads.insert(
+        "node-a".to_string(),
+        PeerCommittedHead {
+            height: peer_head_height,
+            block_hash: format!("block-{peer_head_height}"),
+            committed_at_ms: 7_164,
+            observed_at_ms: 7_200,
+            execution_block_hash: Some(format!("execution-block-{peer_head_height}")),
+            execution_state_root: Some(format!("execution-state-{peer_head_height}")),
+            action_root: empty_action_root(),
+            public_key_hex: Some(public_key_a),
+            signature_hex: Some(format!("signed-node-a-{peer_head_height}")),
+        },
+    );
+    engine_b.checkpoint_bootstrap_enabled = true;
+    FreshObserverWithoutCheckpointFixture {
+        world_id,
+        dir_a,
+        dir_b,
+        endpoint_b,
+        replication_b,
+        engine_b,
+    }
+}
+
+#[test]
+fn execution_mismatch_without_authenticated_checkpoint_remains_fail_closed() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let fixture = fresh_observer_without_authenticated_checkpoint_fixture();
+    let mut replication_b = fixture.replication_b;
+    let mut engine_b = fixture.engine_b;
+    let mut execution_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+
+    let result = engine_b.sync_missing_replication_commits(
+        &fixture.endpoint_b,
+        "node-b",
+        fixture.world_id.as_str(),
+        Some(&mut replication_b),
+        Some(&mut execution_hook),
+    );
+    let error = result.expect_err(
+        "a target mismatch without an authenticated checkpoint must remain fail-closed",
+    );
+    let rendered = error.to_string();
+    assert!(
+        rendered.contains("execution hash validation failed"),
+        "original execution mismatch must be preserved: {rendered}"
+    );
+    assert!(
+        rendered.contains("rollback record for height 0 is unavailable"),
+        "original rollback failure must be preserved: {rendered}"
+    );
+    assert!(
+        execution_hook.installed.is_empty(),
+        "no unauthenticated checkpoint may be installed: {:?}",
+        execution_hook.installed
+    );
+    assert_eq!(engine_b.committed_height, 0);
+    assert_eq!(engine_b.replication_persisted_height, 0);
+    assert!(
+        !fixture.dir_b.join("checkpoint-verification").exists(),
+        "no checkpoint receipt may be emitted without authenticated closure"
+    );
+    let _ = fs::remove_dir_all(&fixture.dir_a);
+    let _ = fs::remove_dir_all(&fixture.dir_b);
 }

--- a/crates/oasis7_node/src/tests_storage_replication_checkpoint_fallback.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_checkpoint_fallback.rs
@@ -1,0 +1,207 @@
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use oasis7_proto::distributed_checkpoint_lineage::CheckpointLineageHeadV1;
+
+use super::*;
+use super::storage_replication_first_ready_checkpoint_tests::{
+    checkpoint_bundle, committed_decision, BootstrapBeforeIncrementalHook,
+    FirstReadyHeadCheckpointNetwork, CheckpointProbeNonceGuard, lock_checkpoint_probe_nonce,
+};
+
+#[test]
+fn fresh_observer_execution_mismatch_falls_back_to_authenticated_retained_checkpoint() {
+    let _nonce_lock = lock_checkpoint_probe_nonce();
+    let _probe_nonce = CheckpointProbeNonceGuard::install();
+    let world_id = "world-fresh-observer-execution-mismatch-checkpoint-fallback";
+    let dir_a = temp_dir("fresh-observer-execution-mismatch-fallback-a");
+    let dir_b = temp_dir("fresh-observer-execution-mismatch-fallback-b");
+    let (_, public_key_a) = deterministic_keypair_hex(192);
+    let (_, public_key_b) = deterministic_keypair_hex(193);
+    let checkpoint_height = REPLICATION_GAP_SYNC_MAX_HEIGHTS_PER_POLL;
+    let peer_head_height = checkpoint_height + 36;
+    let pos_config = signed_pos_config_with_signer_seeds(
+        vec![PosValidator {
+            validator_id: "node-a".to_string(),
+            stake: 100,
+        }],
+        &[("node-a", 192)],
+    );
+    let replication_config_a = signed_replication_config(dir_a.clone(), 192)
+        .with_remote_writer_allowlist(vec![public_key_b.clone()])
+        .expect("allowlist a")
+        .with_fetch_requester_allowlist(vec![public_key_b.clone()])
+        .expect("fetch allowlist a");
+    let replication_config_b = signed_replication_config(dir_b.clone(), 193)
+        .with_remote_writer_allowlist(vec![public_key_a.clone()])
+        .expect("allowlist b")
+        .with_fetch_requester_allowlist(vec![public_key_a.clone()])
+        .expect("fetch allowlist b");
+    let config_a = NodeConfig::new("node-a", world_id, NodeRole::Sequencer)
+        .expect("config a")
+        .with_pos_config(pos_config.clone())
+        .expect("pos config a")
+        .with_replication(replication_config_a.clone());
+    let config_b = NodeConfig::new("node-b", world_id, NodeRole::Observer)
+        .expect("config b")
+        .with_pos_config(pos_config)
+        .expect("pos config b")
+        .with_require_execution_on_commit(true)
+        .with_replication(replication_config_b.clone());
+    let mut replication_a =
+        ReplicationRuntime::new(config_a.replication.as_ref().expect("repl a"), "node-a")
+            .expect("remote replication runtime");
+    replication_a
+        .build_local_commit_message(
+            "node-a",
+            world_id,
+            7_100,
+            &committed_decision(1),
+            Some("peer-execution-block-1"),
+            Some("peer-execution-state-1"),
+        )
+        .expect("build valid height-one commit")
+        .expect("height-one commit");
+    let checkpoint_execution_block_hash = format!("execution-block-{checkpoint_height}");
+    let checkpoint_execution_state_root = format!("execution-state-{checkpoint_height}");
+    replication_a
+        .build_local_commit_message_with_checkpoint(
+            "node-a",
+            world_id,
+            7_164,
+            &committed_decision(checkpoint_height),
+            Some(checkpoint_execution_block_hash.as_str()),
+            Some(checkpoint_execution_state_root.as_str()),
+            Some(checkpoint_bundle(
+                checkpoint_height,
+                checkpoint_execution_block_hash.as_str(),
+                checkpoint_execution_state_root.as_str(),
+            )),
+        )
+        .expect("build retained checkpoint commit")
+        .expect("retained checkpoint commit");
+    let engine_a = PosNodeEngine::new(&config_a).expect("lineage authority engine");
+    let peer_head_block_hash = format!("block-{peer_head_height}");
+    let peer_head_execution_block_hash = format!("execution-block-{peer_head_height}");
+    let peer_head_execution_state_root = format!("execution-state-{peer_head_height}");
+    let checkpoint_head = CheckpointLineageHeadV1 {
+        height: peer_head_height,
+        block_hash: peer_head_block_hash.clone(),
+        state_root: peer_head_execution_state_root.clone(),
+        execution_block_hash: peer_head_execution_block_hash.clone(),
+        execution_state_root: peer_head_execution_state_root.clone(),
+    };
+    let lineage_envelope = super::storage_replication_live_retained_boundary_tests::
+        attach_production_lineage_envelope(
+            &mut replication_a,
+            world_id,
+            checkpoint_height,
+            checkpoint_head.clone(),
+            &[&engine_a],
+        );
+    assert_eq!(lineage_envelope.head, checkpoint_head);
+    let persisted_checkpoint = replication_a
+        .load_commit_message_by_height(world_id, checkpoint_height)
+        .expect("load retained checkpoint source")
+        .expect("retained checkpoint source");
+    assert!(
+        parse_replication_commit_payload(persisted_checkpoint.payload.as_slice())
+            .expect("decode retained checkpoint source")
+            .lineage_envelope
+            .is_some(),
+        "the fallback fixture must retain the signed lineage sidecar"
+    );
+
+    let network: Arc<
+        dyn oasis7_proto::distributed_net::DistributedNetwork<WorldError> + Send + Sync,
+    > = Arc::new(FirstReadyHeadCheckpointNetwork {
+        inner: Arc::new(TestInMemoryNetwork::default()),
+        fetch_protocols: Arc::new(Mutex::new(Vec::new())),
+    });
+    register_replication_fetch_handlers(
+        &NodeReplicationNetworkHandle::new(Arc::clone(&network)),
+        &replication_config_a,
+        world_id,
+        &config_a.network_policy,
+    )
+    .expect("register authenticated checkpoint provider");
+    let handle_b = NodeReplicationNetworkHandle::new(Arc::clone(&network));
+    let endpoint_b =
+        ReplicationNetworkEndpoint::new(&handle_b, world_id, true, &config_b.network_policy)
+            .expect("fresh observer endpoint");
+    let mut replication_b =
+        ReplicationRuntime::new(config_b.replication.as_ref().expect("repl b"), "node-b")
+            .expect("fresh observer replication runtime");
+    let mut engine_b = PosNodeEngine::new(&config_b).expect("fresh observer engine");
+    // Model the probe's stale low network cursor plus an authenticated high
+    // peer head.  The current implementation enters height-one replay from
+    // this state and returns the mismatch before trying the retained boundary.
+    engine_b.network_committed_height = 1;
+    engine_b.peer_heads.insert(
+        "node-a".to_string(),
+        PeerCommittedHead {
+            height: peer_head_height,
+            block_hash: peer_head_block_hash,
+            committed_at_ms: 7_164,
+            observed_at_ms: 7_200,
+            execution_block_hash: Some(peer_head_execution_block_hash),
+            execution_state_root: Some(peer_head_execution_state_root),
+            action_root: empty_action_root(),
+            public_key_hex: Some(public_key_a),
+            signature_hex: Some(format!("signed-node-a-{peer_head_height}")),
+        },
+    );
+    let mut execution_hook = BootstrapBeforeIncrementalHook {
+        installed: Vec::new(),
+        incremental_commits: Vec::new(),
+        rollback_heights: Vec::new(),
+    };
+
+    // Keep the valid height-one commit available and make its clean-local
+    // execution result disagree with the signed peer binding.  Height zero
+    // rollback is deliberately unavailable; the expected recovery is the
+    // authenticated retained checkpoint closure above.
+    let result = engine_b.sync_missing_replication_commits(
+        &endpoint_b,
+        "node-b",
+        world_id,
+        Some(&mut replication_b),
+        Some(&mut execution_hook),
+    );
+    assert!(
+        result.is_ok(),
+        "fresh observer must recover through the retained checkpoint after height-one execution mismatch: result={result:?} installed={:?} incremental={:?} rollback={:?}",
+        execution_hook.installed,
+        execution_hook.incremental_commits,
+        execution_hook.rollback_heights
+    );
+    assert_eq!(execution_hook.incremental_commits, vec![1]);
+    assert_eq!(execution_hook.rollback_heights, vec![0]);
+    assert_eq!(execution_hook.installed, vec![checkpoint_height]);
+    assert_eq!(engine_b.committed_height, checkpoint_height);
+    assert_eq!(engine_b.replication_persisted_height, checkpoint_height);
+    assert_eq!(engine_b.last_execution_height, checkpoint_height);
+    assert!(
+        replication_b
+            .load_commit_message_by_height(world_id, 1)
+            .expect("inspect height-one persistence")
+            .is_none(),
+        "mismatched height-one commit must not be persisted before checkpoint recovery"
+    );
+    assert!(
+        replication_b
+            .load_commit_message_by_height(world_id, checkpoint_height)
+            .expect("inspect checkpoint persistence")
+            .is_some(),
+        "verified retained checkpoint must be persisted after fallback"
+    );
+    assert!(
+        dir_b
+            .join("checkpoint-verification")
+            .join(format!("{checkpoint_height}.json"))
+            .exists(),
+        "checkpoint probe receipt must be retained"
+    );
+    let _ = fs::remove_dir_all(&dir_a);
+    let _ = fs::remove_dir_all(&dir_b);
+}

--- a/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
+++ b/crates/oasis7_node/src/tests_storage_replication_first_ready_checkpoint.rs
@@ -7,9 +7,9 @@ use oasis7_proto::distributed::WorldHeadAnnounce;
 use oasis7_proto::distributed_checkpoint_lineage::CheckpointLineageHeadV1;
 use oasis7_proto::distributed_dht::DistributedDht;
 #[derive(Clone)]
-struct FirstReadyHeadCheckpointNetwork {
-    inner: Arc<TestInMemoryNetwork>,
-    fetch_protocols: Arc<Mutex<Vec<String>>>,
+pub(super) struct FirstReadyHeadCheckpointNetwork {
+    pub(super) inner: Arc<TestInMemoryNetwork>,
+    pub(super) fetch_protocols: Arc<Mutex<Vec<String>>>,
 }
 
 #[derive(Clone)]
@@ -130,10 +130,10 @@ impl oasis7_proto::distributed_net::DistributedNetwork<WorldError> for PeerHeadC
 
 include!("tests_storage_replication_first_ready_checkpoint_support.rs");
 
-struct BootstrapBeforeIncrementalHook {
-    installed: Vec<u64>,
-    incremental_commits: Vec<u64>,
-    rollback_heights: Vec<u64>,
+pub(super) struct BootstrapBeforeIncrementalHook {
+    pub(super) installed: Vec<u64>,
+    pub(super) incremental_commits: Vec<u64>,
+    pub(super) rollback_heights: Vec<u64>,
 }
 
 impl NodeExecutionHook for BootstrapBeforeIncrementalHook {
@@ -174,7 +174,7 @@ impl NodeExecutionHook for BootstrapBeforeIncrementalHook {
     }
 }
 
-fn checkpoint_bundle(
+pub(super) fn checkpoint_bundle(
     height: u64,
     execution_block_hash: &str,
     execution_state_root: &str,
@@ -193,7 +193,7 @@ fn checkpoint_bundle(
     }
 }
 
-fn committed_decision(height: u64) -> PosDecision {
+pub(super) fn committed_decision(height: u64) -> PosDecision {
     PosDecision {
         height,
         slot: height,
@@ -867,6 +867,7 @@ fn fresh_observer_bootstraps_checkpoint_at_boundary_before_height_one_peer_misma
     let _ = fs::remove_dir_all(&dir_a);
     let _ = fs::remove_dir_all(&dir_b);
 }
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum InitialPeerHead {
     Unavailable,


### PR DESCRIPTION
## Summary
- route a fresh observer height-one execution mismatch into the existing authenticated retained-checkpoint recovery path
- preserve fail-closed behavior for unrelated execution failures and invalid or unavailable checkpoint candidates
- add a deterministic RED-to-GREEN regression covering signed lineage, closure fetch, install, and probe receipt persistence

## Verification
- `cargo test -p oasis7_node fresh_observer_execution_mismatch_falls_back_to_authenticated_retained_checkpoint -- --nocapture`
- `cargo test -p oasis7_node checkpoint -- --nocapture` (76 passed)
- `cargo check -p oasis7_node`
- `cargo fmt --all -- --check`
- `git diff --check`
- `./scripts/check-rust-file-size.sh`

Task: task_c99527f1ae66443da50cb2e57ecf2bec
Refs #3400
Incident continuation: #3318