### PR TITLE
Fix trunk prerequisite for full CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -342,6 +342,8 @@ jobs:
         with:
           shared-key: ci-full-regression-v1
           cache-on-failure: true
+      - name: Install trunk
+        run: cargo install trunk --locked
       - name: Run full test tier
         run: CI_VERBOSE=1 ./scripts/ci-tests.sh full
 
@@ -408,6 +410,8 @@ jobs:
         with:
           shared-key: ci-full-escalation-v1
           cache-on-failure: true
+      - name: Install trunk
+        run: cargo install trunk --locked
       - id: full
         name: Run human-authorized full test tier
         run: CI_VERBOSE=1 ./scripts/ci-tests.sh full

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,7 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   RUST_TOOLCHAIN: 1.96.0
+  TRUNK_VERSION: 0.21.14
   OASIS7_WASM_TOOLCHAIN: nightly-2025-12-11
   OASIS7_WASM_TARGET: wasm32-unknown-unknown
   OASIS7_WASM_BUILD_STD: "1"
@@ -342,8 +343,13 @@ jobs:
         with:
           shared-key: ci-full-regression-v1
           cache-on-failure: true
-      - name: Install trunk
-        run: cargo install trunk --locked
+      - name: Install pinned trunk
+        run: cargo install trunk --locked --version "${TRUNK_VERSION}"
+      - name: Verify pinned trunk
+        shell: bash
+        run: |
+          set -euo pipefail
+          trunk --version | grep -Fqx "trunk ${TRUNK_VERSION}"
       - name: Run full test tier
         run: CI_VERBOSE=1 ./scripts/ci-tests.sh full
 
@@ -410,8 +416,13 @@ jobs:
         with:
           shared-key: ci-full-escalation-v1
           cache-on-failure: true
-      - name: Install trunk
-        run: cargo install trunk --locked
+      - name: Install pinned trunk
+        run: cargo install trunk --locked --version "${TRUNK_VERSION}"
+      - name: Verify pinned trunk
+        shell: bash
+        run: |
+          set -euo pipefail
+          trunk --version | grep -Fqx "trunk ${TRUNK_VERSION}"
       - id: full
         name: Run human-authorized full test tier
         run: CI_VERBOSE=1 ./scripts/ci-tests.sh full

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -273,6 +273,7 @@ run_required_gate_checks() {
   run ./scripts/check-standalone-tool-lockfiles.sh
   run ./scripts/plan-rust-required-scope.test.sh
   run ./scripts/rust-required-gate-compile-command-contract.test.sh
+  run bash ./scripts/rust-full-tier-trunk-prerequisite-contract.test.sh
   run ./scripts/unified-world-code-terminology-scan.test.sh
   run_required_component "operational contracts" "${OASIS7_CI_RUN_OPERATIONAL_CONTRACTS:-}" "disabled_by_scope_planner" run_operational_contract_tests
   run_required_component "provider bridge live gate" "${OASIS7_CI_RUN_PROVIDER_LIVE_GATE:-false}" "explicit_opt_in_not_enabled" run_provider_bridge_live_gate

--- a/scripts/rust-full-tier-trunk-prerequisite-contract.test.sh
+++ b/scripts/rust-full-tier-trunk-prerequisite-contract.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/rust.yml"
+
+python3 - "$WORKFLOW" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow_path = Path(sys.argv[1])
+lines = workflow_path.read_text(encoding="utf-8").splitlines()
+job_header = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):\s*$")
+run_key = re.compile(r"^(?P<indent>\s*)run:\s*(?P<body>.*)$")
+target = "CI_VERBOSE=1 ./scripts/ci-tests.sh full"
+trunk_install = "cargo install trunk --locked"
+
+try:
+    jobs_index = next(index for index, line in enumerate(lines) if line == "jobs:")
+except StopIteration:
+    raise SystemExit("rust.yml contract: missing jobs: mapping")
+
+jobs = {}
+current_name = None
+for index in range(jobs_index + 1, len(lines)):
+    match = job_header.match(lines[index])
+    if match:
+        current_name = match.group("name")
+        jobs[current_name] = []
+        continue
+    if current_name is not None:
+        jobs[current_name].append((index, lines[index]))
+
+def run_commands(job_lines):
+    """Return (line number, shell text) for each YAML run key and body."""
+    commands = []
+    position = 0
+    while position < len(job_lines):
+        line_number, line = job_lines[position]
+        match = run_key.match(line)
+        if not match:
+            position += 1
+            continue
+
+        body = match.group("body").strip()
+        commands.append((line_number, body))
+        if body in {"|", ">", "|-", "|+", ">-", ">+"}:
+            run_indent = len(match.group("indent"))
+            position += 1
+            while position < len(job_lines):
+                body_line_number, body_line = job_lines[position]
+                if body_line.strip() and len(body_line) - len(body_line.lstrip()) <= run_indent:
+                    break
+                commands.append((body_line_number, body_line.strip()))
+                position += 1
+            continue
+        position += 1
+    return commands
+
+full_jobs = []
+failures = []
+for job_name, job_lines in jobs.items():
+    commands = run_commands(job_lines)
+    invocation_lines = [
+        (line_number, command)
+        for line_number, command in commands
+        if target in command and "--command" not in command
+    ]
+    if not invocation_lines:
+        continue
+
+    full_jobs.append(job_name)
+    invocation_line = invocation_lines[0][0]
+    install_lines = [
+        line_number
+        for line_number, command in commands
+        if trunk_install in command and line_number < invocation_line
+    ]
+    if not install_lines:
+        failures.append(
+            f"{job_name}: full-tier invocation at rust.yml:{invocation_line + 1} "
+            f"lacks preceding `{trunk_install}`"
+        )
+
+expected_jobs = {"full-regression", "full-escalation"}
+missing_expected_jobs = sorted(expected_jobs - set(full_jobs))
+if missing_expected_jobs:
+    failures.extend(
+        f"{job}: expected full-tier job invocation was not found"
+        for job in missing_expected_jobs
+    )
+
+if failures:
+    print("rust-full-tier-trunk-prerequisite contract: FAIL", file=sys.stderr)
+    for failure in failures:
+        print(f"- {failure}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(
+    "rust-full-tier-trunk-prerequisite contract: passed "
+    f"({len(full_jobs)} full-tier jobs install trunk before invocation)"
+)
+PY

