### PR TITLE
Close streamed rollout helper dependencies

### DIFF
--- a/scripts/p2p-public-testnet-package-rollout.py
+++ b/scripts/p2p-public-testnet-package-rollout.py
@@ -862,8 +862,16 @@ def linux_plan_commands(
     user = str(node.get("user") or "root")
     operator_known_hosts = validate_operator_known_hosts(known_hosts_path)
     helper_asset = ROOT_DIR / "scripts" / "p2p-public-testnet-package-node-upgrade.sh"
-    if helper_asset.is_symlink() or not helper_asset.is_file() or not stat.S_ISREG(helper_asset.lstat().st_mode):
-        die(f"missing Linux package upgrade helper: {helper_asset}")
+    direct_helper_assets = [
+        ("safe_extract", ROOT_DIR / "scripts" / "p2p-safe-extract-tar.py"),
+        ("safe_validate", ROOT_DIR / "scripts" / "p2p-safe-validate-deb-tree.py"),
+        ("verify_bundle", ROOT_DIR / "scripts" / "p2p-verify-linux-package-bundle.py"),
+        ("rebuild_checksums", ROOT_DIR / "scripts" / "p2p-rebuild-linux-bundle-checksums.py"),
+    ]
+    local_assets = [("upgrade helper", helper_asset), *direct_helper_assets]
+    for description, asset in local_assets:
+        if asset.is_symlink() or not asset.is_file() or not stat.S_ISREG(asset.lstat().st_mode):
+            die(f"missing Linux package {description}: {asset}")
     node_root = str(node.get("node_root") or "")
     if not node_root:
         die(f"linux node {node.get('name', '<unnamed>')} missing node_root")
@@ -877,6 +885,11 @@ def linux_plan_commands(
     package_size = linux_asset.stat().st_size
     ops_tools_size = linux_ops_tools_asset.stat().st_size
     helper_size = helper_asset.stat().st_size
+    direct_helper_metadata = [
+        (label, asset.name, sha256_file(asset), asset.stat().st_size)
+        for label, asset in direct_helper_assets
+    ]
+    direct_helper_names = [name for _, name, _, _ in direct_helper_metadata]
 
     def remote_file(name: str) -> str:
         return f'"$stage/{name}"'
@@ -930,34 +943,59 @@ def linux_plan_commands(
             f" --post-restart-timeout-secs {remote_quote(str(node.get('post_restart_timeout_secs') or 120))}"
         )
 
-    remote_body = "\n".join(
+    remote_body_lines = [
+        "set -euo pipefail",
+        'stage="$(mktemp -d /tmp/oasis7-package-rollout.XXXXXX)"',
+        'cleanup() { rm -rf "$stage"; }',
+        "trap cleanup EXIT",
+        'tar -xzf - -C "$stage"',
+        f'test -f {remote_file(package_name)}',
+        f'test -f {remote_file(ops_tools_name)}',
+        f'test -f {remote_file(helper_name)}',
+    ]
+    remote_body_lines.extend(
+        f'test -f {remote_file(name)}' for name in direct_helper_names
+    )
+    remote_body_lines.extend(
         [
-            "set -euo pipefail",
-            'stage="$(mktemp -d /tmp/oasis7-package-rollout.XXXXXX)"',
-            'cleanup() { rm -rf "$stage"; }',
-            "trap cleanup EXIT",
-            'tar -xzf - -C "$stage"',
-            f'test -f {remote_file(package_name)}',
-            f'test -f {remote_file(ops_tools_name)}',
-            f'test -f {remote_file(helper_name)}',
             f"expected_package_sha={remote_quote(package_sha)}",
             f"expected_ops_tools_sha={remote_quote(ops_tools_sha)}",
             f"expected_helper_sha={remote_quote(helper_sha)}",
             f"expected_package_size={remote_quote(str(package_size))}",
             f"expected_ops_tools_size={remote_quote(str(ops_tools_size))}",
             f"expected_helper_size={remote_quote(str(helper_size))}",
+        ]
+    )
+    remote_body_lines.extend(
+        f"expected_{label}_sha={remote_quote(digest)}\nexpected_{label}_size={remote_quote(str(size))}"
+        for label, _, digest, size in direct_helper_metadata
+    )
+    remote_body_lines.extend(
+        [
             f'test "$(sha256sum {remote_file(package_name)} | awk \'{{print $1}}\')" = "$expected_package_sha"',
             f'test "$(sha256sum {remote_file(ops_tools_name)} | awk \'{{print $1}}\')" = "$expected_ops_tools_sha"',
             f'test "$(sha256sum {remote_file(helper_name)} | awk \'{{print $1}}\')" = "$expected_helper_sha"',
             f'test "$(stat -c %s {remote_file(package_name)})" = "$expected_package_size"',
             f'test "$(stat -c %s {remote_file(ops_tools_name)})" = "$expected_ops_tools_size"',
             f'test "$(stat -c %s {remote_file(helper_name)})" = "$expected_helper_size"',
+        ]
+    )
+    for label, name, _, _ in direct_helper_metadata:
+        remote_body_lines.extend(
+            [
+                f'test "$(sha256sum {remote_file(name)} | awk \'{{print $1}}\')" = "$expected_{label}_sha"',
+                f'test "$(stat -c %s {remote_file(name)})" = "$expected_{label}_size"',
+            ]
+        )
+    remote_body_lines.extend(
+        [
             "printf '%s\\n' streamed_envelope_sha256_verified=true",
             "printf '%s\\n' streamed_envelope_size_verified=true",
             "printf '%s\\n' streamed_envelope_complete=true",
             f"exec {remote_invocation}",
         ]
     )
+    remote_body = "\n".join(remote_body_lines)
     provider_env_name = re.sub(
         r"[^A-Z0-9_]",
         "_",
@@ -966,7 +1004,9 @@ def linux_plan_commands(
     credential_env = f"PUBLIC_TESTNET_{provider_env_name}_SSHPASS"
     tar_command = (
         f"tar -czf - -C {remote_quote(str(linux_asset.parent))} {remote_quote(package_name)}"
-        f" {remote_quote(ops_tools_name)} -C {remote_quote(str(helper_asset.parent))} {remote_quote(helper_name)}"
+        f" {remote_quote(ops_tools_name)} -C {remote_quote(str(helper_asset.parent))}"
+        f" {remote_quote(helper_name)}"
+        + " ".join(f" {remote_quote(name)}" for name in direct_helper_names)
     )
     ssh_command = (
         f'SSHPASS="${{{credential_env}:?{credential_env} is required}}" '

--- a/scripts/p2p-public-testnet-package-rollout.test.sh
+++ b/scripts/p2p-public-testnet-package-rollout.test.sh
@@ -2023,6 +2023,137 @@ then
   package_contract_failed=1
 fi
 
+# Execute the generated one-SSH stream through a local fake ssh/sshd pair.
+# The node-upgrade entrypoint directly invokes four sibling helpers; the
+# streamed envelope must therefore carry every one before the remote shell
+# reaches the mutation boundary.  This RED test reports the missing staged
+# helpers while proving no mutation sentinel is reached after server-side
+# reparse.
+if ! python3 - "$TMP_DIR/plan-only.json" <<'PY'
+from pathlib import Path
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+
+plan = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+storage = next(node for node in plan["nodes"] if node["name"] == "storage")
+command = storage["commands"][0]
+argv = shlex.split(command)
+ssh_index = argv.index("ssh")
+target_index = next(
+    index for index in range(ssh_index + 1, len(argv)) if argv[index].startswith("root@")
+)
+remote_argv = argv[target_index + 1 :]
+parsed_remote = shlex.split(" ".join(remote_argv))
+if parsed_remote[:2] != ["bash", "-c"]:
+    raise AssertionError("expected a remote bash -c envelope")
+original_body = parsed_remote[2]
+helper_name = "p2p-public-testnet-package-node-upgrade.sh"
+required_helpers = (
+    "p2p-safe-extract-tar.py",
+    "p2p-safe-validate-deb-tree.py",
+    "p2p-verify-linux-package-bundle.py",
+    "p2p-rebuild-linux-bundle-checksums.py",
+)
+if helper_name not in original_body:
+    raise AssertionError("generated stream does not invoke the node-upgrade helper")
+
+with tempfile.TemporaryDirectory(prefix="oasis7-streamed-helper-reparse-") as tmp:
+    tmp_path = Path(tmp)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    (fake_bin / "sshpass").write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "[[ \"${1:-}\" == -e && \"${2:-}\" == ssh ]]\n"
+        "shift 2\n"
+        "exec ssh \"$@\"\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "ssh").write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import shlex\n"
+        "import sys\n"
+        "args = sys.argv[1:]\n"
+        "while args and args[0] == '-o':\n"
+        "    args = args[2:]\n"
+        "if not args:\n"
+        "    raise SystemExit('fake ssh missing target')\n"
+        "remote = shlex.split(' '.join(args[1:]))\n"
+        "if remote[:2] != ['bash', '-c']:\n"
+        "    raise SystemExit('fake ssh missing remote bash -c')\n"
+        "os.execvp(remote[0], remote)\n",
+        encoding="utf-8",
+    )
+    for path in fake_bin.iterdir():
+        path.chmod(0o755)
+
+    sentinel = tmp_path / "mutation-sentinel"
+    sentinel_literal = shlex.quote(str(sentinel))
+    required_helper_literals = " ".join(shlex.quote(name) for name in required_helpers)
+    remote_body = "\n".join(
+        [
+            "set -euo pipefail",
+            'stage="$(mktemp -d /tmp/oasis7-package-rollout.XXXXXX)"',
+            'trap \'rm -rf "$stage"\' EXIT',
+            'tar -xzf - -C "$stage"',
+            f'test -f "$stage/{helper_name}"',
+            f'for required_helper in {required_helper_literals}; do',
+            f'  grep -Fq "$required_helper" "$stage/{helper_name}" || {{',
+            '    printf \'%s\\n\' "node-upgrade helper does not reference $required_helper" >&2',
+            "    exit 43",
+            "  }",
+            f'  if [[ ! -f "$stage/$required_helper" ]]; then',
+            f'    printf \'%s\\n\' "missing direct staged helper: $required_helper" >&2',
+            "    missing_helpers+=\" $required_helper\"",
+            "  fi",
+            "done",
+            'if [[ -n "${missing_helpers:-}" ]]; then',
+            '  printf \'%s\\n\' "direct helper closure incomplete:$missing_helpers" >&2',
+            "  exit 42",
+            "fi",
+            f"printf '%s' mutation > {sentinel_literal}",
+        ]
+    )
+    remote_command = command.replace(
+        shlex.quote(remote_argv[2]), shlex.quote(shlex.quote(remote_body)), 1
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["PUBLIC_TESTNET_STORAGE_SSHPASS"] = "fixture-only"
+    result = subprocess.run(
+        ["bash", "-c", remote_command],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        if "direct helper closure incomplete:" in result.stderr:
+            if sentinel.exists():
+                raise AssertionError(
+                    "direct helper closure failure reached the mutation sentinel"
+                )
+            print(
+                f"{result.stderr.strip()} mutation_sentinel=False",
+                file=sys.stderr,
+            )
+            raise SystemExit(42)
+        raise AssertionError(
+            "remote streamed-envelope reparse failed for an unexpected reason: "
+            f"rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+    if not sentinel.exists():
+        raise AssertionError("streamed-envelope reparse did not reach its mutation sentinel")
+PY
+then
+  package_contract_failed=1
+fi
+
 if ! python3 - \
   "$TMP_DIR/plan-only.json" \
   "$TMP_DIR/plan-only-out/macos-observer-macos-arm64-upgrade.sh" \


### PR DESCRIPTION
Task: task_d004391a908a449a9722628c25ff4afb

Refs #3585

## Summary
- include the Debian tree validator in the single authenticated tar-over-SSH envelope
- verify its exact SHA-256 and byte size before the remote mutation boundary
- add an execution regression covering server-shell reparse and dependency closure

## Verification
- rollout helper fixture
- workflow lint
- doc governance
- Python compile and SyntaxWarning gate
- Bash syntax and diff check

Provider mutation remains blocked pending exact-head CI, repo-owned review, merge, and a new exact package.