### PR TITLE
Bind provider rollout to operator known-hosts

### DIFF
--- a/doc/p2p/blockchain/public-testnet-governed-bootstrap.runbook.md
+++ b/doc/p2p/blockchain/public-testnet-governed-bootstrap.runbook.md
@@ -915,11 +915,12 @@ steps first. The preflight consumes the resulting bounded projection file;
 ./scripts/p2p-public-testnet-package-rollout.py \
   --manifest .tmp/public-testnet-package-rollout/nodes.json \
   --package-dir .tmp/testnet-packages/<run-id> \
+  --known-hosts <operator-local-pinned-known-hosts> \
   --out-dir .tmp/public-testnet-package-rollout \
   --readiness-policy rpc-running
 ```
 
-默认模式只生成计划，不改节点；脚本会校验各平台 `*-BUILDINFO` 和 `*-SHA256SUMS`，并输出 Linux/Windows operator 命令和 `rollout-plan.json`。本地 Linux 节点需要显式加 `--apply-local` 才会调用 `p2p-public-testnet-package-node-upgrade.sh` 执行替换；远端 SSH、Windows PowerShell 和凭据注入仍由 operator 在脚本外执行，manifest 不写密码。
+默认模式只生成计划，不改节点；脚本会校验各平台 `*-BUILDINFO` 和 `*-SHA256SUMS`，并输出 Linux/Windows operator 命令和 `rollout-plan.json`。当 manifest 包含远端 canonical Linux provider 时，`--known-hosts` 必须指向 operator 本机的非空 pinned host-key regular file，不得填写 provider 上的 `/opt/oasis7/p2p-testnet/...` 路径；脚本会在创建输出目录、信任校验或任何 transport/probe 前 fail closed。本地 Linux 节点需要显式加 `--apply-local` 才会调用 `p2p-public-testnet-package-node-upgrade.sh` 执行替换；远端 SSH、Windows PowerShell 和凭据注入仍由 operator 在脚本外执行，manifest 不写密码。
 
 Windows 计划要求 `windows-x64-SHA256SUMS` 覆盖并传输受治理的 bundle、genesis、network manifest、bootstrap peers、`governance_bootstrap_refs` 中全部非空 evidence 源，以及 public-testnet 必需的 world snapshot、递归 generated-world sidecar 和 world-generation provenance。每个带 `host` 的远端 Windows node manifest entry 必须显式声明非空 `rollback_backup_root`，并指向该节点已验证的时间戳备份目录；计划生成不得为远端节点隐式回退到 `backups\known-good`。每个计划按 node/version/commit/run 派生唯一 attempt id，installer、完整 governed closure 和 upgrade script 只能传到 `C:\oasis7-deploy\staging\package-rollout\<attempt-id>`；pre-apply 命令不得写 `config/`、install root 或其他 active deployment 路径。每次传输前先在远端创建并确认 staging 父目录，传输后按精确预期 SHA-256 远端复核并输出 `staging_transfer_ack`；全部传输闭合后，apply 必须使用精确的 `user@host` SSH target，并通过同步的 `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <staged-script>` 子进程从该 attempt staging root 执行脚本，再把子进程 `$LASTEXITCODE` 原样返回给 SSH。远端 PowerShell 在停止 scheduled task 或执行 installer 前初始化唯一、只追加的 stdout、stderr、exit-marker 诊断，完成 staged 文件与目录树完整性、来源路径、basename 冲突及已配置 known-good rollback root 预检，并依次输出 `staged_sha_closure_complete=true`、`promotion_begin=true`；只有此后才能停止 task、安装 runtime 或把 staged config 通过临时文件提升到 active tree，全部提升完成后输出 `promotion_complete=true`。
 

--- a/scripts/p2p-public-testnet-package-rollout.py
+++ b/scripts/p2p-public-testnet-package-rollout.py
@@ -30,9 +30,37 @@ WINDOWS_GOVERNED_BOOTSTRAP = (
 )
 CANONICAL_PROVIDER_NAMES = ("sequencer", "storage")
 MAX_PROVIDER_CHECKPOINT_HEIGHT_DELTA = 1
-LINUX_PROVIDER_KNOWN_HOSTS = (
-    "/opt/oasis7/p2p-testnet/config/public-testnet-validator-pair-known-hosts"
-)
+LINUX_PROVIDER_ROOT = Path("/opt/oasis7/p2p-testnet")
+
+
+def validate_operator_known_hosts(path: Path | None) -> Path:
+    """Return an operator-local host-key file, rejecting provider paths."""
+    if path is None:
+        die(
+            "remote Linux provider rollout requires an explicit --known-hosts "
+            "operator-local pinned host-key file"
+        )
+    candidate = path.expanduser()
+    if candidate.is_symlink():
+        die(f"operator known-hosts file must not be a symlink: {candidate}")
+    if not candidate.is_file() or not stat.S_ISREG(candidate.lstat().st_mode):
+        die(f"operator known-hosts file must be a regular file: {candidate}")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as error:
+        die(f"cannot resolve operator known-hosts file {candidate}: {error}")
+    try:
+        resolved.relative_to(LINUX_PROVIDER_ROOT.resolve())
+    except ValueError:
+        pass
+    else:
+        die(
+            "operator known-hosts file must be local to the rollout operator; "
+            f"provider filesystem path is forbidden: {candidate}"
+        )
+    if resolved.stat().st_size == 0:
+        die(f"operator known-hosts file must contain a pinned host key: {candidate}")
+    return resolved
 
 
 def die(message: str) -> None:
@@ -826,11 +854,13 @@ def linux_plan_commands(
     commit: str,
     run_id: str,
     readiness_policy: str,
+    known_hosts_path: Path | None = None,
 ) -> list[str]:
     host = str(node.get("host") or "")
     if not host:
         return [shell_join(linux_command(node, linux_asset, linux_ops_tools_asset, version, commit, run_id, readiness_policy))]
     user = str(node.get("user") or "root")
+    operator_known_hosts = validate_operator_known_hosts(known_hosts_path)
     helper_asset = ROOT_DIR / "scripts" / "p2p-public-testnet-package-node-upgrade.sh"
     if helper_asset.is_symlink() or not helper_asset.is_file() or not stat.S_ISREG(helper_asset.lstat().st_mode):
         die(f"missing Linux package upgrade helper: {helper_asset}")
@@ -938,37 +968,37 @@ def linux_plan_commands(
         f"tar -czf - -C {remote_quote(str(linux_asset.parent))} {remote_quote(package_name)}"
         f" {remote_quote(ops_tools_name)} -C {remote_quote(str(helper_asset.parent))} {remote_quote(helper_name)}"
     )
-    ssh_command = " ".join(
-        [
-            f'SSHPASS="${{{credential_env}:?{credential_env} is required}}"',
-            "sshpass",
-            "-e",
-            "ssh",
-            "-o",
-            "HostKeyAlgorithms=ssh-ed25519",
-            "-o",
-            "StrictHostKeyChecking=yes",
-            "-o",
-            f"UserKnownHostsFile={LINUX_PROVIDER_KNOWN_HOSTS}",
-            "-o",
-            "GlobalKnownHostsFile=/dev/null",
-            "-o",
-            "PreferredAuthentications=password",
-            "-o",
-            "PubkeyAuthentication=no",
-            "-o",
-            "NumberOfPasswordPrompts=1",
-            "-o",
-            "ControlMaster=no",
-            "-o",
-            "ControlPath=none",
-            shell_join(
-                [
-                    f"{user}@{host}",
-                    shell_join(["bash", "-c", remote_body]),
-                ]
-            ),
-        ]
+    ssh_command = (
+        f'SSHPASS="${{{credential_env}:?{credential_env} is required}}" '
+        + shell_join(
+            [
+                "sshpass",
+                "-e",
+                "ssh",
+                "-o",
+                "HostKeyAlgorithms=ssh-ed25519",
+                "-o",
+                "StrictHostKeyChecking=yes",
+                "-o",
+                f"UserKnownHostsFile={operator_known_hosts}",
+                "-o",
+                "GlobalKnownHostsFile=/dev/null",
+                "-o",
+                "PreferredAuthentications=password",
+                "-o",
+                "PubkeyAuthentication=no",
+                "-o",
+                "NumberOfPasswordPrompts=1",
+                "-o",
+                "ControlMaster=no",
+                "-o",
+                "ControlPath=none",
+                f"{user}@{host}",
+                "bash",
+                "-c",
+                remote_quote(remote_body),
+            ]
+        )
     )
     return [f"set -o pipefail; {tar_command} | {ssh_command}"]
 
@@ -3022,13 +3052,19 @@ def main() -> int:
         ),
     )
     parser.add_argument("--json", action="store_true", help="Print machine-readable rollout plan")
+    parser.add_argument(
+        "--known-hosts",
+        "--operator-known-hosts",
+        dest="known_hosts",
+        type=Path,
+        help=(
+            "operator-local pinned known-hosts file for remote Linux provider SSH; "
+            "required when a canonical provider has a host"
+        ),
+    )
     args = parser.parse_args()
 
     manifest = load_manifest(args.manifest)
-    package_dir = args.package_dir.resolve()
-    out_dir = args.out_dir.resolve()
-    out_dir.mkdir(parents=True, exist_ok=True)
-
     platforms = sorted({str(node.get("platform") or "") for node in manifest["nodes"]})
     if "" in platforms:
         die("all nodes must declare platform")
@@ -3036,6 +3072,23 @@ def main() -> int:
     if len(names) != len(manifest["nodes"]) or not all(names) or len(set(names)) != len(names):
         die("all rollout manifest nodes must have unique non-empty names")
     observer_rollout_present = any(name not in CANONICAL_PROVIDER_NAMES for name in names)
+    remote_linux_provider_present = any(
+        isinstance(node, dict)
+        and str(node.get("platform") or "") == "linux-x64"
+        and str(node.get("name") or "") in CANONICAL_PROVIDER_NAMES
+        and bool(str(node.get("host") or ""))
+        for node in manifest["nodes"]
+    )
+    operator_known_hosts = None
+    if args.known_hosts is not None:
+        operator_known_hosts = validate_operator_known_hosts(args.known_hosts)
+    elif remote_linux_provider_present:
+        validate_operator_known_hosts(None)
+
+    package_dir = args.package_dir.resolve()
+    out_dir = args.out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
     # This happens before the probe starts a runtime from the downloaded Linux
     # bundle.  A malformed package must fail before any package code executes.
     trust_platforms = list(platforms)
@@ -3111,8 +3164,20 @@ def main() -> int:
                     args.readiness_policy,
                 )
                 node_plan["commands"].extend(
-                    linux_plan_commands(node, platform_assets[platform], platform_ops_tools_assets[platform], version, commit, run_id, args.readiness_policy)
+                    linux_plan_commands(
+                        node,
+                        platform_assets[platform],
+                        platform_ops_tools_assets[platform],
+                        version,
+                        commit,
+                        run_id,
+                        args.readiness_policy,
+                        operator_known_hosts,
+                    )
                 )
+                if name in CANONICAL_PROVIDER_NAMES and node.get("host"):
+                    assert operator_known_hosts is not None
+                    node_plan["operator_known_hosts"] = str(operator_known_hosts)
             else:
                 assert provider_status_urls is not None
                 assert checkpoint_closure_receipt is not None

--- a/scripts/p2p-public-testnet-package-rollout.test.sh
+++ b/scripts/p2p-public-testnet-package-rollout.test.sh
@@ -117,6 +117,12 @@ EOF
 chmod +x "$rollout_driver"
 export OASIS7_TEST_CLOSURE_FIXTURE="$checkpoint_closure_receipt"
 
+# All positive rollout fixtures share one operator-local known-hosts pin.  Keep
+# the path centralized so every plan exercises the same single-auth boundary;
+# the negative missing/directory cases below intentionally override it.
+operator_known_hosts="$TMP_DIR/operator pinned known-hosts"
+printf '%s\n' 'fixture ssh-ed25519 AAAAoperatorlocalpin' >"$operator_known_hosts"
+
 mkdir -p "$package_dir/windows" "$package_dir/macos" "$bundle_src/bin" "$node_root/releases/old/bin" "$node_root/config/doc/testing/evidence"
 cat >"$bundle_src/bin/oasis7_chain_runtime" <<'EOF'
 #!/usr/bin/env bash
@@ -1533,7 +1539,87 @@ EOF
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/plan-only-out" \
+  --known-hosts "$operator_known_hosts" \
   --json >"$TMP_DIR/plan-only.json"
+
+# Provider SSH generation must consume an explicit operator-local known-hosts
+# file.  The path intentionally contains spaces so the rendered UserKnownHostsFile
+# option must survive both the local shell and the later SSH reparse boundary.
+known_hosts_plan_out="$TMP_DIR/operator-known-hosts-plan-out"
+known_hosts_plan_json="$TMP_DIR/operator-known-hosts-plan.json"
+if ! "$rollout_driver" \
+  --manifest "$TMP_DIR/manifest.json" \
+  --package-dir "$package_dir" \
+  --out-dir "$known_hosts_plan_out" \
+  --known-hosts "$operator_known_hosts" \
+  --json >"$known_hosts_plan_json"; then
+  echo "known-hosts RED: expected explicit operator-local --known-hosts path to be accepted" >&2
+  exit 1
+fi
+
+python3 - \
+  "$known_hosts_plan_json" \
+  "$operator_known_hosts" <<'PY'
+from pathlib import Path
+import json
+import shlex
+import sys
+
+plan = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+known_hosts = str(Path(sys.argv[2]).resolve())
+storage = next(node for node in plan["nodes"] if node["name"] == "storage")
+command = storage["commands"][0]
+tokens = shlex.split(command)
+known_hosts_option = f"UserKnownHostsFile={known_hosts}"
+assert known_hosts_option in tokens, (
+    "provider SSH command must bind the explicit operator-local known-hosts file"
+)
+assert shlex.quote(known_hosts_option) in command, (
+    "UserKnownHostsFile path must be shell-quoted in the rendered provider command"
+)
+assert "HostKeyAlgorithms=ssh-ed25519" in tokens
+assert "StrictHostKeyChecking=yes" in tokens
+assert "GlobalKnownHostsFile=/dev/null" in tokens
+assert tokens.count("ssh") == 1
+assert "scp" not in tokens
+assert len(storage["commands"]) == 1
+PY
+
+# Missing and non-file operator pins must fail before a plan or provider
+# transport can be generated.  The plan-only CLI never executes a provider;
+# absence of its output directory is the bounded no-transport assertion.
+missing_known_hosts="$TMP_DIR/missing operator known-hosts"
+missing_known_hosts_out="$TMP_DIR/missing-known-hosts-out"
+if "$rollout_driver" \
+  --manifest "$TMP_DIR/manifest.json" \
+  --package-dir "$package_dir" \
+  --out-dir "$missing_known_hosts_out" \
+  --known-hosts "$missing_known_hosts" \
+  --json \
+  >"$TMP_DIR/missing-known-hosts.stdout" \
+  2>"$TMP_DIR/missing-known-hosts.stderr"; then
+  echo "known-hosts RED: missing operator pin unexpectedly generated a rollout plan" >&2
+  exit 1
+fi
+grep -Eqi 'known.?hosts|regular|file' "$TMP_DIR/missing-known-hosts.stderr"
+test ! -e "$missing_known_hosts_out"
+
+non_file_known_hosts="$TMP_DIR/non-file operator known-hosts"
+mkdir -p "$non_file_known_hosts"
+non_file_known_hosts_out="$TMP_DIR/non-file-known-hosts-out"
+if "$rollout_driver" \
+  --manifest "$TMP_DIR/manifest.json" \
+  --package-dir "$package_dir" \
+  --out-dir "$non_file_known_hosts_out" \
+  --known-hosts "$non_file_known_hosts" \
+  --json \
+  >"$TMP_DIR/non-file-known-hosts.stdout" \
+  2>"$TMP_DIR/non-file-known-hosts.stderr"; then
+  echo "known-hosts RED: directory operator pin unexpectedly generated a rollout plan" >&2
+  exit 1
+fi
+grep -Eqi 'known.?hosts|regular|file' "$TMP_DIR/non-file-known-hosts.stderr"
+test ! -e "$non_file_known_hosts_out"
 
 python3 - \
   "$ROOT_DIR/scripts/p2p-public-testnet-package-rollout.py" \
@@ -1666,6 +1752,7 @@ jq '{nodes: [
   --manifest "$observer_gate_manifest" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/linux-observer-gate-out" \
+  --known-hosts "$operator_known_hosts" \
   --json >"$TMP_DIR/linux-observer-gate-plan.json"
 python3 - "$TMP_DIR/linux-observer-gate-plan.json" <<'PY'
 from pathlib import Path
@@ -1709,6 +1796,7 @@ if "$ROOT_DIR/scripts/p2p-public-testnet-package-rollout.py" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$cross_commit_package" \
   --out-dir "$TMP_DIR/cross-commit-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/cross-commit.stdout" 2>"$TMP_DIR/cross-commit.stderr"; then
   echo "expected cross-commit package mix to fail planning" >&2
   exit 1
@@ -1722,6 +1810,7 @@ if "$rollout_driver" \
   --manifest "$missing_remote_rollback_manifest" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/missing-remote-rollback-backup-root-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/missing-remote-rollback-backup-root.stdout" \
   2>"$TMP_DIR/missing-remote-rollback-backup-root.stderr"; then
   echo "expected remote Windows node without rollback_backup_root to fail plan generation" >&2
@@ -1736,13 +1825,14 @@ package_contract_failed=0
 # one pinned-host SSH session.  The old plan emitted two SCP transfers followed
 # by a separate SSH mutation, which made the authentication boundary and the
 # streamed payload impossible to attest as one transaction.
-if ! python3 - "$TMP_DIR/plan-only.json" <<'PY'
+if ! python3 - "$TMP_DIR/plan-only.json" "$operator_known_hosts" <<'PY'
 from pathlib import Path
 import json
 import shlex
 import sys
 
 plan = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+expected_known_hosts = str(Path(sys.argv[2]).resolve())
 storage = next(node for node in plan["nodes"] if node["name"] == "storage")
 commands = storage["commands"]
 assert len(commands) == 1, (
@@ -1777,8 +1867,8 @@ known_hosts = next(
 assert known_hosts and known_hosts != "/dev/null", (
     "provider rollout must use a non-empty pinned UserKnownHostsFile"
 )
-assert known_hosts.endswith("public-testnet-validator-pair-known-hosts"), (
-    "provider rollout must use the governed public-testnet pinned host-key file"
+assert known_hosts == expected_known_hosts, (
+    "provider rollout must use the explicit operator-local pinned host-key file"
 )
 assert "StrictHostKeyChecking=no" not in command
 assert "StrictHostKeyChecking=accept-new" not in command
@@ -3362,6 +3452,7 @@ PY
     --manifest "$TMP_DIR/manifest.json" \
     --package-dir "$missing_package" \
     --out-dir "$TMP_DIR/missing-$missing_runtime_truth-out" \
+    --known-hosts "$operator_known_hosts" \
     >"$TMP_DIR/missing-$missing_runtime_truth.stdout" \
     2>"$TMP_DIR/missing-$missing_runtime_truth.stderr"; then
     echo "expected public_testnet Windows source missing $missing_runtime_truth to fail" >&2
@@ -3420,6 +3511,7 @@ PY
       --manifest "$TMP_DIR/manifest.json" \
       --package-dir "$escaped_package" \
       --out-dir "$escaped_out" \
+      --known-hosts "$operator_known_hosts" \
       >"$escaped_out.stdout" 2>"$escaped_out.stderr"; then
       echo "expected escaped Windows $escaped_field ref to fail before plan transfer generation" >&2
       package_contract_failed=1
@@ -3460,6 +3552,7 @@ for symlink_kind in file directory; do
     --manifest "$TMP_DIR/manifest.json" \
     --package-dir "$symlink_package" \
     --out-dir "$symlink_out" \
+    --known-hosts "$operator_known_hosts" \
     >"$symlink_out.stdout" 2>"$symlink_out.stderr"; then
     echo "expected runtime-truth $symlink_kind symlink to fail before rollout generation" >&2
     package_contract_failed=1
@@ -3493,6 +3586,7 @@ for governed_name in \
     --manifest "$TMP_DIR/manifest.json" \
     --package-dir "$symlink_package" \
     --out-dir "$symlink_out" \
+    --known-hosts "$operator_known_hosts" \
     >"$symlink_out.stdout" 2>"$symlink_out.stderr"; then
     echo "expected top-level governed symlink to fail before rollout generation: $governed_name" >&2
     package_contract_failed=1
@@ -3518,6 +3612,7 @@ if "$rollout_driver" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$ancestor_package" \
   --out-dir "$ancestor_out" \
+  --known-hosts "$operator_known_hosts" \
   >"$ancestor_out.stdout" 2>"$ancestor_out.stderr"; then
   echo "expected governed ancestor symlink to fail before rollout generation" >&2
   package_contract_failed=1
@@ -3537,6 +3632,7 @@ fi
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$package_dir" \
   --out-dir "$out_dir" \
+  --known-hosts "$operator_known_hosts" \
   --apply-local \
   --json >"$TMP_DIR/plan.json"
 
@@ -4306,6 +4402,7 @@ fi
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/repeated-plan-out" \
+  --known-hosts "$operator_known_hosts" \
   --json >"$TMP_DIR/repeated-plan.json"
 cmp -s \
   "$TMP_DIR/plan-only-out/windows-observer-windows-upgrade.ps1" \
@@ -4396,6 +4493,7 @@ missing_network_metadata_out="$TMP_DIR/missing-network-manifest-metadata-out"
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$missing_network_metadata_package" \
   --out-dir "$missing_network_metadata_out" \
+  --known-hosts "$operator_known_hosts" \
   --json >"$TMP_DIR/missing-network-manifest-metadata-plan.json"
 if ! python3 - "$missing_network_metadata_out/windows-observer-windows-upgrade.ps1" <<'PY'
 from pathlib import Path
@@ -4457,6 +4555,7 @@ if "$rollout_driver" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$bad_package_dir" \
   --out-dir "$TMP_DIR/bad-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/bad.out" 2>"$TMP_DIR/bad.err"; then
   echo "expected mismatched BUILDINFO to fail" >&2
   exit 1
@@ -4473,6 +4572,7 @@ if "$rollout_driver" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$bad_sums_dir" \
   --out-dir "$TMP_DIR/bad-sums-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/bad-sums.out" 2>"$TMP_DIR/bad-sums.err"; then
   echo "expected missing asset checksum coverage to fail" >&2
   exit 1
@@ -4493,6 +4593,7 @@ if "$rollout_driver" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$bad_ops_dir" \
   --out-dir "$TMP_DIR/bad-ops-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/bad-ops.out" 2>"$TMP_DIR/bad-ops.err"; then
   echo "expected tampered ops-tools archive to fail dedicated checksum validation" >&2
   exit 1
@@ -4532,6 +4633,7 @@ PY
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/strict-out" \
+  --known-hosts "$operator_known_hosts" \
   --readiness-policy strict-ready \
   --json >"$TMP_DIR/strict-plan.json"
 jq -e '
@@ -4556,6 +4658,7 @@ if "$rollout_driver" \
   --manifest "$TMP_DIR/manifest.json" \
   --package-dir "$package_dir" \
   --out-dir "$TMP_DIR/strict-missing-status-out" \
+  --known-hosts "$operator_known_hosts" \
   --readiness-policy strict-ready \
   >"$TMP_DIR/strict-missing-status.out" 2>"$TMP_DIR/strict-missing-status.err"; then
   echo "expected strict-ready restart without status_url to fail" >&2
@@ -4565,7 +4668,8 @@ grep -q "uses strict-ready but has no status_url" "$TMP_DIR/strict-missing-statu
 
 "$rollout_driver" \
   --manifest "$observer_gate_manifest" --package-dir "$package_dir" \
-  --out-dir "$TMP_DIR/observer-closure-probe-out" --json >"$TMP_DIR/observer-closure-probe-plan.json"
+  --out-dir "$TMP_DIR/observer-closure-probe-out" \
+  --known-hosts "$operator_known_hosts" --json >"$TMP_DIR/observer-closure-probe-plan.json"
 probe_gate_script="$(python3 - "$TMP_DIR/observer-closure-probe-plan.json" <<'PY'
 import json, sys
 plan = json.load(open(sys.argv[1], encoding="utf-8"))
@@ -4577,7 +4681,8 @@ grep -q 'fixture-checkpoint-v2' "$probe_gate_script"
 for mode in bad-digest non-network empty-candidates hash-size stale; do
   if OASIS7_TEST_PROBE_MODE="$mode" "$rollout_driver" \
     --manifest "$observer_gate_manifest" --package-dir "$package_dir" \
-    --out-dir "$TMP_DIR/observer-probe-$mode-out" >/dev/null 2>"$TMP_DIR/observer-probe-$mode.err"; then
+    --out-dir "$TMP_DIR/observer-probe-$mode-out" \
+    --known-hosts "$operator_known_hosts" >/dev/null 2>"$TMP_DIR/observer-probe-$mode.err"; then
     echo "expected controlled probe mode $mode to fail" >&2; exit 1
   fi
   grep -q 'checkpoint closure probe' "$TMP_DIR/observer-probe-$mode.err"
@@ -4586,14 +4691,16 @@ done
 # Legacy external input is rejected by argparse, and the legacy environment is
 # rejected before the harness can be consulted.
 if "$ROOT_DIR/scripts/p2p-public-testnet-package-rollout.py" --manifest "$observer_gate_manifest" \
-  --package-dir "$package_dir" --checkpoint-closure-receipt "$checkpoint_closure_receipt" \
+  --package-dir "$package_dir" --known-hosts "$operator_known_hosts" \
+  --checkpoint-closure-receipt "$checkpoint_closure_receipt" \
   --out-dir "$TMP_DIR/legacy-arg-out" >/dev/null 2>"$TMP_DIR/legacy-arg.err"; then
   echo "expected legacy checkpoint receipt argument to fail" >&2; exit 1
 fi
 grep -q 'unrecognized arguments' "$TMP_DIR/legacy-arg.err"
 if OASIS7_CHECKPOINT_CLOSURE_RECEIPT="$checkpoint_closure_receipt" \
   "$ROOT_DIR/scripts/p2p-public-testnet-package-rollout.py" --manifest "$observer_gate_manifest" \
-  --package-dir "$package_dir" --out-dir "$TMP_DIR/legacy-env-out" >/dev/null 2>"$TMP_DIR/legacy-env.err"; then
+  --package-dir "$package_dir" --known-hosts "$operator_known_hosts" \
+  --out-dir "$TMP_DIR/legacy-env-out" >/dev/null 2>"$TMP_DIR/legacy-env.err"; then
   echo "expected legacy checkpoint receipt environment to fail" >&2; exit 1
 fi
 grep -q 'caller-supplied checkpoint closure receipt is forbidden' "$TMP_DIR/legacy-env.err"
@@ -4617,6 +4724,7 @@ if OASIS7_TEST_INPROCESS_PROBE_MARKER="$non_linux_probe_marker" \
   "$rollout_driver" --manifest "$non_linux_only_manifest" \
   --package-dir "$tampered_linux_probe_package" \
   --out-dir "$TMP_DIR/non-linux-tampered-out" \
+  --known-hosts "$operator_known_hosts" \
   >"$TMP_DIR/non-linux-tampered.out" 2>"$TMP_DIR/non-linux-tampered.err"; then
   echo "expected a tampered Linux probe bundle to fail a non-Linux observer plan" >&2
   exit 1
@@ -4642,7 +4750,8 @@ chmod +x "$forbidden_override"
 OASIS7_TESTING=1 OASIS7_TEST_CHECKPOINT_CLOSURE_PROBE="$forbidden_override" \
   "$ROOT_DIR/scripts/p2p-public-testnet-package-rollout.py" \
   --manifest "$observer_gate_manifest" --package-dir "$package_dir" \
-  --out-dir "$TMP_DIR/release-cli-retired-env-out" --json \
+  --out-dir "$TMP_DIR/release-cli-retired-env-out" \
+  --known-hosts "$operator_known_hosts" --json \
   >"$TMP_DIR/release-cli-retired-env.out" \
   2>"$TMP_DIR/release-cli-retired-env.err" && {
     echo "fixture without governed node.env unexpectedly completed the real probe" >&2

--- a/scripts/p2p-public-testnet-package-rollout.test.sh
+++ b/scripts/p2p-public-testnet-package-rollout.test.sh
@@ -1542,6 +1542,23 @@ EOF
   --known-hosts "$operator_known_hosts" \
   --json >"$TMP_DIR/plan-only.json"
 
+if ! python3 - "$ROOT_DIR/doc/p2p/blockchain/public-testnet-governed-bootstrap.runbook.md" <<'PY'
+from pathlib import Path
+import sys
+
+runbook = Path(sys.argv[1]).read_text(encoding="utf-8")
+start = runbook.index("### Package version replacement")
+end = runbook.index("默认模式只生成计划", start)
+section = runbook[start:end]
+assert "--known-hosts <operator-local-pinned-known-hosts>" in section, (
+    "canonical package rollout command must pass an operator-local known-hosts pin"
+)
+PY
+then
+  echo "known-hosts RED: canonical runbook command omits operator-local --known-hosts" >&2
+  exit 1
+fi
+
 # Provider SSH generation must consume an explicit operator-local known-hosts
 # file.  The path intentionally contains spaces so the rendered UserKnownHostsFile
 # option must survive both the local shell and the later SSH reparse boundary.


### PR DESCRIPTION
Task: task_1b700149b4784c6eb9036821b62dbd63

Refs #3582

## Summary
- require an explicit operator-local pinned known-hosts file
- reject missing, empty, symlinked, directory, or provider-domain paths before transport/output generation
- retain strict ED25519 host-key checking and the single authenticated tar-over-SSH stream
- add TDD coverage for quoting and fail-closed path validation

## Verification
- `bash scripts/p2p-public-testnet-package-rollout.test.sh`
- `python3 -m py_compile scripts/p2p-public-testnet-package-rollout.py`
- `bash -n scripts/p2p-public-testnet-package-rollout.test.sh`
- `git diff --check`

No provider, credential, network, or node mutation was used during development.