--- a/scripts/rust-full-tier-trunk-prerequisite-contract.test.sh
+++ b/scripts/rust-full-tier-trunk-prerequisite-contract.test.sh
@@ -8,29 +8,33 @@ python3 - "$WORKFLOW" <<'PY'
 from pathlib import Path
 import re
 import sys
+import tempfile
 
 workflow_path = Path(sys.argv[1])
-lines = workflow_path.read_text(encoding="utf-8").splitlines()
 job_header = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):\s*$")
-run_key = re.compile(r"^(?P<indent>\s*)run:\s*(?P<body>.*)$")
+run_key = re.compile(r"^(?P<indent>\s*)(?:-\s+)?run:\s*(?P<body>.*)$")
 target = "CI_VERBOSE=1 ./scripts/ci-tests.sh full"
-trunk_install = "cargo install trunk --locked"
+trunk_install = 'cargo install trunk --locked --version "${TRUNK_VERSION}"'
+trunk_verify = 'trunk --version | grep -Fqx "trunk ${TRUNK_VERSION}"'
+expected_jobs = {"full-regression", "full-escalation"}
 
-try:
-    jobs_index = next(index for index, line in enumerate(lines) if line == "jobs:")
-except StopIteration:
-    raise SystemExit("rust.yml contract: missing jobs: mapping")
 
-jobs = {}
-current_name = None
-for index in range(jobs_index + 1, len(lines)):
-    match = job_header.match(lines[index])
-    if match:
-        current_name = match.group("name")
-        jobs[current_name] = []
-        continue
-    if current_name is not None:
-        jobs[current_name].append((index, lines[index]))
+def repository_trunk_version():
+    release_workflow_path = workflow_path.with_name("release-packages.yml")
+    release_lines = release_workflow_path.read_text(encoding="utf-8").splitlines()
+    versions = [
+        match.group("version")
+        for line in release_lines
+        if (match := re.match(r"^  TRUNK_VERSION: (?P<version>[0-9]+\.[0-9]+\.[0-9]+)$", line))
+    ]
+    if len(versions) != 1:
+        raise SystemExit(
+            "rust.yml contract: release workflow must define exactly one pinned TRUNK_VERSION"
+        )
+    return versions[0]
+
+
+expected_trunk_version = repository_trunk_version()
 
 def run_commands(job_lines):
     """Return (line number, shell text) for each YAML run key and body."""
@@ -58,38 +62,175 @@ def run_commands(job_lines):
         position += 1
     return commands
 
-full_jobs = []
-failures = []
-for job_name, job_lines in jobs.items():
-    commands = run_commands(job_lines)
-    invocation_lines = [
-        (line_number, command)
-        for line_number, command in commands
-        if target in command and "--command" not in command
-    ]
-    if not invocation_lines:
-        continue
+def validate_workflow(path, required_jobs):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    try:
+        jobs_start = next(index for index, line in enumerate(lines) if line == "jobs:")
+    except StopIteration:
+        raise SystemExit(f"rust.yml contract: {path} is missing jobs: mapping")
 
-    full_jobs.append(job_name)
-    invocation_line = invocation_lines[0][0]
-    install_lines = [
-        line_number
-        for line_number, command in commands
-        if trunk_install in command and line_number < invocation_line
-    ]
-    if not install_lines:
-        failures.append(
-            f"{job_name}: full-tier invocation at rust.yml:{invocation_line + 1} "
-            f"lacks preceding `{trunk_install}`"
-        )
+    # Keep the parser intentionally small, but support both YAML step forms:
+    # `run: ...` under a named step and the valid inline `- run: ...` form.
+    local_jobs = {}
+    current_name = None
+    for index in range(jobs_start + 1, len(lines)):
+        match = job_header.match(lines[index])
+        if match:
+            current_name = match.group("name")
+            local_jobs[current_name] = []
+            continue
+        if current_name is not None:
+            local_jobs[current_name].append((index, lines[index]))
 
-expected_jobs = {"full-regression", "full-escalation"}
-missing_expected_jobs = sorted(expected_jobs - set(full_jobs))
-if missing_expected_jobs:
+    top_level_versions = [
+        match.group("version")
+        for line in lines
+        if (match := re.match(r"^  TRUNK_VERSION: (?P<version>[0-9]+\.[0-9]+\.[0-9]+)$", line))
+    ]
+    top_level_version = top_level_versions[0] if len(top_level_versions) == 1 else None
+    failures = []
+    full_jobs = []
+    for job_name, job_lines in local_jobs.items():
+        commands = [
+            (line_number, command.strip())
+            for line_number, command in run_commands(job_lines)
+            if command.strip() and not command.strip().startswith("#")
+        ]
+        invocation_lines = [
+            (line_number, command)
+            for line_number, command in commands
+            if target in command and "--command" not in command
+        ]
+        if not invocation_lines:
+            continue
+
+        full_jobs.append(job_name)
+        invocation_line = invocation_lines[0][0]
+        if top_level_version != expected_trunk_version:
+            failures.append(
+                f"{job_name}: top-level TRUNK_VERSION is "
+                f"{top_level_version or '<missing>'}; expected {expected_trunk_version}"
+            )
+        preceding_commands = [
+            (line_number, command)
+            for line_number, command in commands
+            if line_number < invocation_line
+        ]
+        if not any(trunk_install in command for _, command in preceding_commands):
+            failures.append(
+                f"{job_name}: full-tier invocation at rust.yml:{invocation_line + 1} "
+                f"lacks preceding pinned `{trunk_install}`"
+            )
+        if not any(trunk_verify in command for _, command in preceding_commands):
+            failures.append(
+                f"{job_name}: full-tier invocation at rust.yml:{invocation_line + 1} "
+                f"lacks preceding `{trunk_verify}` verification"
+            )
+
+    missing_expected_jobs = sorted(required_jobs - set(full_jobs))
     failures.extend(
         f"{job}: expected full-tier job invocation was not found"
         for job in missing_expected_jobs
     )
+    return full_jobs, failures
+
+
+def fixture_workflow(step_lines):
+    return "\n".join(
+        [
+            "name: trunk prerequisite fixture",
+            "on:",
+            "  workflow_dispatch:",
+            "env:",
+            f"  TRUNK_VERSION: {expected_trunk_version}",
+            "jobs:",
+            "  full-caller:",
+            "    runs-on: ubuntu-24.04",
+            "    steps:",
+            *step_lines,
+            "",
+        ]
+    )
+
+
+def check_fixture(name, contents, expected_pass):
+    with tempfile.TemporaryDirectory(prefix="rust-full-tier-trunk-") as temp_dir:
+        path = Path(temp_dir) / "rust.yml"
+        path.write_text(contents, encoding="utf-8")
+        _, fixture_failures = validate_workflow(path, {"full-caller"})
+    if expected_pass and fixture_failures:
+        return [f"{name}: expected pass, got {fixture_failures}"]
+    if expected_pass:
+        fixture_results.append(f"{name}: correctly accepted")
+        return []
+    if not expected_pass and not fixture_failures:
+        return [f"{name}: expected contract failure, but fixture passed"]
+    fixture_results.append(f"{name}: correctly rejected")
+    return []
+
+
+production_full_jobs, failures = validate_workflow(workflow_path, expected_jobs)
+fixture_results = []
+fixture_failures = []
+fixture_failures.extend(
+    check_fixture(
+        "inline full caller without trunk",
+        fixture_workflow([f"      - run: {target}"]),
+        expected_pass=False,
+    )
+)
+fixture_failures.extend(
+    check_fixture(
+        "unpinned trunk install",
+        fixture_workflow(
+            [
+                "      - name: Install trunk",
+                "        run: cargo install trunk --locked",
+                f"      - name: Verify trunk",
+                f"        run: {trunk_verify}",
+                f"      - name: Run full test tier",
+                f"        run: {target}",
+            ]
+        ),
+        expected_pass=False,
+    )
+)
+fixture_failures.extend(
+    check_fixture(
+        "wrong-version trunk install",
+        fixture_workflow(
+            [
+                "      - name: Install trunk",
+                '        run: cargo install trunk --locked --version "999.99.99"',
+                f"      - name: Verify trunk",
+                f"        run: {trunk_verify}",
+                f"      - name: Run full test tier",
+                f"        run: {target}",
+            ]
+        ),
+        expected_pass=False,
+    )
+)
+fixture_failures.extend(
+    check_fixture(
+        "repository pinned trunk install",
+        fixture_workflow(
+            [
+                "      - name: Install trunk",
+                f"        run: {trunk_install}",
+                "      - name: Verify trunk",
+                f"        run: {trunk_verify}",
+                f"      - name: Run full test tier",
+                f"        run: {target}",
+            ]
+        ),
+        expected_pass=True,
+    )
+)
+failures.extend(fixture_failures)
+
+for fixture_result in fixture_results:
+    print(f"fixture: {fixture_result}")
 
 if failures:
     print("rust-full-tier-trunk-prerequisite contract: FAIL", file=sys.stderr)
@@ -99,6 +240,6 @@ if failures:
 
 print(
     "rust-full-tier-trunk-prerequisite contract: passed "
-    f"({len(full_jobs)} full-tier jobs install trunk before invocation)"
+    f"({len(production_full_jobs)} full-tier jobs use the pinned trunk prerequisite)"
 )
 PY


### PR DESCRIPTION
## Summary
- install canonical `trunk` prerequisite in both full-regression and full-escalation jobs
- add a required workflow contract covering every `ci-tests.sh full` caller
- keep runtime PR #3455 frozen and independent

## Verification
- focused trunk prerequisite contract
- existing full-escalation/full-superset/apt/release-trunk contracts
- actionlint, Bash syntax, executable-bit, workflow lint, doc governance, diff check

Task: task_fe6b5d8ffb8442e692ac937bf3d488ba
Refs #3459
Blocked parent rollout task: #3454