### PR TITLE
Improve player visual feedback and responsive interactions

### DIFF
--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -1,0 +1,512 @@
+import { createServer } from "node:http";
+import { readFileSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, extname, join, normalize, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+
+// QA-owned S6 browser fixture. It exercises the player-visible Viewer shell
+// with a deterministic local bridge and fake world-feed transport. It does
+// not start a runtime, provider, chain, or real gameplay session.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const viewerRoot = resolve(scriptDir, "..");
+const repoRoot = resolve(viewerRoot, "../..");
+const taskUid = "task_872ecd04e2824c02a685e1fd6df63d03";
+const runId = new Date().toISOString().replace(/[:.]/g, "-");
+const outDir = resolve(repoRoot, ".pm/scratch", taskUid, "browser", runId);
+const bundlePath = resolve(viewerRoot, ".software-safe-build/viewer.js");
+const session = `player-visual-feedback-${process.pid}`;
+const browserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
+const skipBuild = process.argv.includes("--skip-build");
+const statuses = ["ready", "replay", "empty", "gap", "unavailable"];
+const viewports = [
+  { name: "mobile", width: 390, height: 844 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1440, height: 1000 },
+];
+const summary = {
+  caseId: "S6-Q1-player-visual-feedback",
+  taskUid,
+  mode: "viewer_test_api_fixture",
+  inputMode: "visible-ui-controls-plus-dom-readback",
+  mockDisabled: false,
+  fixtureBoundary: "deterministic QA bridge and fake world_feed; no runtime/provider/playability claim",
+  status: "running",
+  startedAt: new Date().toISOString(),
+  viewports: {},
+  feedStatuses: {},
+  interactions: {},
+};
+
+mkdirSync(outDir, { recursive: true });
+
+function assert(condition, message, details = undefined) {
+  if (condition) return;
+  const suffix = details === undefined ? "" : `\n${JSON.stringify(details, null, 2)}`;
+  throw new Error(`${message}${suffix}`);
+}
+
+function run(command, args, { input, timeout = 30_000 } = {}) {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      rejectRun(new Error(`timed out: ${command} ${args.join(" ")}`));
+    }, timeout);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      rejectRun(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolveRun(stdout);
+        return;
+      }
+      rejectRun(new Error([
+        `command failed: ${command} ${args.join(" ")}`,
+        `exit=${code ?? "null"} signal=${signal ?? "null"}`,
+        stdout.trim() ? `stdout:\n${stdout.trim()}` : null,
+        stderr.trim() ? `stderr:\n${stderr.trim()}` : null,
+      ].filter(Boolean).join("\n")));
+    });
+    if (input !== undefined) child.stdin.end(input);
+    else child.stdin.end();
+  });
+}
+
+async function browserJson(args, options = {}) {
+  const output = await run(browserBin, ["--session", session, "--headed", "--json", ...args], options);
+  const parsed = JSON.parse(output);
+  if (!parsed.success) throw new Error(parsed.error || `agent-browser failed: ${args.join(" ")}`);
+  return parsed.data;
+}
+
+async function browserRaw(args, options = {}) {
+  return run(browserBin, ["--session", session, "--headed", ...args], options);
+}
+
+async function evalJson(source) {
+  const data = await browserJson(["eval", "--stdin"], { input: source });
+  const result = data.result;
+  return typeof result === "string" ? JSON.parse(result) : result;
+}
+
+function closeBrowser() {
+  spawnSync(browserBin, ["--session", session, "close"], { stdio: "ignore", timeout: 10_000 });
+}
+
+function contentType(pathname) {
+  const type = extname(pathname);
+  if (type === ".html") return "text/html; charset=utf-8";
+  if (type === ".js" || type === ".mjs") return "text/javascript; charset=utf-8";
+  if (type === ".css") return "text/css; charset=utf-8";
+  if (type === ".wasm") return "application/wasm";
+  if (type === ".ico") return "image/x-icon";
+  return "application/octet-stream";
+}
+
+function feedPayload(status) {
+  const event = {
+    event_seq: "1",
+    kind: "resource_change",
+    summary: "Fixture ambient resource update",
+    detail: "QA fixture event; no player action receipt.",
+    receipt_ref: null,
+  };
+  return {
+    schema_version: "world_feed/v1",
+    world_id: "fixture-world",
+    reorg_epoch: "0",
+    cursor: status === "empty" ? "" : "1",
+    status,
+    events: ["ready", "replay"].includes(status) ? [event] : [],
+    gap_reason: status === "gap" ? "cursor_gap" : null,
+    unavailable_reason: status === "unavailable" ? "source_unavailable" : null,
+    snapshot_reload_required: status === "gap",
+  };
+}
+
+// This adapter only replaces the bridge module in the test server. The DOM
+// and Viewer source remain the real bundle under test; the canvas is rendered
+// by the repo-owned JS bridge and its derived state is deterministic.
+const bridgeModule = String.raw`import { createPixelWorldBevyBridge } from "/software_safe_src/pixel_world_bevy_bridge.js";
+export const PIXEL_WORLD_RUNTIME_SOURCE = "qa_browser_fixture_bridge";
+export async function createPixelWorldBridge(options) { return createPixelWorldBevyBridge(options); }
+const field = (value, snake, camel, fallback = null) => value?.[snake] ?? value?.[camel] ?? fallback;
+const pos = (entity) => entity?.pos || { x_cm: 0, y_cm: 0, z_cm: 0 };
+export function derivePixelWorldRenderState(input) {
+  const snapshot = input?.snapshot || {};
+  const model = snapshot.model || {};
+  const gameplay = input?.gameplay || snapshot.player_gameplay || {};
+  const locations = Object.values(model.locations || {});
+  const agents = Object.values(model.agents || {});
+  const bounds = snapshot.config?.space || { width_cm: 10000000, depth_cm: 5000000, height_cm: 1000000 };
+  const selectedId = input?.selectedId || gameplay.intent_target || agents[0]?.id || null;
+  const selectedKind = input?.selectedKind || (selectedId ? "agent" : null);
+  const fragments = locations.flatMap((location) => (location.fragment_profile?.blocks?.blocks || []).map((block, index) => ({
+    id: "fragment:" + location.id + ":" + index, location_id: location.id,
+    pos: { x_cm: pos(location).x_cm + Number(block.origin_cm?.x_cm || 0), y_cm: pos(location).y_cm + Number(block.origin_cm?.z_cm || block.origin_cm?.y_cm || 0), z_cm: pos(location).z_cm + Number(block.origin_cm?.y_cm || 0) },
+    dominant_compound: Object.entries(block.compounds?.ppm || {}).sort((a, b) => Number(b[1]) - Number(a[1]))[0]?.[0] || "unknown",
+    footprint_cm: Math.max(Number(block.size_cm?.x_cm || 12000), Number(block.size_cm?.z_cm || block.size_cm?.y_cm || 12000)),
+  })));
+  const normalizedAgents = agents.map((agent, index) => {
+    const location = model.locations?.[agent.location_id];
+    return { id: agent.id, label: agent.name || agent.id, pos: agent.pos || { x_cm: pos(location).x_cm + 20000 + index * 15000, y_cm: pos(location).y_cm + 10000 + index * 12000, z_cm: pos(location).z_cm }, position_source: agent.pos ? "runtime_agent" : "location_derived" };
+  });
+  const normalizedLocations = locations.map((location) => ({ id: location.id, label: location.name || location.id, pos: pos(location), marker_role: "logic_anchor", marker_alpha: 0.32 }));
+  const firstAction = (gameplay.available_actions || gameplay.availableActions || [])[0] || {};
+  const hasReceipt = Boolean(gameplay.recent_feedback || gameplay.recentFeedback || gameplay.last_world_change || gameplay.lastWorldChange);
+  const blocker = gameplay.blocker_kind || gameplay.blockerKind || null;
+  const blockerDetail = gameplay.blocker_detail || gameplay.blockerDetail || null;
+  const objective = gameplay.objective || gameplay.progress_detail || gameplay.progressDetail || "Stabilize the first production line before expanding.";
+  return {
+    world_bounds: bounds, locations: normalizedLocations, agents: normalizedAgents, fragment_terrain: fragments,
+    links: normalizedAgents.filter((agent) => model.locations?.[agents.find((candidate) => candidate.id === agent.id)?.location_id]).map((agent) => ({ id: "link:" + agent.id, kind: "agent_assignment", from: agent.pos, to: pos(model.locations?.[agents.find((candidate) => candidate.id === agent.id)?.location_id]) })),
+    selection: selectedKind && selectedId ? { kind: selectedKind, id: selectedId } : null,
+    goal_highlight: { title: gameplay.goal_title || gameplay.goalTitle || "Recover sustainable capability", objective },
+    blocker_highlight: blocker ? { kind: blocker, label: blocker === "material_shortage" ? "Missing Material" : blocker, detail: blockerDetail } : null,
+    // Three read-only fixture explanations exercise blocker/goal/info paths.
+    visual_hotspots: [
+      { id: "fixture-hotspot-blocker", kind: "blocker", label: "iron input is exhausted", pos: { x_cm: 2900000, y_cm: 3450000, z_cm: 0 } },
+      { id: "fixture-hotspot-goal", kind: "goal", label: "stabilize the first production line", pos: { x_cm: 7150000, y_cm: 2200000, z_cm: 0 } },
+      { id: "fixture-hotspot-info", kind: "info", label: "read-only world context", pos: { x_cm: 4550000, y_cm: 1200000, z_cm: 0 } },
+    ],
+    commercial_surface: {
+      objective: { title: gameplay.goal_title || gameplay.goalTitle || "Recover sustainable capability", detail: objective, progress_percent: gameplay.progress_percent ?? gameplay.progressPercent ?? 68 },
+      next_action: { label: field(firstAction, "label", "label", "Build smelter mk1"), detail: gameplay.intent_summary || gameplay.intentSummary || "Replenish upstream materials, then advance again to confirm the line resumes.", target_agent_id: field(firstAction, "target_agent_id", "targetAgentId", selectedId), execute_kind: field(firstAction, "execute_kind", "executeKind", "gameplay_action") },
+      active_agent_id: selectedId,
+      player_leverage: { state: gameplay.stage_status || gameplay.stageStatus || "blocked", label: hasReceipt ? "Blocked" : "Waiting for Intent", summary: gameplay.progress_detail || gameplay.progressDetail || "The primary line is blocked by missing material input.", detail: gameplay.next_step_hint || gameplay.nextStepHint || "Replenish upstream materials, then advance again to confirm the line resumes." },
+      action_receipt: { present: hasReceipt, state: hasReceipt ? "blocked" : "waiting_for_intent", confidence: hasReceipt ? "world_delta" : "none", title: hasReceipt ? "Action blocked" : "No action receipt yet", summary: hasReceipt ? "Smelter build request reached factory-0; iron shortage blocks construction." : "No receipt", detail: gameplay.last_world_change || gameplay.lastWorldChange || "No player-caused world change has been confirmed yet.", target_agent_id: hasReceipt ? selectedId : null },
+      blocker: { label: blocker === "material_shortage" ? "Missing Material" : blocker, detail: gameplay.next_step_hint || gameplay.nextStepHint || blockerDetail },
+      world_read: { agents: normalizedAgents.length, routes: normalizedAgents.length, fragments: fragments.length, hotspots: 3 },
+    },
+  };
+}`;
+
+const fakeWebSocket = String.raw`(() => {
+  const status = new URLSearchParams(location.search).get("feed_status") || "ready";
+  const listeners = new WeakMap();
+  const emit = (socket, type, payload = {}) => {
+    const callbacks = listeners.get(socket)?.[type] || [];
+    for (const callback of callbacks) callback({ type, ...payload });
+  };
+  const feed = (value) => ({ schema_version: "world_feed/v1", world_id: "fixture-world", reorg_epoch: "0", cursor: value === "empty" ? "" : "1", status: value, events: ["ready", "replay"].includes(value) ? [{ event_seq: "1", kind: "resource_change", summary: "Fixture ambient resource update", detail: "QA fixture event; no player action receipt.", receipt_ref: null }] : [], gap_reason: value === "gap" ? "cursor_gap" : null, unavailable_reason: value === "unavailable" ? "source_unavailable" : null, snapshot_reload_required: value === "gap" });
+  class FixtureWebSocket {
+    static OPEN = 1;
+    static CONNECTING = 0;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    constructor(url) { this.url = url; this.readyState = FixtureWebSocket.CONNECTING; listeners.set(this, {}); queueMicrotask(() => { this.readyState = FixtureWebSocket.OPEN; emit(this, "open"); }); }
+    addEventListener(type, callback) { const table = listeners.get(this); table[type] ||= []; table[type].push(callback); }
+    removeEventListener(type, callback) { const list = listeners.get(this)?.[type] || []; const index = list.indexOf(callback); if (index >= 0) list.splice(index, 1); }
+    send(raw) { const message = JSON.parse(raw); if (message.type === "hello") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "hello_ack", server: "qa-fixture", world_id: "fixture-world", control_profile: "fixture" }) })); if (message.type === "request_world_feed") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "world_feed", feed: feed(status) }) })); }
+    close() { this.readyState = FixtureWebSocket.CLOSED; emit(this, "close"); }
+  }
+  window.WebSocket = FixtureWebSocket;
+})();`;
+
+// The deterministic repo-owned JS bridge below paints with a 2D context,
+// while the production host performs a WebGL2 surface probe first. A real
+// canvas cannot claim both context types, so this fixture satisfies only the
+// host probe and leaves the bridge's 2D context untouched. This keeps the
+// browser coverage focused on the real Viewer DOM/shell without implying a
+// live WebGPU/WebGL renderer or playability.
+const fixtureCanvasCompatibility = String.raw`(() => {
+  const nativeGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function getContext(type, ...args) {
+    if (type === "webgl2") return { __qaWebgl2ProbeOnly: true };
+    return nativeGetContext.call(this, type, ...args);
+  };
+  document.body.setAttribute("data-viewer-visual-fixture", "shell_selected_blocker");
+})();`;
+
+function serveFile(request, response) {
+  const requestUrl = new URL(request.url || "/", "http://127.0.0.1");
+  const pathname = requestUrl.pathname;
+  if (pathname === "/pixel-world-bridge/pixel_world_bridge.js") {
+    response.writeHead(200, { "Content-Type": "text/javascript; charset=utf-8", "Cache-Control": "no-store" });
+    response.end(bridgeModule);
+    return;
+  }
+  const rawPath = decodeURIComponent(pathname === "/" ? "/viewer.html" : pathname);
+  const normalized = normalize(rawPath).replace(/^(\.\.(\/|\\|$))+/, "");
+  const filePath = pathname === "/viewer.js" && statSafe(bundlePath)
+    ? bundlePath
+    : resolve(viewerRoot, `.${normalized}`);
+  if (!relative(viewerRoot, filePath) || relative(viewerRoot, filePath).startsWith("..")) {
+    response.writeHead(403); response.end("forbidden"); return;
+  }
+  try {
+    let body = readFileSync(filePath, "utf8");
+    if (pathname === "/viewer.html" && requestUrl.searchParams.get("browser_fixture") === "1") {
+      body = body.replace('<script type="module" src="./viewer.js"></script>', `<script>${fixtureCanvasCompatibility}</script><script>${fakeWebSocket}</script><script type="module" src="./viewer.js"></script>`);
+    }
+    response.writeHead(200, { "Content-Type": contentType(filePath), "Cache-Control": "no-store" });
+    response.end(body);
+  } catch {
+    response.writeHead(404); response.end("not found");
+  }
+}
+
+function statSafe(path) {
+  try { return statSync(path).isFile(); } catch { return false; }
+}
+
+function fixtureUrl(port, { status = "ready", locale = "en" } = {}) {
+  const params = new URLSearchParams({
+    browser_fixture: "1", test_api: "1", connect: "1", hosted_bootstrap: "0", ws: "ws://qa-fixture",
+    locale, feed_status: status, viewer_visual_fixture: "shell_selected_blocker", pixel_world_visual_fixture: "selected_blocker", t: Date.now().toString(),
+  });
+  return `http://127.0.0.1:${port}/viewer.html?${params}`;
+}
+
+const probe = String.raw`(() => {
+  const rect = (element) => { if (!element) return null; const r = element.getBoundingClientRect(); return { x: Math.round(r.x), y: Math.round(r.y), right: Math.round(r.right), bottom: Math.round(r.bottom), width: Math.round(r.width), height: Math.round(r.height) }; };
+  const text = (selector, root = document) => root.querySelector(selector)?.textContent.trim() || null;
+  const intersects = (a, b) => Boolean(a && b && a.right > b.x && a.x < b.right && a.bottom > b.y && a.y < b.bottom);
+  const stackAt = (box) => {
+    if (!box) return [];
+    const x = Math.max(1, Math.min(innerWidth - 1, box.x + Math.max(1, box.width / 2)));
+    const y = Math.max(1, Math.min(innerHeight - 1, box.y + Math.max(1, box.height / 2)));
+    return document.elementsFromPoint(x, y).slice(0, 6).map((node) => ({ tag: node.tagName, id: node.id || null, className: node.className || null, overlay: node.getAttribute?.('data-viewer-overlay') || null, text: String(node.textContent || '').trim().slice(0, 160) }));
+  };
+  const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const command = document.querySelector('[data-viewer-overlay="next-move"]');
+  const primary = command?.querySelector('[data-shell-region="next-move-primary"]') || command;
+  const supporting = command?.querySelector('[data-shell-region="supporting-context"]');
+  const receipt = document.querySelector('.pixel-world-action-receipt');
+  const selection = document.querySelector('.pixel-world-canvas__selection');
+  const readout = document.querySelector('.pixel-world-readout');
+  const hotspotNodes = [...document.querySelectorAll('[data-hotspot-kind]')];
+  return JSON.stringify({
+    runtime: window.__AW_TEST__?.getState?.() || null,
+    feed: feed ? { status: feed.dataset.worldFeedStatus || null, open: feed.open, text: feed.textContent.trim(), rect: rect(feed), statusRow: text('.world-feed__status-row', feed), scrollTop: feed.scrollTop, scrollHeight: feed.scrollHeight, clientHeight: feed.clientHeight } : null,
+    readout: readout ? { text: readout.textContent.trim(), classes: [...readout.querySelectorAll('.badge')].map((node) => ({ text: node.textContent.trim(), className: node.className })) } : null,
+    selection: selection ? { text: selection.textContent.trim(), rect: rect(selection) } : null,
+    primary: primary ? { text: primary.textContent.trim(), rect: rect(primary), visible: getComputedStyle(primary).display !== 'none' && getComputedStyle(primary).visibility !== 'hidden' } : null,
+    supporting: supporting ? { text: supporting.textContent.trim(), rect: rect(supporting), visible: getComputedStyle(supporting).display !== 'none' } : null,
+    receipt: receipt ? { present: receipt.dataset.receiptPresent, state: receipt.dataset.receiptState, confidence: receipt.dataset.receiptConfidence, text: receipt.textContent.trim(), rect: rect(receipt), visible: getComputedStyle(receipt).display !== 'none', scrollTop: receipt.scrollTop, scrollHeight: receipt.scrollHeight, clientHeight: receipt.clientHeight } : null,
+    tooltip: document.querySelector('[data-hotspot-tooltip]') ? { text: text('[data-hotspot-tooltip]'), rect: rect(document.querySelector('[data-hotspot-tooltip]')) } : null,
+    hotspots: hotspotNodes.map((node) => ({ tag: node.tagName, kind: node.dataset.hotspotKind, label: node.getAttribute('aria-label'), title: node.getAttribute('title'), role: node.getAttribute('role'), tabIndex: node.tabIndex, text: node.textContent.trim(), rect: rect(node) })),
+    viewport: { width: innerWidth, height: innerHeight, clientWidth: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth, overflowX: Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth) },
+    hitTest: { selection: stackAt(selection ? rect(selection) : null), feed: stackAt(feed ? rect(feed) : null) },
+    bodyText: document.body.innerText,
+  });
+})()`;
+
+const waitReady = String.raw`(async () => { const end = Date.now() + 15000; while (Date.now() < end) { const state = window.__AW_TEST__?.getState?.() || {}; if (state.pixelWorldRuntimeStatus === "ready" && document.querySelector('[data-viewer-overlay="feed"]')) return JSON.stringify(state); await new Promise((resolve) => setTimeout(resolve, 100)); } throw new Error(JSON.stringify(window.__AW_TEST__?.getState?.() || null)); })()`;
+
+function visible(textValue) { return textValue && textValue.trim().length > 0; }
+
+function intersects(a, b) {
+  return Boolean(a && b && a.right > b.x && a.x < b.right && a.bottom > b.y && a.y < b.bottom);
+}
+
+async function waitForFeedStatus(status) {
+  const end = Date.now() + 10_000;
+  while (Date.now() < end) {
+    const result = await evalJson(probe);
+    if (result.feed?.status === status && result.runtime?.connectionStatus === "connected") return result;
+    await browserRaw(["wait", "100"]);
+  }
+  return evalJson(probe);
+}
+
+async function openFixture(port, options) {
+  await browserJson(["open", fixtureUrl(port, options)], { timeout: 45_000 });
+  await browserJson(["set", "viewport", String(options.width || 390), String(options.height || 844)]);
+  await evalJson(waitReady);
+}
+
+async function clickVisible(selector) {
+  await browserJson(["scrollintoview", selector]);
+  await browserJson(["click", selector]);
+  return { selector };
+}
+
+async function waitShort() { await browserRaw(["wait", "180"]); }
+
+function assertBase(label, result, expectedStatus) {
+  assert(result.runtime?.pixelWorldRuntimeStatus === "ready", `${label}: runtime not ready`, result);
+  assert(result.runtime?.renderMode === "viewer" || result.runtime?.renderMode === "software_safe", `${label}: unexpected render mode`, result.runtime);
+  assert(result.feed?.status === expectedStatus, `${label}: expected feed status ${expectedStatus}`, result.feed);
+  assert(result.selection?.rect?.width > 0 && visible(result.selection?.text), `${label}: selected object confirmation missing`, result.selection);
+  assert(!/^.*agent-[a-z0-9_-]+.*$/i.test(result.selection?.text || ""), `${label}: raw selected agent id leaked`, result.selection);
+  assert(result.primary?.visible && result.primary?.rect?.width > 0, `${label}: Next Move is not visible`, result.primary);
+  assert(result.receipt?.visible && result.receipt?.rect?.width > 0, `${label}: Action Receipt is not visible`, result.receipt);
+  assert(result.viewport.overflowX <= 2, `${label}: horizontal overflow ${result.viewport.overflowX}px`, result.viewport);
+  if (result.feed && !result.feed.open) {
+    assert(!intersects(result.feed.rect, result.selection.rect), `${label}: collapsed Feed overlaps selected-object confirmation`, {
+      feed: result.feed.rect,
+      selection: result.selection.rect,
+      topHit: result.hitTest?.selection?.[0],
+    });
+  }
+}
+
+async function runStatusMatrix(port) {
+  for (const status of statuses) {
+    await openFixture(port, { status, locale: "en", width: 390, height: 844 });
+    const result = await waitForFeedStatus(status);
+    assertBase(`A2/${status}`, result, status);
+    const readout = result.readout?.text || "";
+    const expected = { ready: "LIVE", replay: "REPLAY", empty: "NO EVENTS", gap: "GAP", unavailable: "UNAVAILABLE" }[status];
+    assert(readout.includes(expected), `A2/${status}: readout missing ${expected}`, result.readout);
+    if (status !== "ready") assert(!readout.includes("LIVE"), `A2/${status}: context incorrectly labeled LIVE`, result.readout);
+    const screenshot = join(outDir, `a2-${status}-mobile.png`);
+    await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+    summary.feedStatuses[status] = { screenshot, result };
+  }
+}
+
+async function runInteractions(port) {
+  await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844 });
+  const before = await evalJson(probe);
+  await clickVisible("button[data-pixel-world-agent-marker='true']");
+  await waitShort();
+  const afterAgent = await evalJson(probe);
+  assert(afterAgent.selection?.rect?.width > 0 && visible(afterAgent.selection?.text), "A1/agent: selection confirmation missing after visible click", afterAgent.selection);
+  await clickVisible("button[data-pixel-world-location-marker]");
+  await waitShort();
+  const afterLocation = await evalJson(probe);
+  assert(afterLocation.selection?.rect?.width > 0 && visible(afterLocation.selection?.text), "A1/location: selection confirmation missing after visible click", afterLocation.selection);
+
+  const feedBefore = afterLocation;
+  await clickVisible('[data-viewer-overlay="feed"] > summary');
+  await waitShort();
+  const feedOpen = await evalJson(probe);
+  assert(feedOpen.feed?.open === true, "A3: Feed did not open through visible summary control", feedOpen.feed);
+  assert(feedOpen.primary?.visible && feedOpen.receipt?.visible, "A3: Next Move or Action Receipt hidden with Feed open", { primary: feedOpen.primary, receipt: feedOpen.receipt });
+  assert(!intersects(feedOpen.feed.rect, feedOpen.primary.rect), "A3: Feed overlaps Next Move", { feed: feedOpen.feed.rect, primary: feedOpen.primary.rect });
+  assert(!intersects(feedOpen.feed.rect, feedOpen.receipt.rect), "A3: Feed overlaps Action Receipt", { feed: feedOpen.feed.rect, receipt: feedOpen.receipt.rect });
+  await browserRaw(["scroll", "down", "320", "--selector", '[data-viewer-overlay="feed"]']);
+  await waitShort();
+  const feedScrolled = await evalJson(probe);
+  assert(feedScrolled.feed?.scrollTop > 0 || feedScrolled.feed?.scrollHeight <= feedScrolled.feed?.clientHeight, "A3: expanded Feed could not scroll its long detail surface", feedScrolled.feed);
+  await browserRaw(["scroll", "down", "320", "--selector", '[data-viewer-overlay="receipt"]']);
+  await waitShort();
+  const receiptScrolled = await evalJson(probe);
+  assert(receiptScrolled.receipt?.scrollTop > 0 || receiptScrolled.receipt?.scrollHeight <= receiptScrolled.receipt?.clientHeight, "A3: Action Receipt could not scroll its detail surface", receiptScrolled.receipt);
+  const feedScreenshot = join(outDir, "a3-feed-open-mobile.png");
+  await browserRaw(["screenshot", feedScreenshot], { timeout: 20_000 });
+  await clickVisible('[data-viewer-overlay="feed"] > summary');
+
+  const hotspots = feedOpen.hotspots || [];
+  assert(hotspots.length >= 2, "A4: fixture did not expose blocker/goal hotspots", hotspots);
+  for (const hotspot of hotspots) {
+    assert(hotspot.tabIndex >= 0 || hotspot.role === "button" || hotspot.tag === "BUTTON" || visible(hotspot.label), `A4: hotspot ${hotspot.kind} has no keyboard/accessibility affordance`, hotspot);
+  }
+  const beforeInteractionState = before.runtime || {};
+  await clickVisible('[data-hotspot-kind="goal"]');
+  await waitShort();
+  const afterPointerHotspot = await evalJson(probe);
+  assert(afterPointerHotspot.tooltip?.text?.includes("Goal: stabilize the first production line"), "A4: visible hotspot click did not expose a goal explanation", afterPointerHotspot.tooltip);
+  await clickVisible('.pixel-world-canvas__hotspot-tooltip-close');
+  await waitShort();
+  const afterPointerClose = await evalJson(probe);
+  assert(!afterPointerClose.tooltip, "A4: visible tooltip close control did not dismiss the explanation", afterPointerClose);
+  await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="blocker"]'); if (!node) throw new Error("missing blocker hotspot"); node.scrollIntoView({ block: "center" }); node.focus?.(); return JSON.stringify({ active: document.activeElement === node, tag: node.tagName }); })()`);
+  await browserRaw(["press", "Enter"]);
+  await waitShort();
+  const afterHotspot = await evalJson(probe);
+  const explanation = afterHotspot.bodyText.includes("Blocker: iron input is exhausted") || afterHotspot.bodyText.includes("阻塞") || afterHotspot.bodyText.includes("iron input");
+  assert(explanation, "A4: blocker hotspot did not expose a readable explanation after keyboard activation", { hotspots: afterHotspot.hotspots, bodyText: afterHotspot.bodyText.slice(-2500) });
+  const afterHotspotState = afterHotspot.runtime || {};
+  assert(afterHotspotState.logicalTime === beforeInteractionState.logicalTime && afterHotspotState.eventSeq === beforeInteractionState.eventSeq, "A4: hotspot inspection changed runtime time/event state", { before: beforeInteractionState, after: afterHotspotState });
+  const hotspotScreenshot = join(outDir, "a4-hotspot-keyboard-mobile.png");
+  await browserRaw(["screenshot", hotspotScreenshot], { timeout: 20_000 });
+  await browserRaw(["press", "Escape"]);
+  await waitShort();
+  const afterEscape = await evalJson(probe);
+  assert(!afterEscape.tooltip, "A4: Escape did not dismiss the keyboard-opened explanation", afterEscape);
+  summary.interactions = { before: feedBefore, afterAgent, afterLocation, feedOpen: { ...feedOpen, screenshot: feedScreenshot, feedScrolled: feedScrolled.feed, receiptScrolled: receiptScrolled.receipt }, hotspot: { ...afterHotspot, screenshot: hotspotScreenshot }, pointerHotspot: afterPointerHotspot, pointerClose: afterPointerClose, afterEscape };
+}
+
+async function runViewportMatrix(port) {
+  for (const viewport of viewports) {
+    await openFixture(port, { status: "ready", locale: "en", width: viewport.width, height: viewport.height });
+    const result = await waitForFeedStatus("ready");
+    assertBase(`A1/A3/A5/${viewport.name}`, result, "ready");
+    assert(result.bodyText.includes("Replenish upstream materials") || result.bodyText.includes("Missing Material"), `A5/${viewport.name}: blocking/next-action copy not present`, result.bodyText.slice(-2500));
+    const screenshot = join(outDir, `a1-a3-a5-${viewport.name}.png`);
+    await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+    summary.viewports[viewport.name] = { viewport, screenshot, result };
+  }
+  await openFixture(port, { status: "ready", locale: "zh-CN", width: 390, height: 844 });
+  const cjk = await waitForFeedStatus("ready");
+  assertBase("A5/CJK/mobile", cjk, "ready");
+  assert(cjk.bodyText.includes("目标") || cjk.bodyText.includes("玩家杠杆") || cjk.bodyText.includes("行动回执"), "A5/CJK: localized hierarchy labels missing", cjk.bodyText.slice(-2500));
+  const screenshot = join(outDir, "a5-cjk-mobile.png");
+  await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+  summary.viewports.cjk = { viewport: { width: 390, height: 844 }, screenshot, result: cjk };
+
+  await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844 });
+  const resized = {};
+  for (const viewport of [
+    { name: "resize-tablet", width: 768, height: 1024 },
+    { name: "resize-desktop", width: 1440, height: 1000 },
+    { name: "resize-mobile", width: 390, height: 844 },
+  ]) {
+    await browserJson(["set", "viewport", String(viewport.width), String(viewport.height)]);
+    await waitShort();
+    const result = await waitForFeedStatus("ready");
+    assertBase(`A1/resize/${viewport.name}`, result, "ready");
+    const screenshot = join(outDir, `a1-resize-${viewport.name}.png`);
+    await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+    resized[viewport.name] = { viewport, screenshot, result };
+  }
+  summary.viewports.resize = resized;
+}
+
+async function main() {
+  if (!skipBuild) {
+    const build = spawnSync("npm", ["--prefix", "crates/oasis7_viewer", "run", "build:viewer:bundle"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    writeFileSync(join(outDir, "bundle-build.log"), `${build.stdout || ""}${build.stderr || ""}`, "utf8");
+    assert(build.status === 0, "Viewer bundle build failed; see bundle-build.log", { status: build.status, signal: build.signal });
+  }
+  assert(statSafe(bundlePath), `missing ${bundlePath}; build:viewer:bundle did not produce the test bundle`);
+  assert(spawnSync(browserBin, ["--version"], { stdio: "ignore" }).status === 0, `missing browser automation command: ${browserBin}`);
+  const server = createServer(serveFile);
+  await new Promise((resolveServer) => server.listen(0, "127.0.0.1", resolveServer));
+  const address = server.address();
+  const port = address.port;
+  try {
+    closeBrowser();
+    await runStatusMatrix(port);
+    await runViewportMatrix(port);
+    await runInteractions(port);
+    const consoleOutput = await browserRaw(["console"]);
+    writeFileSync(join(outDir, "browser-console.log"), consoleOutput, "utf8");
+    assert(!/\[(?:error|pageerror)\]|\b(?:fatal|CONTEXT_LOST_WEBGL)\b/i.test(consoleOutput), "browser console contains runtime errors", { consoleOutput });
+    summary.console = { path: join(outDir, "browser-console.log"), errors: 0 };
+    summary.status = "passed";
+  } catch (error) {
+    summary.status = "failed";
+    summary.failure = String(error?.stack || error);
+    try {
+      writeFileSync(join(outDir, "failure-state.json"), JSON.stringify(await evalJson(probe), null, 2), "utf8");
+      await browserRaw(["screenshot", join(outDir, "failure.png")], { timeout: 20_000 });
+      writeFileSync(join(outDir, "browser-console.log"), await browserRaw(["console"]), "utf8");
+    } catch (diagnosticError) {
+      summary.failureDiagnostics = String(diagnosticError?.stack || diagnosticError);
+    }
+    throw error;
+  } finally {
+    summary.completedAt = new Date().toISOString();
+    writeFileSync(join(outDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+    closeBrowser();
+    await new Promise((resolveServer) => server.close(resolveServer));
+  }
+  console.log(`player visual feedback browser smoke passed: ${outDir}`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || error);
+  process.exitCode = 1;
+});

--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -836,16 +836,21 @@ async function runFocusRestorationRegression(port) {
 
 async function runThirdReview(port) {
   for (const visualFixture of [true, false]) {
-    for (const kind of ["blocker", "goal"]) {
+    for (const { kind, feedOpen } of [{ kind: "blocker" }, { kind: "goal" }, { kind: "info" }, { kind: "info", feedOpen: true }]) {
       await openFixture(port, { visualFixture, width: 390, height: 844 });
+      if (feedOpen) await clickVisibleInPlace(".world-feed__summary");
       const start = await focusHotspotAndActivate(kind);
       const successor = await evalJson(`(() => {
         const origin = window.__qaOriginalTrigger;
-        const controls = [...document.querySelectorAll('button,a[href],input,select,textarea,summary,[tabindex]')].filter((node) => node.tabIndex >= 0 && !node.disabled && !node.closest('[data-hotspot-tooltip]') && node.getClientRects().length && getComputedStyle(node).visibility !== 'hidden');
+        const controls = [...document.querySelectorAll('button,a[href],input,select,textarea,summary,[tabindex]')].filter((node) =>
+          node.tabIndex >= 0 && !node.disabled && !node.closest('[data-hotspot-tooltip]')
+          && node.checkVisibility({ visibilityProperty: true }) && node.getClientRects().length);
         window.__qaNextControl = controls[controls.indexOf(origin) + 1];
-        return JSON.stringify({ exists: Boolean(window.__qaNextControl), kind: window.__qaNextControl?.dataset?.hotspotKind, label: window.__qaNextControl?.getAttribute('aria-label') });
+        return JSON.stringify({ exists: Boolean(window.__qaNextControl), kind: window.__qaNextControl?.dataset?.hotspotKind, label: window.__qaNextControl?.getAttribute('aria-label'), tag: window.__qaNextControl?.tagName, className: window.__qaNextControl?.className, closedDetailsHiddenButtons: [...document.querySelectorAll('details:not([open]) button')].filter((node) => !node.checkVisibility({ visibilityProperty: true })).length });
       })()`);
       assert(successor.exists, "T2 keyboard: no native successor found", successor);
+      if (kind === "info") assert(successor.tag === "SUMMARY" && successor.className.includes("world-feed__summary"), "F2 keyboard: last hotspot native successor must be visible Feed summary", successor);
+      if (kind === "info" && !feedOpen) assert(successor.closedDetailsHiddenButtons > 0, "F2 keyboard: real DOM must contain hidden closed-details controls", successor);
       await browserRaw(["press", "Tab"]);
       let state = await evalJson(probe);
       assert(state.activeElement?.className?.includes("hotspot-tooltip-close"), "T2 keyboard: first Tab did not reach close", state.activeElement);
@@ -860,7 +865,7 @@ async function runThirdReview(port) {
       assert(forward.next, "T2 keyboard: forward Tab restarted document or trapped focus", { successor, forward });
       const after = await evalJson(probe);
       assert(runtimeStable(start.opened.runtime, after.runtime), "T2 keyboard traversal changed runtime", after.runtime);
-      summary.thirdReview.keyboard.push({ visualFixture, kind, successor, backward, forward });
+      summary.thirdReview.keyboard.push({ visualFixture, kind, feedOpen: Boolean(feedOpen), successor, backward, forward });
     }
   }
   for (const viewport of [viewports[0], ...shortLandscapeViewports]) {

--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -19,6 +19,7 @@ const session = `player-visual-feedback-${process.pid}`;
 const browserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
 const skipBuild = process.argv.includes("--skip-build");
 const onlyProduction = process.argv.includes("--only-production");
+const onlyOffscreen = process.argv.includes("--only-offscreen");
 const onlyCamera = process.argv.includes("--only-camera");
 const onlyTouch = process.argv.includes("--only-touch");
 const onlyTooltipFeed = process.argv.includes("--only-tooltip-feed");
@@ -41,7 +42,7 @@ const summary = {
   inputMode: "visible-ui-controls-plus-dom-readback",
   mockDisabled: false,
   fixtureBoundary: "deterministic QA bridge and fake world_feed; no runtime/provider/playability claim",
-  phase: onlyThirdReview ? "third-review-only" : onlyProduction ? "production-hotspot-only"
+  phase: onlyOffscreen ? "offscreen-only" : onlyThirdReview ? "third-review-only" : onlyProduction ? "production-hotspot-only"
     : onlyCamera ? "camera-regression-only"
       : onlyTouch ? "touch-regression-only"
         : onlyTooltipFeed ? "tooltip-feed-regression-only"
@@ -605,6 +606,60 @@ function assertHotspotTooltipPainted(result, label) {
     `${label}: tooltip close control is not visible`, tooltip);
   assert(stackHasClass(tooltip.close.stack, "pixel-world-canvas__hotspot-tooltip-close"),
     `${label}: tooltip close control is obscured at its painted center`, tooltip.close);
+}
+
+async function runOffscreenRegression(port) {
+  summary.offscreen = [];
+  for (const visualFixture of [true, false]) {
+    await openFixture(port, { visualFixture, width: 768, height: 1024 });
+    await dispatchCanvasZoom(-100);
+    for (const edge of ["left", "right", "top", "bottom"]) {
+      for (const partial of [false, true]) {
+        const before = await evalJson(probe);
+        const projected = projectedCanvasPoint(before.canvas, cameraHotspotWorld("info"), cameraState(before));
+        const stage = before.canvas.rect;
+        const outside = partial ? -3 : -80;
+        const x = edge === "left" ? outside : edge === "right" ? stage.width - outside : stage.width / 2;
+        const y = edge === "top" ? outside : edge === "bottom" ? stage.height - outside : stage.height / 2;
+        await dispatchCanvasPan((stage.x + x - projected.x) * before.canvas.width / stage.width,
+          (stage.y + y - projected.y) * before.canvas.height / stage.height);
+        const state = await evalJson(`(() => {
+          const node = document.querySelector('[data-hotspot-kind="info"]');
+          window.__qaOffscreenNode ||= node;
+          const stage = node.parentElement.getBoundingClientRect();
+          const r = node.getBoundingClientRect();
+          const glyph = node.querySelector('.pixel-world-hotspot__glyph').getBoundingClientRect();
+          const rect = (r) => ({ x:r.x,y:r.y,right:r.right,bottom:r.bottom,width:r.width,height:r.height });
+          const x = Math.max(stage.left + 22, Math.min(stage.right - 22, stage.left + ${x}));
+          const y = Math.max(stage.top + 22, Math.min(stage.bottom - 22, stage.top + ${y}));
+          document.querySelector('.mobile-rail__link').focus();
+          node.focus();
+          return JSON.stringify({ sameNode: node === window.__qaOffscreenNode, disabled:node.disabled, tabIndex:node.tabIndex,
+            display:getComputedStyle(node).display, focused:document.activeElement === node,
+            hitPresent:document.elementsFromPoint(x,y).some((hit) => hit === node || node.contains(hit)),
+            rect:rect(r),glyph:rect(glyph),stage:rect(stage),x,y });
+        })()`);
+        assert(state.sameNode, "offscreen recovery replaced original control", state);
+        if (partial) {
+          assert(!state.disabled && state.tabIndex >= 0 && state.focused && state.rect.width >= 44 && state.rect.height >= 44,
+            "partial glyph did not restore44px focusable target", { edge, state });
+          assert(state.glyph.right > state.stage.x && state.glyph.x < state.stage.right && state.glyph.bottom > state.stage.y && state.glyph.y < state.stage.bottom,
+            "partial-return glyph does not intersect stage", { edge, state });
+          assert(state.rect.x >= state.stage.x && state.rect.y >= state.stage.y && state.rect.right <= state.stage.right + 1 && state.rect.bottom <= state.stage.bottom + 1,
+            "partial target escapes stage", { edge, state });
+          await browserRaw(["press", "Escape"]);
+        } else {
+          assert(state.disabled && state.tabIndex === -1 && !state.focused && !state.hitPresent && state.display === "none",
+            "fully offscreen hotspot remains hit/focusable", { edge, state });
+          await browserJson(["mouse", "move", String(Math.round(state.x)), String(Math.round(state.y))]);
+          await browserJson(["mouse", "down"]); await browserJson(["mouse", "up"]);
+          const clicked = await evalJson("JSON.stringify({ infoTooltip: Boolean(document.querySelector('[data-hotspot-tooltip][id$=info]')) })");
+          assert(!clicked.infoTooltip, "offscreen edge click reopened invisible hotspot", { edge, clicked });
+        }
+        summary.offscreen.push({ visualFixture, edge, partial, state });
+      }
+    }
+  }
 }
 
 async function runCameraProjectionRegression(port, { visualFixture, label }) {
@@ -1172,7 +1227,9 @@ async function main() {
   const port = address.port;
   try {
     closeBrowser();
-    if (onlyThirdReview) {
+    if (onlyOffscreen) {
+      await runOffscreenRegression(port);
+    } else if (onlyThirdReview) {
       await runThirdReview(port);
     } else if (onlyProduction) {
       await runProductionHotspotRegression(port);
@@ -1186,6 +1243,7 @@ async function main() {
     } else if (onlyFocus) {
       await runFocusRestorationRegression(port);
     } else {
+      await runOffscreenRegression(port);
       await runThirdReview(port);
       await runStatusMatrix(port);
       await runViewportMatrix(port);

--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -22,6 +22,7 @@ const onlyProduction = process.argv.includes("--only-production");
 const onlyCamera = process.argv.includes("--only-camera");
 const onlyTouch = process.argv.includes("--only-touch");
 const onlyTooltipFeed = process.argv.includes("--only-tooltip-feed");
+const onlyThirdReview = process.argv.includes("--only-third-review");
 const onlyFocus = process.argv.includes("--only-focus");
 const statuses = ["ready", "replay", "empty", "gap", "unavailable"];
 const viewports = [
@@ -40,7 +41,7 @@ const summary = {
   inputMode: "visible-ui-controls-plus-dom-readback",
   mockDisabled: false,
   fixtureBoundary: "deterministic QA bridge and fake world_feed; no runtime/provider/playability claim",
-  phase: onlyProduction ? "production-hotspot-only"
+  phase: onlyThirdReview ? "third-review-only" : onlyProduction ? "production-hotspot-only"
     : onlyCamera ? "camera-regression-only"
       : onlyTouch ? "touch-regression-only"
         : onlyTooltipFeed ? "tooltip-feed-regression-only"
@@ -53,6 +54,7 @@ const summary = {
   feedStatuses: {},
   interactions: {},
   productionHotspot: {},
+  thirdReview: { keyboard: [], longTooltips: [], glow: [] },
   secondReview: {
     camera: {},
     touchTargets: {},
@@ -198,7 +200,7 @@ export function derivePixelWorldRenderState(input) {
     // Three read-only fixture explanations exercise blocker/goal/info paths.
     visual_hotspots: [
       { id: "fixture-hotspot-blocker", kind: "blocker", label: "iron input is exhausted", pos: { x_cm: 2900000, y_cm: 3450000, z_cm: 0 } },
-      { id: "fixture-hotspot-goal", kind: "goal", label: "stabilize the first production line", pos: { x_cm: 7150000, y_cm: 2200000, z_cm: 0 } },
+      { id: "fixture-hotspot-goal", kind: "goal", label: String(gameplay.objective || "").length > 120 ? gameplay.objective : "stabilize the first production line", pos: { x_cm: 7150000, y_cm: 2200000, z_cm: 0 } },
       { id: "fixture-hotspot-info", kind: "info", label: "read-only world context", pos: { x_cm: 4550000, y_cm: 1200000, z_cm: 0 } },
     ],
     commercial_surface: {
@@ -241,6 +243,8 @@ const productionSnapshot = {
 const fakeWebSocket = String.raw`(() => {
   const status = new URLSearchParams(location.search).get("feed_status") || "ready";
   const sendProductionSnapshot = !new URLSearchParams(location.search).has("pixel_world_visual_fixture");
+  const incomingSnapshot = ${JSON.stringify(productionSnapshot)};
+  if (new URLSearchParams(location.search).get("long_hotspot") === "1") incomingSnapshot.player_gameplay.objective = "Long runtime explanation: " + "Replenish upstream materials and inspect sustainable production constraints before expansion. ".repeat(32) + "QA_LABEL_END";
   const listeners = new WeakMap();
   const emit = (socket, type, payload = {}) => {
     const callbacks = listeners.get(socket)?.[type] || [];
@@ -255,7 +259,7 @@ const fakeWebSocket = String.raw`(() => {
     constructor(url) { this.url = url; this.readyState = FixtureWebSocket.CONNECTING; listeners.set(this, {}); queueMicrotask(() => { this.readyState = FixtureWebSocket.OPEN; emit(this, "open"); }); }
     addEventListener(type, callback) { const table = listeners.get(this); table[type] ||= []; table[type].push(callback); }
     removeEventListener(type, callback) { const list = listeners.get(this)?.[type] || []; const index = list.indexOf(callback); if (index >= 0) list.splice(index, 1); }
-    send(raw) { const message = JSON.parse(raw); if (message.type === "hello") { if (sendProductionSnapshot) queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "snapshot", snapshot: ${JSON.stringify(productionSnapshot)} }) })); queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "hello_ack", server: "qa-fixture", world_id: "fixture-world", control_profile: "fixture" }) })); } if (message.type === "request_world_feed") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "world_feed", feed: feed(status) }) })); }
+    send(raw) { const message = JSON.parse(raw); if (message.type === "hello") { if (sendProductionSnapshot) queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "snapshot", snapshot: incomingSnapshot }) })); queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "hello_ack", server: "qa-fixture", world_id: "fixture-world", control_profile: "fixture" }) })); } if (message.type === "request_world_feed") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "world_feed", feed: feed(status) }) })); }
     close() { this.readyState = FixtureWebSocket.CLOSED; emit(this, "close"); }
   }
   window.WebSocket = FixtureWebSocket;
@@ -314,11 +318,12 @@ function statSafe(path) {
   try { return statSync(path).isFile(); } catch { return false; }
 }
 
-function fixtureUrl(port, { status = "ready", locale = "en", visualFixture = true } = {}) {
+function fixtureUrl(port, { status = "ready", locale = "en", visualFixture = true, longHotspot = false } = {}) {
   const params = new URLSearchParams({
     browser_fixture: "1", test_api: "1", connect: "1", hosted_bootstrap: "0", ws: "ws://qa-fixture",
     locale, feed_status: status, t: Date.now().toString(),
   });
+  if (longHotspot) params.set("long_hotspot", "1");
   if (visualFixture) {
     params.set("visual_fixture", "1");
     params.set("viewer_visual_fixture", "shell_selected_blocker");
@@ -829,6 +834,86 @@ async function runFocusRestorationRegression(port) {
   await runFocusRestorationSurface(port, { visualFixture: false, label: "production" });
 }
 
+async function runThirdReview(port) {
+  for (const visualFixture of [true, false]) {
+    for (const kind of ["blocker", "goal"]) {
+      await openFixture(port, { visualFixture, width: 390, height: 844 });
+      const start = await focusHotspotAndActivate(kind);
+      const successor = await evalJson(`(() => {
+        const origin = window.__qaOriginalTrigger;
+        const controls = [...document.querySelectorAll('button,a[href],input,select,textarea,summary,[tabindex]')].filter((node) => node.tabIndex >= 0 && !node.disabled && !node.closest('[data-hotspot-tooltip]') && node.getClientRects().length && getComputedStyle(node).visibility !== 'hidden');
+        window.__qaNextControl = controls[controls.indexOf(origin) + 1];
+        return JSON.stringify({ exists: Boolean(window.__qaNextControl), kind: window.__qaNextControl?.dataset?.hotspotKind, label: window.__qaNextControl?.getAttribute('aria-label') });
+      })()`);
+      assert(successor.exists, "T2 keyboard: no native successor found", successor);
+      await browserRaw(["press", "Tab"]);
+      let state = await evalJson(probe);
+      assert(state.activeElement?.className?.includes("hotspot-tooltip-close"), "T2 keyboard: first Tab did not reach close", state.activeElement);
+      await browserRaw(["press", "Shift+Tab"]);
+      const backward = await evalJson("JSON.stringify({ original: document.activeElement === window.__qaOriginalTrigger })");
+      assert(backward.original, "T2 keyboard: ShiftTab did not return to exact origin", backward);
+      await browserRaw(["press", "Tab"]);
+      state = await evalJson(probe);
+      assert(state.activeElement?.className?.includes("hotspot-tooltip-close"), "T2 keyboard: repeated Tab did not reach close", state.activeElement);
+      await browserRaw(["press", "Tab"]);
+      const forward = await evalJson("JSON.stringify({ next: document.activeElement === window.__qaNextControl, tag: document.activeElement?.tagName, kind: document.activeElement?.dataset?.hotspotKind })");
+      assert(forward.next, "T2 keyboard: forward Tab restarted document or trapped focus", { successor, forward });
+      const after = await evalJson(probe);
+      assert(runtimeStable(start.opened.runtime, after.runtime), "T2 keyboard traversal changed runtime", after.runtime);
+      summary.thirdReview.keyboard.push({ visualFixture, kind, successor, backward, forward });
+    }
+  }
+  for (const viewport of [viewports[0], ...shortLandscapeViewports]) {
+    for (const feedOpen of [false, true]) {
+      await openFixture(port, { visualFixture: false, longHotspot: true, width: viewport.width, height: viewport.height });
+      await waitForFeedStatus("ready");
+      if (feedOpen) await clickVisible('[data-viewer-overlay="feed"] > summary');
+      const label = `${viewport.name}-${feedOpen ? "open" : "collapsed"}`;
+      const initial = await focusHotspotAndActivate("goal");
+      assert(initial.opened.tooltip.text.length > 2000 && initial.opened.tooltip.text.includes("QA_LABEL_END"), `T2 ${label}: normal snapshot did not deliver long explanation`, initial.opened.tooltip);
+      assertHotspotTooltipPainted(initial.opened, `T2 ${label}`);
+      if (feedOpen) assert(!intersects(initial.opened.tooltip.rect, initial.opened.feed.summaryRect), `T2 ${label}: long tooltip covers Feed summary`, initial.opened);
+      const bodySelector = '.pixel-world-canvas__hotspot-tooltip > span';
+      const bodyBefore = await evalJson(`(() => { const node = document.querySelector('${bodySelector}'); return JSON.stringify({ scrollTop: node?.scrollTop, scrollHeight: node?.scrollHeight, clientHeight: node?.clientHeight }); })()`);
+      assert(bodyBefore.scrollHeight > bodyBefore.clientHeight + 5, `T2 ${label}: long tooltip lacks bounded scroll body`, bodyBefore);
+      await browserRaw(["scroll", "down", "10000", "--selector", bodySelector]);
+      const bodyAfter = await evalJson(`(() => { const node = document.querySelector('${bodySelector}'); return JSON.stringify({ scrollTop: node.scrollTop, scrollHeight: node.scrollHeight, clientHeight: node.clientHeight }); })()`);
+      assert(bodyAfter.scrollTop > 0 && bodyAfter.scrollTop + bodyAfter.clientHeight >= bodyAfter.scrollHeight - 3, `T2 ${label}: long explanation end cannot be reached`, bodyAfter);
+      const scrolled = await evalJson(probe);
+      assertHotspotTooltipPainted(scrolled, `T2 ${label} scrolled`);
+      const screenshot = join(outDir, `t2-long-tooltip-${label}.png`);
+      await browserRaw(["screenshot", screenshot]);
+      const taps = [];
+      for (const [edge, xSide, ySide] of [["top-left", "x", "y"], ["top-right", "right", "y"], ["bottom-left", "x", "bottom"], ["bottom-right", "right", "bottom"]]) {
+        const opened = await evalJson(probe);
+        const close = opened.tooltip?.close?.rect;
+        assert(close?.width >= 44 && close.height >= 44, `T2 ${label}: sole touch close is below44px`, close);
+        const x = close[xSide] + (xSide === "x" ? 2 : -2);
+        const y = close[ySide] + (ySide === "y" ? 2 : -2);
+        const tap = await clickAtCoordinates(x, y, '.pixel-world-canvas__hotspot-tooltip-close', `T2 ${label}/${edge}`);
+        await waitShort();
+        const closed = await evalJson(probe);
+        assert(!closed.tooltip && closed.activeElement?.originalTrigger, `T2 ${label}/${edge}: close failed to dismiss and restore`, closed);
+        assert(runtimeStable(initial.opened.runtime, closed.runtime), `T2 ${label}/${edge}: close changed runtime`, closed.runtime);
+        taps.push({ edge, close, tap });
+        if (edge !== "bottom-right") await focusHotspotAndActivate("goal");
+      }
+      summary.thirdReview.longTooltips.push({ viewport, feedOpen, screenshot, initial: initial.opened, bodyBefore, bodyAfter, taps });
+    }
+  }
+  for (const visualFixture of [true, false]) {
+    for (const viewport of [viewports[0], viewports[1]]) {
+      await openFixture(port, { visualFixture, width: viewport.width, height: viewport.height });
+      await waitForFeedStatus("ready");
+      const glow = await evalJson(`JSON.stringify([...document.querySelectorAll('[data-hotspot-kind]')].map((node) => { const glyph = node.querySelector('.pixel-world-hotspot__glyph'); return { kind: node.dataset.hotspotKind, outerShadow: getComputedStyle(node).boxShadow, glyphShadow: getComputedStyle(glyph).boxShadow, outerWidth: node.getBoundingClientRect().width, glyphWidth: glyph.getBoundingClientRect().width }; }))`);
+      assert(glow.length === 3 && glow.every((node) => node.outerShadow === "none" && node.glyphShadow !== "none" && node.outerWidth >= 44 && node.glyphWidth <= 32), "T2 responsive glow leaks onto44px hitbox", glow);
+      const screenshot = join(outDir, `t2-glow-${visualFixture ? "fixture" : "production"}-${viewport.name}.png`);
+      await browserRaw(["screenshot", screenshot]);
+      summary.thirdReview.glow.push({ visualFixture, viewport, glow, screenshot });
+    }
+  }
+}
+
 function assertBase(label, result, expectedStatus) {
   assert(result.runtime?.pixelWorldRuntimeStatus === "ready", `${label}: runtime not ready`, result);
   assert(result.runtime?.renderMode === "viewer" || result.runtime?.renderMode === "software_safe", `${label}: unexpected render mode`, result.runtime);
@@ -1082,7 +1167,9 @@ async function main() {
   const port = address.port;
   try {
     closeBrowser();
-    if (onlyProduction) {
+    if (onlyThirdReview) {
+      await runThirdReview(port);
+    } else if (onlyProduction) {
       await runProductionHotspotRegression(port);
     } else if (onlyCamera) {
       await runCameraProjectionRegression(port, { visualFixture: true, label: "fixture" });
@@ -1094,6 +1181,7 @@ async function main() {
     } else if (onlyFocus) {
       await runFocusRestorationRegression(port);
     } else {
+      await runThirdReview(port);
       await runStatusMatrix(port);
       await runViewportMatrix(port);
       await runShortLandscapeMatrix(port);

--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { createHash } from "node:crypto";
 import { readFileSync, statSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, extname, join, normalize, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +19,10 @@ const session = `player-visual-feedback-${process.pid}`;
 const browserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
 const skipBuild = process.argv.includes("--skip-build");
 const onlyProduction = process.argv.includes("--only-production");
+const onlyCamera = process.argv.includes("--only-camera");
+const onlyTouch = process.argv.includes("--only-touch");
+const onlyTooltipFeed = process.argv.includes("--only-tooltip-feed");
+const onlyFocus = process.argv.includes("--only-focus");
 const statuses = ["ready", "replay", "empty", "gap", "unavailable"];
 const viewports = [
   { name: "mobile", width: 390, height: 844 },
@@ -35,7 +40,12 @@ const summary = {
   inputMode: "visible-ui-controls-plus-dom-readback",
   mockDisabled: false,
   fixtureBoundary: "deterministic QA bridge and fake world_feed; no runtime/provider/playability claim",
-  phase: onlyProduction ? "production-hotspot-only" : "full-matrix",
+  phase: onlyProduction ? "production-hotspot-only"
+    : onlyCamera ? "camera-regression-only"
+      : onlyTouch ? "touch-regression-only"
+        : onlyTooltipFeed ? "tooltip-feed-regression-only"
+          : onlyFocus ? "focus-regression-only"
+            : "full-matrix",
   status: "running",
   startedAt: new Date().toISOString(),
   viewports: {},
@@ -43,6 +53,12 @@ const summary = {
   feedStatuses: {},
   interactions: {},
   productionHotspot: {},
+  secondReview: {
+    camera: {},
+    touchTargets: {},
+    tooltipFeed: {},
+    focusRestoration: {},
+  },
 };
 
 mkdirSync(outDir, { recursive: true });
@@ -319,7 +335,7 @@ const probe = String.raw`(() => {
     if (!box) return [];
     const x = Math.max(1, Math.min(innerWidth - 1, box.x + Math.max(1, box.width / 2)));
     const y = Math.max(1, Math.min(innerHeight - 1, box.y + Math.max(1, box.height / 2)));
-    return document.elementsFromPoint(x, y).slice(0, 6).map((node) => ({ tag: node.tagName, id: node.id || null, className: node.className || null, overlay: node.getAttribute?.('data-viewer-overlay') || null, text: String(node.textContent || '').trim().slice(0, 160) }));
+    return document.elementsFromPoint(x, y).slice(0, 6).map((node) => ({ tag: node.tagName, id: node.id || null, className: node.className || null, tooltipAncestor: node.closest?.(".pixel-world-canvas__hotspot-tooltip")?.className || null, overlay: node.getAttribute?.('data-viewer-overlay') || null, text: String(node.textContent || '').trim().slice(0, 160) }));
   };
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
   const feedSummary = feed?.querySelector("summary");
@@ -328,9 +344,12 @@ const probe = String.raw`(() => {
   const primaryAction = primary?.querySelector('.pixel-world-command-cell__action');
   const supporting = command?.querySelector('[data-shell-region="supporting-context"]');
   const receipt = document.querySelector('.pixel-world-action-receipt');
+  const canvas = document.querySelector('#pixel-world-embedded-runtime-canvas');
   const selection = document.querySelector('.pixel-world-canvas__selection');
   const readout = document.querySelector('.pixel-world-readout');
   const hotspotNodes = [...document.querySelectorAll('[data-hotspot-kind]')];
+  const tooltipNode = document.querySelector('[data-hotspot-tooltip]');
+  const tooltipClose = tooltipNode?.querySelector('.pixel-world-canvas__hotspot-tooltip-close');
   return JSON.stringify({
     runtime: window.__AW_TEST__?.getState?.() || null,
     feed: feed ? { status: feed.dataset.worldFeedStatus || null, open: feed.open, text: feed.textContent.trim(), rect: rect(feed), summaryRect: rect(feedSummary), statusRow: text('.world-feed__status-row', feed), scrollTop: feed.scrollTop, scrollHeight: feed.scrollHeight, clientHeight: feed.clientHeight } : null,
@@ -339,11 +358,12 @@ const probe = String.raw`(() => {
     primary: primary ? { text: primary.textContent.trim(), rect: rect(primary), visible: getComputedStyle(primary).display !== 'none' && getComputedStyle(primary).visibility !== 'hidden', scrollTop: primary.scrollTop, scrollHeight: primary.scrollHeight, clientHeight: primary.clientHeight, actionRect: rect(primaryAction), actionText: primaryAction?.textContent.trim() || null } : null,
     supporting: supporting ? { text: supporting.textContent.trim(), rect: rect(supporting), visible: getComputedStyle(supporting).display !== 'none' } : null,
     receipt: receipt ? { present: receipt.dataset.receiptPresent, state: receipt.dataset.receiptState, confidence: receipt.dataset.receiptConfidence, text: receipt.textContent.trim(), rect: rect(receipt), visible: getComputedStyle(receipt).display !== 'none', scrollTop: receipt.scrollTop, scrollHeight: receipt.scrollHeight, clientHeight: receipt.clientHeight } : null,
-    tooltip: document.querySelector('[data-hotspot-tooltip]') ? { text: text('[data-hotspot-tooltip]'), rect: rect(document.querySelector('[data-hotspot-tooltip]')), close: (() => { const node = document.querySelector('.pixel-world-canvas__hotspot-tooltip-close'); return node ? { ariaLabel: node.getAttribute('aria-label'), rect: rect(node) } : null; })() } : null,
-    hotspots: hotspotNodes.map((node) => ({ tag: node.tagName, kind: node.dataset.hotspotKind, label: node.getAttribute('aria-label'), title: node.getAttribute('title'), role: node.getAttribute('role'), tabIndex: node.tabIndex, text: node.textContent.trim(), rect: rect(node) })),
+    canvas: canvas ? { rect: rect(canvas), width: canvas.width, height: canvas.height } : null,
+    tooltip: tooltipNode ? { text: text('[data-hotspot-tooltip]'), rect: rect(tooltipNode), stack: stackAt(rect(tooltipNode)), close: tooltipClose ? { ariaLabel: tooltipClose.getAttribute('aria-label'), rect: rect(tooltipClose), stack: stackAt(rect(tooltipClose)) } : null } : null,
+    hotspots: hotspotNodes.map((node) => ({ tag: node.tagName, kind: node.dataset.hotspotKind, label: node.getAttribute('aria-label'), title: node.getAttribute('title'), role: node.getAttribute('role'), tabIndex: node.tabIndex, text: node.textContent.trim(), rect: rect(node), glyphRect: rect(node.querySelector(".pixel-world-hotspot__glyph")) })),
     viewport: { width: innerWidth, height: innerHeight, clientWidth: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth, overflowX: Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth) },
     visualFixture: Boolean(document.body.getAttribute("data-viewer-visual-fixture")),
-    activeElement: (() => { const node = document.activeElement; return node ? { tag: node.tagName, id: node.id || null, className: node.className || null, ariaLabel: node.getAttribute?.('aria-label') || null, kind: node.getAttribute?.('data-hotspot-kind') || null } : null; })(),
+    activeElement: (() => { const node = document.activeElement; return node ? { tag: node.tagName, id: node.id || null, className: node.className || null, ariaLabel: node.getAttribute?.('aria-label') || null, kind: node.getAttribute?.('data-hotspot-kind') || null, originalTrigger: node === window.__qaOriginalTrigger } : null; })(),
     hitTest: { selection: stackAt(selection ? rect(selection) : null), feed: stackAt(feed ? rect(feed) : null) },
     bodyText: document.body.innerText,
   });
@@ -355,6 +375,66 @@ function visible(textValue) { return textValue && textValue.trim().length > 0; }
 
 function intersects(a, b) {
   return Boolean(a && b && a.right > b.x && a.x < b.right && a.bottom > b.y && a.y < b.bottom);
+}
+
+function rectCenter(rect) {
+  return rect ? { x: rect.x + (rect.width / 2), y: rect.y + (rect.height / 2) } : null;
+}
+
+function cameraHotspotWorld(kind) {
+  return {
+    blocker: { x: 2_900_000, y: 3_450_000 },
+    goal: { x: 7_150_000, y: 2_200_000 },
+    info: { x: 4_550_000, y: 1_200_000 },
+  }[kind] || null;
+}
+
+function projectedCanvasPoint(canvas, world, camera) {
+  const width = Number(canvas?.width || 960);
+  const height = Number(canvas?.height || 540);
+  const cssWidth = Number(canvas?.rect?.width || 0);
+  const cssHeight = Number(canvas?.rect?.height || 0);
+  const normalizedX = Math.min(1, Math.max(0, Number(world?.x || 0) / 10_000_000));
+  const normalizedY = Math.min(1, Math.max(0, Number(world?.y || 0) / 5_000_000));
+  const baseX = 20 + (normalizedX * Math.max(1, width - 40));
+  const baseY = 20 + (normalizedY * Math.max(1, height - 40));
+  const zoom = Math.max(0.5, Number(camera?.zoom) || 1);
+  const panX = Number(camera?.pan_x_px) || 0;
+  const panY = Number(camera?.pan_y_px) || 0;
+  const point = {
+    x: (width / 2) + ((baseX - (width / 2)) * zoom) + panX,
+    y: (height / 2) + ((baseY - (height / 2)) * zoom) + panY,
+  };
+  return {
+    x: Number(canvas?.rect?.x || 0) + (point.x * (cssWidth / width)),
+    y: Number(canvas?.rect?.y || 0) + (point.y * (cssHeight / height)),
+    canvasPoint: point,
+  };
+}
+
+function assertPointNear(actual, expected, tolerance, message, details = {}) {
+  assert(actual && expected, `${message}: missing point`, { actual, expected, ...details });
+  const dx = Math.abs(actual.x - expected.x);
+  const dy = Math.abs(actual.y - expected.y);
+  assert(dx <= tolerance && dy <= tolerance, `${message}: projected point drifted by ${dx.toFixed(2)}px/${dy.toFixed(2)}px`, {
+    actual,
+    expected,
+    dx,
+    dy,
+    tolerance,
+    ...details,
+  });
+}
+
+function runtimeStable(before, after) {
+  return before?.logicalTime === after?.logicalTime
+    && before?.eventSeq === after?.eventSeq
+    && before?.selectedKind === after?.selectedKind
+    && before?.selectedId === after?.selectedId;
+}
+
+function stackHasClass(stack, classFragment) {
+  return String(stack?.[0]?.className || "").includes(classFragment) || String(stack?.[0]?.tooltipAncestor || "").includes(classFragment);
 }
 
 async function waitForFeedStatus(status) {
@@ -391,8 +471,8 @@ async function clickVisible(selector) {
 
 async function clickVisibleInPlace(selector) {
   const selectorLiteral = JSON.stringify(selector);
-  const target = await evalJson(`(() => { const node = document.querySelector(${selectorLiteral}); if (!node) throw new Error("missing visible target"); const rect = node.getBoundingClientRect(); const x = Math.max(1, Math.min(innerWidth - 1, rect.left + Math.max(1, rect.width / 2))); const y = Math.max(1, Math.min(innerHeight - 1, rect.top + Math.max(1, rect.height / 2))); const visible = rect.width > 0 && rect.height > 0 && rect.top >= 0 && rect.bottom <= innerHeight; const topHit = document.elementsFromPoint(x, y).slice(0, 4).map((hit) => ({ tag: hit.tagName, className: hit.className || null, kind: hit.getAttribute?.("data-hotspot-kind") || null })); return JSON.stringify({ visible, rect: { x: Math.round(rect.x), y: Math.round(rect.y), right: Math.round(rect.right), bottom: Math.round(rect.bottom) }, topHit }); })()`);
-  assert(target.visible, `target is not visible in place: ${selector}`, target);
+  const target = await evalJson(`(() => { const node = document.querySelector(${selectorLiteral}); if (!node) throw new Error("missing visible target"); const rect = node.getBoundingClientRect(); const x = Math.max(1, Math.min(innerWidth - 1, rect.left + Math.max(1, rect.width / 2))); const y = Math.max(1, Math.min(innerHeight - 1, rect.top + Math.max(1, rect.height / 2))); const visible = rect.width > 0 && rect.height > 0 && rect.top >= 0 && rect.bottom <= innerHeight; const topHit = document.elementsFromPoint(x, y).slice(0, 4).map((hit) => ({ tag: hit.tagName, className: hit.className || null, kind: hit.getAttribute?.("data-hotspot-kind") || null })); return JSON.stringify({ visible, targetTop: node === document.elementFromPoint(x, y) || node.contains(document.elementFromPoint(x, y)), rect: { x: Math.round(rect.x), y: Math.round(rect.y), right: Math.round(rect.right), bottom: Math.round(rect.bottom) }, topHit }); })()`);
+  assert(target.visible && target.targetTop, `target is not the visible top hit in place: ${selector}`, target);
   const x = Math.round((target.rect.x + target.rect.right) / 2);
   const y = Math.round((target.rect.y + target.rect.bottom) / 2);
   await browserJson(["mouse", "move", String(x), String(y)]);
@@ -411,6 +491,86 @@ async function clickRecordedRect(rect, description) {
   return { rect, x, y };
 }
 
+async function clickAtCoordinates(x, y, selector, description) {
+  const selectorLiteral = JSON.stringify(selector);
+  const point = await evalJson(`(() => {
+    const target = document.querySelector(${selectorLiteral});
+    const node = document.elementFromPoint(${Number(x)}, ${Number(y)});
+    const stack = document.elementsFromPoint(${Number(x)}, ${Number(y)}).slice(0, 6).map((hit) => ({
+      tag: hit.tagName,
+      className: hit.className || null,
+      kind: hit.getAttribute?.("data-hotspot-kind") || null,
+      overlay: hit.getAttribute?.("data-viewer-overlay") || null,
+    }));
+    return JSON.stringify({
+      targetPresent: Boolean(target),
+      targetTop: Boolean(target && (node === target || target.contains(node))),
+      stack,
+    });
+  })()`);
+  assert(point.targetPresent && point.targetTop, `${description} is not the top hit at the requested point`, point);
+  await browserJson(["mouse", "move", String(Math.round(x)), String(Math.round(y))]);
+  await browserJson(["mouse", "down"]);
+  await browserJson(["mouse", "up"]);
+  return { x: Math.round(x), y: Math.round(y), point };
+}
+
+async function dispatchCanvasPan(deltaX, deltaY) {
+  const delta = await evalJson(`(() => {
+    const canvas = document.querySelector('#pixel-world-embedded-runtime-canvas');
+    if (!canvas) throw new Error("missing runtime canvas");
+    const rect = canvas.getBoundingClientRect();
+    const start = { x: rect.left + (rect.width * 0.63), y: rect.top + (rect.height * 0.31) };
+    const pointer = (type, x, y, buttons) => canvas.dispatchEvent(new PointerEvent(type, {
+      bubbles: true, cancelable: true, pointerId: 7331, clientX: x, clientY: y, buttons, button: 0,
+    }));
+    pointer("pointerdown", start.x, start.y, 1);
+    pointer("pointermove", start.x + ${Number(deltaX)}, start.y + ${Number(deltaY)}, 1);
+    pointer("pointerup", start.x + ${Number(deltaX)}, start.y + ${Number(deltaY)}, 0);
+    return JSON.stringify({ start, end: { x: start.x + ${Number(deltaX)}, y: start.y + ${Number(deltaY)} } });
+  })()`);
+  await waitShort();
+  return delta;
+}
+
+async function dispatchCanvasZoom(deltaY) {
+  const point = await evalJson(`(() => {
+    const canvas = document.querySelector('#pixel-world-embedded-runtime-canvas');
+    if (!canvas) throw new Error("missing runtime canvas");
+    const rect = canvas.getBoundingClientRect();
+    const x = rect.left + (rect.width * 0.56);
+    const y = rect.top + (rect.height * 0.42);
+    canvas.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: ${Number(deltaY)}, deltaX: 0, clientX: x, clientY: y }));
+    return JSON.stringify({ x, y });
+  })()`);
+  await waitShort();
+  return point;
+}
+
+function cameraState(result) {
+  return result.runtime?.pixelWorldCamera || result.runtime?.camera || null;
+}
+
+function projectedCanvasDelta(before, after, hotspot, canvas) {
+  const width = Number(canvas?.width || 960);
+  const height = Number(canvas?.height || 540);
+  const cssWidth = Number(canvas?.rect?.width || 0);
+  const cssHeight = Number(canvas?.rect?.height || 0);
+  const worldWidth = 10_000_000;
+  const worldDepth = 5_000_000;
+  const normalizedX = Math.min(1, Math.max(0, Number(hotspot.worldX ?? 0) / worldWidth));
+  const normalizedY = Math.min(1, Math.max(0, Number(hotspot.worldY ?? 0) / worldDepth));
+  const centeredX = (20 + (normalizedX * Math.max(1, width - 40))) - (width / 2);
+  const centeredY = (20 + (normalizedY * Math.max(1, height - 40))) - (height / 2);
+  const zoomDelta = Number(after.zoom || 1) - Number(before.zoom || 1);
+  const panDeltaX = Number(after.pan_x_px || 0) - Number(before.pan_x_px || 0);
+  const panDeltaY = Number(after.pan_y_px || 0) - Number(before.pan_y_px || 0);
+  return {
+    x: (centeredX * zoomDelta + panDeltaX) * (cssWidth / width),
+    y: (centeredY * zoomDelta + panDeltaY) * (cssHeight / height),
+  };
+}
+
 async function waitShort() { await browserRaw(["wait", "180"]); }
 
 async function waitForTooltip() {
@@ -421,6 +581,252 @@ async function waitForTooltip() {
     await browserRaw(["wait", "100"]);
   }
   return evalJson(probe);
+}
+
+function hotspotFor(result, kind) {
+  return result.hotspots?.find((hotspot) => hotspot.kind === kind) || null;
+}
+
+function assertHotspotTooltipPainted(result, label) {
+  const tooltip = result.tooltip;
+  const viewport = result.viewport;
+  assert(tooltip?.rect?.width > 0 && tooltip.rect.height > 0, `${label}: tooltip is not visible`, tooltip);
+  assert(tooltip.rect.x >= 0 && tooltip.rect.y >= 0
+    && tooltip.rect.right <= viewport.width && tooltip.rect.bottom <= viewport.height,
+  `${label}: tooltip leaves viewport`, { tooltip, viewport });
+  assert(stackHasClass(tooltip.stack, "pixel-world-canvas__hotspot-tooltip"),
+    `${label}: tooltip is not the painted hit at its center`, tooltip);
+  assert(tooltip.close?.rect?.width > 0 && tooltip.close.rect.height > 0,
+    `${label}: tooltip close control is not visible`, tooltip);
+  assert(stackHasClass(tooltip.close.stack, "pixel-world-canvas__hotspot-tooltip-close"),
+    `${label}: tooltip close control is obscured at its painted center`, tooltip.close);
+}
+
+async function runCameraProjectionRegression(port, { visualFixture, label }) {
+  await openFixture(port, { status: "ready", locale: "en", width: 768, height: 1024, visualFixture });
+  const initial = await waitForFeedStatus("ready");
+  const hotspot = hotspotFor(initial, "info");
+  const camera = cameraState(initial);
+  assert(camera && initial.canvas?.rect?.width > 0 && initial.canvas?.rect?.height > 0,
+    `${label}: camera/canvas state is unavailable`, { camera, canvas: initial.canvas });
+  const world = cameraHotspotWorld("info");
+  const initialExpected = projectedCanvasPoint(initial.canvas, world, camera);
+  const initialActual = rectCenter(hotspot?.glyphRect || hotspot?.rect);
+  assertPointNear(initialActual, initialExpected, 4, `${label}: default camera hotspot misses 20px-inset projection`, {
+    camera,
+    world,
+    canvas: initial.canvas,
+    hotspot,
+  });
+
+  const steps = [
+    { name: "pan-both-axes", action: () => dispatchCanvasPan(48, -32) },
+    { name: "zoom-in", action: () => dispatchCanvasZoom(-100) },
+    { name: "zoom-out", action: () => dispatchCanvasZoom(100) },
+  ];
+  const checks = [{ name: "default", before: camera, after: camera, actual: initialActual, expected: initialExpected }];
+  let previous = initial;
+  for (const step of steps) {
+    const beforeCamera = cameraState(previous);
+    const beforeHotspot = hotspotFor(previous, "info");
+    await step.action();
+    const after = await evalJson(probe);
+    const afterCamera = cameraState(after);
+    const afterHotspot = hotspotFor(after, "info");
+    assert(afterCamera && afterHotspot, `${label}/${step.name}: camera or hotspot disappeared`, { afterCamera, afterHotspot: afterHotspot?.rect, after });
+    assert(afterCamera.pan_x_px !== beforeCamera.pan_x_px || afterCamera.pan_y_px !== beforeCamera.pan_y_px || afterCamera.zoom !== beforeCamera.zoom,
+      `${label}/${step.name}: camera input did not change camera state`, { beforeCamera, afterCamera });
+    const expected = projectedCanvasPoint(after.canvas, world, afterCamera);
+    const actual = rectCenter(afterHotspot.glyphRect || afterHotspot.rect);
+    assertPointNear(actual, expected, 4, `${label}/${step.name}: hotspot does not follow canvas projection`, {
+      beforeCamera,
+      afterCamera,
+      beforeHotspot: beforeHotspot?.rect,
+      afterHotspot: afterHotspot.rect,
+      world,
+      canvas: after.canvas,
+    });
+    checks.push({ name: step.name, before: beforeCamera, after: afterCamera, actual, expected });
+    previous = after;
+  }
+  const beforeEdge = previous;
+  const edgePoint = projectedCanvasPoint(beforeEdge.canvas, world, cameraState(beforeEdge));
+  await dispatchCanvasPan(20 - edgePoint.canvasPoint.x, 0);
+  const edge = await evalJson(probe);
+  const edgeHotspot = hotspotFor(edge, "info");
+  const edgeExpected = projectedCanvasPoint(edge.canvas, world, cameraState(edge));
+  const edgeActual = rectCenter(edgeHotspot?.glyphRect || edgeHotspot?.rect);
+  assertPointNear(edgeActual, edgeExpected, 4, `${label}: near-inset glyph projection drifted`, { edgeHotspot, camera: cameraState(edge) });
+  assert(edgeHotspot.rect.x >= edge.canvas.rect.x - 1 && edgeHotspot.rect.right <= edge.canvas.rect.right + 1,
+    `${label}: near-inset 44px target escapes stage`, { hotspot: edgeHotspot, canvas: edge.canvas });
+  checks.push({ name: "near-20px-inset", actual: edgeActual, expected: edgeExpected, target: edgeHotspot.rect, camera: cameraState(edge) });
+  const screenshot = join(outDir, `s3-camera-inset-${label}.png`);
+  await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+  summary.secondReview.camera[label] = { screenshot, visualFixture, initial, checks };
+}
+
+async function runTouchTargetSurface(port, { visualFixture, label }) {
+  await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844, visualFixture });
+  const initial = await waitForFeedStatus("ready");
+  const expectedRuntime = initial.runtime;
+  const taps = [];
+  for (const kind of ["blocker", "goal", "info"]) {
+    const beforePan = await evalJson(probe);
+    const projected = projectedCanvasPoint(beforePan.canvas, cameraHotspotWorld(kind), cameraState(beforePan));
+    // The fixed command HUD owns its painted region. Move the world point
+    // through the real camera handler into clear stage before pointer taps.
+    await dispatchCanvasPan(((kind === "goal" ? 380 : 180) - projected.x) * beforePan.canvas.width / beforePan.canvas.rect.width,
+      (280 - projected.y) * beforePan.canvas.height / beforePan.canvas.rect.height);
+    const reachable = await evalJson(probe);
+    const hotspot = hotspotFor(reachable, kind);
+    assert(hotspot?.rect?.width >= 44 && hotspot.rect.height >= 44,
+      `${label}/${kind}: hotspot hit box is below 44px`, hotspot);
+    assert(hotspot.rect.x >= 0 && hotspot.rect.y >= 0
+      && hotspot.rect.right <= initial.viewport.width && hotspot.rect.bottom <= initial.viewport.height,
+    `${label}/${kind}: hotspot hit box is not clamped into viewport`, { hotspot, viewport: initial.viewport });
+    const points = [
+      { edge: "top-left", x: hotspot.rect.x + 2, y: hotspot.rect.y + 2 },
+      { edge: "top-right", x: hotspot.rect.right - 2, y: hotspot.rect.y + 2 },
+      { edge: "bottom-left", x: hotspot.rect.x + 2, y: hotspot.rect.bottom - 2 },
+      { edge: "bottom-right", x: hotspot.rect.right - 2, y: hotspot.rect.bottom - 2 },
+    ];
+    for (const point of points) {
+      assert(point.x >= 0 && point.y >= 0 && point.x < initial.viewport.width && point.y < initial.viewport.height,
+        `${label}/${kind}/${point.edge}: edge tap leaves viewport`, { point, hotspot: hotspot.rect, viewport: initial.viewport });
+      const tap = await clickAtCoordinates(point.x, point.y, `[data-hotspot-kind="${kind}"]`, `${label}/${kind}/${point.edge}`);
+      const opened = await waitForTooltip();
+      assert(opened.tooltip?.text?.startsWith(`${kind === "blocker" ? "Blocker" : kind === "goal" ? "Goal" : "Info"}:`),
+        `${label}/${kind}/${point.edge}: wrong tooltip opened`, { tap, tooltip: opened.tooltip, hotspots: opened.hotspots });
+      assert(runtimeStable(expectedRuntime, opened.runtime), `${label}/${kind}/${point.edge}: hotspot tap changed runtime selection/time`, {
+        before: expectedRuntime,
+        after: opened.runtime,
+      });
+      assertHotspotTooltipPainted(opened, `${label}/${kind}/${point.edge}`);
+      taps.push({ kind, camera: cameraState(reachable), cameraBefore: cameraState(beforePan), reason: "pan world target clear of fixed command HUD", edge: point.edge, point, target: hotspot.rect, opened: opened.tooltip, runtime: opened.runtime });
+      await clickRecordedRect(opened.tooltip.close.rect, `${label}/${kind}/${point.edge} close`);
+      await waitShort();
+      const closed = await evalJson(probe);
+      assert(!closed.tooltip, `${label}/${kind}/${point.edge}: close did not dismiss tooltip`, closed);
+    }
+  }
+  summary.secondReview.touchTargets[label] = { visualFixture, initial, taps };
+}
+
+async function runTouchTargetRegression(port) {
+  await runTouchTargetSurface(port, { visualFixture: true, label: "fixture" });
+  await runTouchTargetSurface(port, { visualFixture: false, label: "production" });
+}
+
+async function runTooltipFeedSurface(port, { visualFixture, label, width, height, hotspotKind }) {
+  await openFixture(port, { status: "ready", locale: "en", width, height, visualFixture });
+  await waitForFeedStatus("ready");
+  await clickVisible('[data-viewer-overlay="feed"] > summary');
+  await waitShort();
+  const feedOpen = await evalJson(probe);
+  assert(feedOpen.feed?.open === true, `${label}: Feed did not open`, feedOpen.feed);
+  const target = hotspotFor(feedOpen, hotspotKind);
+  assert(target?.rect?.width > 0 && target.rect.height > 0, `${label}: ${hotspotKind} hotspot is not visible`, { target, feed: feedOpen.feed });
+  await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="${hotspotKind}"]'); if (!node) throw new Error("missing hotspot"); node.focus(); return JSON.stringify({ kind: node.dataset.hotspotKind, describedBy: node.getAttribute("aria-describedby") }); })()`);
+  await browserRaw(["press", "Enter"]);
+  const opened = await waitForTooltip();
+  assert(opened.tooltip?.text?.startsWith(`${hotspotKind === "blocker" ? "Blocker" : "Goal"}:`), `${label}: wrong tooltip opened`, opened.tooltip);
+  assertHotspotTooltipPainted(opened, label);
+  assert(!intersects(opened.tooltip.rect, opened.feed?.summaryRect), `${label}: tooltip covers Feed summary action`, {
+    tooltip: opened.tooltip.rect,
+    summary: opened.feed?.summaryRect,
+  });
+  const screenshot = join(outDir, `s3-tooltip-feed-${label}.png`);
+  await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+  await clickRecordedRect(opened.tooltip.close.rect, `${label} tooltip close`);
+  await waitShort();
+  const closed = await evalJson(probe);
+  assert(!closed.tooltip, `${label}: pointer close did not dismiss tooltip`, closed);
+
+  const blocker = hotspotFor(closed, "blocker");
+  assert(blocker?.rect?.width > 0 && blocker.rect.height > 0, `${label}: blocker hotspot is not visible for Escape path`, { blocker, feed: closed.feed });
+  await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="blocker"]'); node.focus(); return JSON.stringify({ kind: node.dataset.hotspotKind }); })()`);
+  await browserRaw(["press", "Enter"]);
+  const beforeEscape = await waitForTooltip();
+  assertHotspotTooltipPainted(beforeEscape, `${label} Escape path`);
+  await browserRaw(["press", "Escape"]);
+  await waitShort();
+  const afterEscape = await evalJson(probe);
+  assert(!afterEscape.tooltip, `${label}: Escape did not dismiss Feed-open tooltip`, afterEscape);
+  summary.secondReview.tooltipFeed[label] = { screenshot, visualFixture, viewport: { width, height }, feedOpen, opened, closed, beforeEscape, afterEscape };
+}
+
+async function runTooltipFeedRegression(port) {
+  const cases = [
+    { width: 390, height: 844, hotspotKind: "goal", label: "fixture-mobile-goal" },
+    { width: 844, height: 390, hotspotKind: "blocker", label: "fixture-landscape-blocker" },
+    { width: 640, height: 360, hotspotKind: "goal", label: "fixture-compact-goal" },
+    { width: 390, height: 844, hotspotKind: "goal", label: "production-mobile-goal", visualFixture: false },
+    { width: 844, height: 390, hotspotKind: "blocker", label: "production-landscape-blocker", visualFixture: false },
+    { width: 640, height: 360, hotspotKind: "goal", label: "production-compact-goal", visualFixture: false },
+  ];
+  for (const testCase of cases) {
+    await runTooltipFeedSurface(port, { visualFixture: testCase.visualFixture !== false, ...testCase });
+  }
+}
+
+async function focusHotspotAndActivate(kind) {
+  const focused = await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="${kind}"]'); if (!node) throw new Error("missing hotspot"); node.focus(); window.__qaOriginalTrigger = node; return JSON.stringify({ kind: node.dataset.hotspotKind, label: node.getAttribute("aria-label"), describedBy: node.getAttribute("aria-describedby"), active: document.activeElement === node }); })()`);
+  assert(focused.active && focused.label && focused.describedBy, `focus/${kind}: trigger did not receive accessible focus`, focused);
+  await browserRaw(["press", "Enter"]);
+  const opened = await waitForTooltip();
+  const relation = await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="${kind}"]'); const id = node?.getAttribute("aria-describedby"); return JSON.stringify({ label: node?.getAttribute("aria-label"), describedBy: id, describedNode: Boolean(id && document.getElementById(id)), active: document.activeElement === node }); })()`);
+  assert(relation.label && relation.describedNode, `focus/${kind}: open tooltip is not linked by aria-describedby`, relation);
+  assert(opened.tooltip, `focus/${kind}: Enter did not open tooltip`, opened);
+  return { focused, opened, relation };
+}
+
+async function runFocusRestorationSurface(port, { visualFixture, label }) {
+  const cases = [];
+  for (const kind of ["goal", "blocker"]) {
+    await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844, visualFixture });
+    const triggerEscape = await focusHotspotAndActivate(kind);
+    await browserRaw(["press", "Escape"]);
+    await waitShort();
+    const afterTriggerEscape = await evalJson(probe);
+    assert(!afterTriggerEscape.tooltip && afterTriggerEscape.activeElement?.kind === kind && afterTriggerEscape.activeElement?.tag === "BUTTON" && afterTriggerEscape.activeElement?.originalTrigger,
+      `${label}/${kind}: trigger Escape did not restore focus`, { afterTriggerEscape, triggerEscape });
+
+    await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844, visualFixture });
+    const pointerClose = await focusHotspotAndActivate(kind);
+    await clickRecordedRect(pointerClose.opened.tooltip.close.rect, `${label}/${kind} pointer close`);
+    await waitShort();
+    const afterPointerClose = await evalJson(probe);
+    assert(!afterPointerClose.tooltip && afterPointerClose.activeElement?.kind === kind && afterPointerClose.activeElement?.tag === "BUTTON" && afterPointerClose.activeElement?.originalTrigger,
+      `${label}/${kind}: pointer close did not restore focus`, { afterPointerClose, pointerClose });
+
+    await openFixture(port, { status: "ready", locale: "en", width: 390, height: 844, visualFixture });
+    const keyboardClose = await focusHotspotAndActivate(kind);
+    let closeFocused = false;
+    for (let tab = 0; tab < 8; tab += 1) {
+      await browserRaw(["press", "Tab"]);
+      const focus = await evalJson(probe);
+      if (focus.activeElement?.className?.includes("pixel-world-canvas__hotspot-tooltip-close")) {
+        closeFocused = true;
+        break;
+      }
+    }
+    assert(closeFocused, `${label}/${kind}: Tab did not reach tooltip close`, keyboardClose.opened);
+    await browserRaw(["press", "Escape"]);
+    await waitShort();
+    const afterKeyboardClose = await evalJson(probe);
+    assert(!afterKeyboardClose.tooltip && afterKeyboardClose.activeElement?.kind === kind && afterKeyboardClose.activeElement?.tag === "BUTTON" && afterKeyboardClose.activeElement?.originalTrigger,
+      `${label}/${kind}: close Escape did not restore focus`, { afterKeyboardClose, keyboardClose });
+    for (const [name, before, after] of [["trigger-Escape", triggerEscape.opened, afterTriggerEscape], ["pointer-close", pointerClose.opened, afterPointerClose], ["close-Escape", keyboardClose.opened, afterKeyboardClose]]) {
+      assert(runtimeStable(before.runtime, after.runtime), `${label}/${kind}/${name}: inspection changed runtime`, { before: before.runtime, after: after.runtime });
+    }
+    cases.push({ kind, triggerEscape, afterTriggerEscape, pointerClose, afterPointerClose, keyboardClose, afterKeyboardClose });
+  }
+  summary.secondReview.focusRestoration[label] = { visualFixture, cases };
+}
+
+async function runFocusRestorationRegression(port) {
+  await runFocusRestorationSurface(port, { visualFixture: true, label: "fixture" });
+  await runFocusRestorationSurface(port, { visualFixture: false, label: "production" });
 }
 
 function assertBase(label, result, expectedStatus) {
@@ -494,6 +900,17 @@ async function runInteractions(port) {
     assert(hotspot.tabIndex >= 0 || hotspot.role === "button" || hotspot.tag === "BUTTON" || visible(hotspot.label), `A4: hotspot ${hotspot.kind} has no keyboard/accessibility affordance`, hotspot);
   }
   const beforeInteractionState = before.runtime || {};
+  // Scrolling the world can leave an Info explanation open. Close it through
+  // its painted control before targeting a world point behind that overlay.
+  const existingExplanation = await evalJson(probe);
+  if (existingExplanation.tooltip) {
+    assertHotspotTooltipPainted(existingExplanation, "A4 existing explanation");
+    await clickRecordedRect(existingExplanation.tooltip.close.rect, "A4 existing explanation close");
+    await waitShort();
+    const dismissed = await evalJson(probe);
+    assert(!dismissed.tooltip, "A4 existing explanation did not close before goal inspection", dismissed);
+    assert(runtimeStable(existingExplanation.runtime, dismissed.runtime), "A4 precondition close changed runtime", dismissed.runtime);
+  }
   const goalClick = await clickVisibleInPlace('[data-hotspot-kind="goal"]');
   const afterPointerHotspot = await waitForTooltip();
   assert(afterPointerHotspot.tooltip?.text?.includes("Goal: stabilize the first production line"), "A4: visible hotspot click did not expose a goal explanation", { tooltip: afterPointerHotspot.tooltip, goalClick });
@@ -602,6 +1019,14 @@ async function runProductionHotspotRegression(port) {
   assert(initial.hotspots.length >= 2, "R2/production: production path did not expose hotspot buttons", initial.hotspots);
   assert(initial.hotspots.every((hotspot) => hotspot.tag === "BUTTON" && hotspot.tabIndex >= 0), "R2/production: hotspot is not keyboard reachable", initial.hotspots);
 
+  await evalJson(`(() => {
+    window.__qaPointerTrace = [];
+    for (const type of ["pointerdown", "pointerup", "click", "focusin", "mouseover", "mouseout"]) document.addEventListener(type, (event) => {
+      const node = event.target;
+      window.__qaPointerTrace.push({ type, time: performance.now(), x: event.clientX, y: event.clientY, tag: node?.tagName, className: node?.className, kind: node?.dataset?.hotspotKind, dismissed: node?.dataset?.dismissedHover, tooltip: Boolean(document.querySelector("[data-hotspot-tooltip]")) });
+    }, true);
+    return true;
+  })()`);
   const zhGoalClick = await clickVisibleInPlace('[data-hotspot-kind="goal"]');
   const zhGoal = await waitForTooltip();
   assert(zhGoal.visualFixture === false, "R2/zh-CN: visual fixture marker unexpectedly enabled", zhGoal);
@@ -610,7 +1035,13 @@ async function runProductionHotspotRegression(port) {
   await clickRecordedRect(zhGoal.tooltip.close?.rect, "R2/zh-CN tooltip close control");
   await waitShort();
   const zhClosed = await evalJson(probe);
-  assert(!zhClosed.tooltip, "R2/zh-CN: visible tooltip close did not dismiss", zhClosed);
+  const pointerTrace = await evalJson("JSON.stringify(window.__qaPointerTrace)");
+  writeFileSync(join(outDir, "production-pointer-trace.json"), JSON.stringify(pointerTrace, null, 2));
+  assert(!zhClosed.tooltip, "R2/zh-CN: visible tooltip close did not dismiss", { zhClosed, zhGoal, trace: pointerTrace });
+  for (const type of ["pointerdown", "pointerup", "click"]) {
+    assert(pointerTrace.some((event) => event.type === type && event.className === "pixel-world-canvas__hotspot-tooltip-close"),
+      `R2/zh-CN: close did not receive ${type}`, pointerTrace);
+  }
 
   await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="blocker"]'); if (!node) throw new Error("missing production blocker hotspot"); node.scrollIntoView({ block: "center" }); node.focus(); return JSON.stringify({ active: document.activeElement === node }); })()`);
   await browserRaw(["press", "Enter"]);
@@ -633,7 +1064,7 @@ async function runProductionHotspotRegression(port) {
   assert(!afterTabEscape.tooltip, "R2/production: Escape on focused tooltip close did not dismiss", afterTabEscape);
   const screenshot = join(outDir, "r2-production-zh-hotspot-tab-close.png");
   await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
-  summary.productionHotspot = { initial, zhGoal, zhClosed, keyboardOpened, afterTabEscape, screenshot };
+  summary.productionHotspot = { pointerTrace, initial, zhGoal, zhClosed, keyboardOpened, afterTabEscape, screenshot };
 }
 
 async function main() {
@@ -643,6 +1074,7 @@ async function main() {
     assert(build.status === 0, "Viewer bundle build failed; see bundle-build.log", { status: build.status, signal: build.signal });
   }
   assert(statSafe(bundlePath), `missing ${bundlePath}; build:viewer:bundle did not produce the test bundle`);
+  summary.sourceDigests = Object.fromEntries([bundlePath, resolve(viewerRoot, "viewer.html"), resolve(viewerRoot, "viewer_terminal_shell.css"), fileURLToPath(import.meta.url)].map((path) => [relative(repoRoot, path), createHash("sha256").update(readFileSync(path)).digest("hex")]));
   assert(spawnSync(browserBin, ["--version"], { stdio: "ignore" }).status === 0, `missing browser automation command: ${browserBin}`);
   const server = createServer(serveFile);
   await new Promise((resolveServer) => server.listen(0, "127.0.0.1", resolveServer));
@@ -652,16 +1084,34 @@ async function main() {
     closeBrowser();
     if (onlyProduction) {
       await runProductionHotspotRegression(port);
+    } else if (onlyCamera) {
+      await runCameraProjectionRegression(port, { visualFixture: true, label: "fixture" });
+      await runCameraProjectionRegression(port, { visualFixture: false, label: "production" });
+    } else if (onlyTouch) {
+      await runTouchTargetRegression(port);
+    } else if (onlyTooltipFeed) {
+      await runTooltipFeedRegression(port);
+    } else if (onlyFocus) {
+      await runFocusRestorationRegression(port);
     } else {
       await runStatusMatrix(port);
       await runViewportMatrix(port);
       await runShortLandscapeMatrix(port);
+      await runCameraProjectionRegression(port, { visualFixture: true, label: "fixture" });
+      await runCameraProjectionRegression(port, { visualFixture: false, label: "production" });
+      await runTouchTargetRegression(port);
+      await runTooltipFeedRegression(port);
+      await runFocusRestorationRegression(port);
       await runProductionHotspotRegression(port);
       await runInteractions(port);
     }
     const consoleOutput = await browserRaw(["console"]);
     writeFileSync(join(outDir, "browser-console.log"), consoleOutput, "utf8");
     assert(!/\[(?:error|pageerror)\]|\b(?:fatal|CONTEXT_LOST_WEBGL)\b/i.test(consoleOutput), "browser console contains runtime errors", { consoleOutput });
+    for (const [path, digest] of Object.entries(summary.sourceDigests)) {
+      assert(createHash("sha256").update(readFileSync(resolve(repoRoot, path))).digest("hex") === digest,
+        `source bytes changed during headed run: ${path}`);
+    }
     summary.console = { path: join(outDir, "browser-console.log"), errors: 0 };
     summary.status = "passed";
   } catch (error) {

--- a/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/player-visual-feedback-browser-smoke.mjs
@@ -17,11 +17,16 @@ const bundlePath = resolve(viewerRoot, ".software-safe-build/viewer.js");
 const session = `player-visual-feedback-${process.pid}`;
 const browserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
 const skipBuild = process.argv.includes("--skip-build");
+const onlyProduction = process.argv.includes("--only-production");
 const statuses = ["ready", "replay", "empty", "gap", "unavailable"];
 const viewports = [
   { name: "mobile", width: 390, height: 844 },
   { name: "tablet", width: 768, height: 1024 },
   { name: "desktop", width: 1440, height: 1000 },
+];
+const shortLandscapeViewports = [
+  { name: "landscape-phone", width: 844, height: 390 },
+  { name: "landscape-compact", width: 640, height: 360 },
 ];
 const summary = {
   caseId: "S6-Q1-player-visual-feedback",
@@ -30,11 +35,14 @@ const summary = {
   inputMode: "visible-ui-controls-plus-dom-readback",
   mockDisabled: false,
   fixtureBoundary: "deterministic QA bridge and fake world_feed; no runtime/provider/playability claim",
+  phase: onlyProduction ? "production-hotspot-only" : "full-matrix",
   status: "running",
   startedAt: new Date().toISOString(),
   viewports: {},
+  shortLandscape: {},
   feedStatuses: {},
   interactions: {},
+  productionHotspot: {},
 };
 
 mkdirSync(outDir, { recursive: true });
@@ -189,8 +197,34 @@ export function derivePixelWorldRenderState(input) {
   };
 }`;
 
+// Production-overlay regression data is sent as a normal snapshot message by
+// the deterministic transport below. It intentionally does not use the
+// pixel-world visual-fixture query or body marker that enables the historical
+// fixture shell.
+const productionSnapshot = {
+  time: 12,
+  config: { space: { width_cm: 10_000_000, depth_cm: 5_000_000, height_cm: 1_000_000 } },
+  model: {
+    agents: { "agent-0": { id: "agent-0", name: "Agent 0", location_id: "loc-0", pos: { x_cm: 2_400_000, y_cm: 1_800_000, z_cm: 0 } } },
+    locations: { "loc-0": { id: "loc-0", name: "Factory Anchor", pos: { x_cm: 2_000_000, y_cm: 1_500_000, z_cm: 0 } } },
+  },
+  player_gameplay: {
+    stage_status: "blocked",
+    goal_title: "Recover sustainable capability",
+    objective: "Stabilize the first production line before expanding.",
+    progress_detail: "The primary line is blocked by missing material input.",
+    blocker_kind: "material_shortage",
+    blocker_detail: "iron input exhausted at factory-0",
+    next_step_hint: "Replenish upstream materials, then advance again to confirm the line resumes.",
+    available_actions: [{ action_id: "request_snapshot", label: "Request snapshot", protocol_action: "world.request_snapshot", execute_kind: "request_snapshot" }],
+    recent_feedback: { action: "build_factory_smelter_mk1", stage: "completed_no_progress", effect: "Smelter build request reached factory-0; iron shortage blocks construction." },
+    last_world_change: "Smelter build request reached factory-0; iron shortage blocks construction.",
+  },
+};
+
 const fakeWebSocket = String.raw`(() => {
   const status = new URLSearchParams(location.search).get("feed_status") || "ready";
+  const sendProductionSnapshot = !new URLSearchParams(location.search).has("pixel_world_visual_fixture");
   const listeners = new WeakMap();
   const emit = (socket, type, payload = {}) => {
     const callbacks = listeners.get(socket)?.[type] || [];
@@ -205,7 +239,7 @@ const fakeWebSocket = String.raw`(() => {
     constructor(url) { this.url = url; this.readyState = FixtureWebSocket.CONNECTING; listeners.set(this, {}); queueMicrotask(() => { this.readyState = FixtureWebSocket.OPEN; emit(this, "open"); }); }
     addEventListener(type, callback) { const table = listeners.get(this); table[type] ||= []; table[type].push(callback); }
     removeEventListener(type, callback) { const list = listeners.get(this)?.[type] || []; const index = list.indexOf(callback); if (index >= 0) list.splice(index, 1); }
-    send(raw) { const message = JSON.parse(raw); if (message.type === "hello") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "hello_ack", server: "qa-fixture", world_id: "fixture-world", control_profile: "fixture" }) })); if (message.type === "request_world_feed") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "world_feed", feed: feed(status) }) })); }
+    send(raw) { const message = JSON.parse(raw); if (message.type === "hello") { if (sendProductionSnapshot) queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "snapshot", snapshot: ${JSON.stringify(productionSnapshot)} }) })); queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "hello_ack", server: "qa-fixture", world_id: "fixture-world", control_profile: "fixture" }) })); } if (message.type === "request_world_feed") queueMicrotask(() => emit(this, "message", { data: JSON.stringify({ type: "world_feed", feed: feed(status) }) })); }
     close() { this.readyState = FixtureWebSocket.CLOSED; emit(this, "close"); }
   }
   window.WebSocket = FixtureWebSocket;
@@ -223,6 +257,9 @@ const fixtureCanvasCompatibility = String.raw`(() => {
     if (type === "webgl2") return { __qaWebgl2ProbeOnly: true };
     return nativeGetContext.call(this, type, ...args);
   };
+})();`;
+
+const fixtureVisualOverlayBootstrap = String.raw`(() => {
   document.body.setAttribute("data-viewer-visual-fixture", "shell_selected_blocker");
 })();`;
 
@@ -245,7 +282,10 @@ function serveFile(request, response) {
   try {
     let body = readFileSync(filePath, "utf8");
     if (pathname === "/viewer.html" && requestUrl.searchParams.get("browser_fixture") === "1") {
-      body = body.replace('<script type="module" src="./viewer.js"></script>', `<script>${fixtureCanvasCompatibility}</script><script>${fakeWebSocket}</script><script type="module" src="./viewer.js"></script>`);
+      const visualOverlayBootstrap = requestUrl.searchParams.get("visual_fixture") === "1"
+        ? fixtureVisualOverlayBootstrap
+        : "";
+      body = body.replace('<script type="module" src="./viewer.js"></script>', `<script>${fixtureCanvasCompatibility}${visualOverlayBootstrap}</script><script>${fakeWebSocket}</script><script type="module" src="./viewer.js"></script>`);
     }
     response.writeHead(200, { "Content-Type": contentType(filePath), "Cache-Control": "no-store" });
     response.end(body);
@@ -258,11 +298,16 @@ function statSafe(path) {
   try { return statSync(path).isFile(); } catch { return false; }
 }
 
-function fixtureUrl(port, { status = "ready", locale = "en" } = {}) {
+function fixtureUrl(port, { status = "ready", locale = "en", visualFixture = true } = {}) {
   const params = new URLSearchParams({
     browser_fixture: "1", test_api: "1", connect: "1", hosted_bootstrap: "0", ws: "ws://qa-fixture",
-    locale, feed_status: status, viewer_visual_fixture: "shell_selected_blocker", pixel_world_visual_fixture: "selected_blocker", t: Date.now().toString(),
+    locale, feed_status: status, t: Date.now().toString(),
   });
+  if (visualFixture) {
+    params.set("visual_fixture", "1");
+    params.set("viewer_visual_fixture", "shell_selected_blocker");
+    params.set("pixel_world_visual_fixture", "selected_blocker");
+  }
   return `http://127.0.0.1:${port}/viewer.html?${params}`;
 }
 
@@ -277,8 +322,10 @@ const probe = String.raw`(() => {
     return document.elementsFromPoint(x, y).slice(0, 6).map((node) => ({ tag: node.tagName, id: node.id || null, className: node.className || null, overlay: node.getAttribute?.('data-viewer-overlay') || null, text: String(node.textContent || '').trim().slice(0, 160) }));
   };
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const feedSummary = feed?.querySelector("summary");
   const command = document.querySelector('[data-viewer-overlay="next-move"]');
   const primary = command?.querySelector('[data-shell-region="next-move-primary"]') || command;
+  const primaryAction = primary?.querySelector('.pixel-world-command-cell__action');
   const supporting = command?.querySelector('[data-shell-region="supporting-context"]');
   const receipt = document.querySelector('.pixel-world-action-receipt');
   const selection = document.querySelector('.pixel-world-canvas__selection');
@@ -286,15 +333,17 @@ const probe = String.raw`(() => {
   const hotspotNodes = [...document.querySelectorAll('[data-hotspot-kind]')];
   return JSON.stringify({
     runtime: window.__AW_TEST__?.getState?.() || null,
-    feed: feed ? { status: feed.dataset.worldFeedStatus || null, open: feed.open, text: feed.textContent.trim(), rect: rect(feed), statusRow: text('.world-feed__status-row', feed), scrollTop: feed.scrollTop, scrollHeight: feed.scrollHeight, clientHeight: feed.clientHeight } : null,
+    feed: feed ? { status: feed.dataset.worldFeedStatus || null, open: feed.open, text: feed.textContent.trim(), rect: rect(feed), summaryRect: rect(feedSummary), statusRow: text('.world-feed__status-row', feed), scrollTop: feed.scrollTop, scrollHeight: feed.scrollHeight, clientHeight: feed.clientHeight } : null,
     readout: readout ? { text: readout.textContent.trim(), classes: [...readout.querySelectorAll('.badge')].map((node) => ({ text: node.textContent.trim(), className: node.className })) } : null,
     selection: selection ? { text: selection.textContent.trim(), rect: rect(selection) } : null,
-    primary: primary ? { text: primary.textContent.trim(), rect: rect(primary), visible: getComputedStyle(primary).display !== 'none' && getComputedStyle(primary).visibility !== 'hidden' } : null,
+    primary: primary ? { text: primary.textContent.trim(), rect: rect(primary), visible: getComputedStyle(primary).display !== 'none' && getComputedStyle(primary).visibility !== 'hidden', scrollTop: primary.scrollTop, scrollHeight: primary.scrollHeight, clientHeight: primary.clientHeight, actionRect: rect(primaryAction), actionText: primaryAction?.textContent.trim() || null } : null,
     supporting: supporting ? { text: supporting.textContent.trim(), rect: rect(supporting), visible: getComputedStyle(supporting).display !== 'none' } : null,
     receipt: receipt ? { present: receipt.dataset.receiptPresent, state: receipt.dataset.receiptState, confidence: receipt.dataset.receiptConfidence, text: receipt.textContent.trim(), rect: rect(receipt), visible: getComputedStyle(receipt).display !== 'none', scrollTop: receipt.scrollTop, scrollHeight: receipt.scrollHeight, clientHeight: receipt.clientHeight } : null,
-    tooltip: document.querySelector('[data-hotspot-tooltip]') ? { text: text('[data-hotspot-tooltip]'), rect: rect(document.querySelector('[data-hotspot-tooltip]')) } : null,
+    tooltip: document.querySelector('[data-hotspot-tooltip]') ? { text: text('[data-hotspot-tooltip]'), rect: rect(document.querySelector('[data-hotspot-tooltip]')), close: (() => { const node = document.querySelector('.pixel-world-canvas__hotspot-tooltip-close'); return node ? { ariaLabel: node.getAttribute('aria-label'), rect: rect(node) } : null; })() } : null,
     hotspots: hotspotNodes.map((node) => ({ tag: node.tagName, kind: node.dataset.hotspotKind, label: node.getAttribute('aria-label'), title: node.getAttribute('title'), role: node.getAttribute('role'), tabIndex: node.tabIndex, text: node.textContent.trim(), rect: rect(node) })),
     viewport: { width: innerWidth, height: innerHeight, clientWidth: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth, overflowX: Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth) },
+    visualFixture: Boolean(document.body.getAttribute("data-viewer-visual-fixture")),
+    activeElement: (() => { const node = document.activeElement; return node ? { tag: node.tagName, id: node.id || null, className: node.className || null, ariaLabel: node.getAttribute?.('aria-label') || null, kind: node.getAttribute?.('data-hotspot-kind') || null } : null; })(),
     hitTest: { selection: stackAt(selection ? rect(selection) : null), feed: stackAt(feed ? rect(feed) : null) },
     bodyText: document.body.innerText,
   });
@@ -318,6 +367,16 @@ async function waitForFeedStatus(status) {
   return evalJson(probe);
 }
 
+async function waitForProductionHotspots() {
+  const end = Date.now() + 10_000;
+  while (Date.now() < end) {
+    const result = await evalJson(probe);
+    if (result.visualFixture === false && result.hotspots?.some((hotspot) => hotspot.kind === "goal" && hotspot.rect?.width > 0 && hotspot.rect?.height > 0)) return result;
+    await browserRaw(["wait", "100"]);
+  }
+  return evalJson(probe);
+}
+
 async function openFixture(port, options) {
   await browserJson(["open", fixtureUrl(port, options)], { timeout: 45_000 });
   await browserJson(["set", "viewport", String(options.width || 390), String(options.height || 844)]);
@@ -330,7 +389,39 @@ async function clickVisible(selector) {
   return { selector };
 }
 
+async function clickVisibleInPlace(selector) {
+  const selectorLiteral = JSON.stringify(selector);
+  const target = await evalJson(`(() => { const node = document.querySelector(${selectorLiteral}); if (!node) throw new Error("missing visible target"); const rect = node.getBoundingClientRect(); const x = Math.max(1, Math.min(innerWidth - 1, rect.left + Math.max(1, rect.width / 2))); const y = Math.max(1, Math.min(innerHeight - 1, rect.top + Math.max(1, rect.height / 2))); const visible = rect.width > 0 && rect.height > 0 && rect.top >= 0 && rect.bottom <= innerHeight; const topHit = document.elementsFromPoint(x, y).slice(0, 4).map((hit) => ({ tag: hit.tagName, className: hit.className || null, kind: hit.getAttribute?.("data-hotspot-kind") || null })); return JSON.stringify({ visible, rect: { x: Math.round(rect.x), y: Math.round(rect.y), right: Math.round(rect.right), bottom: Math.round(rect.bottom) }, topHit }); })()`);
+  assert(target.visible, `target is not visible in place: ${selector}`, target);
+  const x = Math.round((target.rect.x + target.rect.right) / 2);
+  const y = Math.round((target.rect.y + target.rect.bottom) / 2);
+  await browserJson(["mouse", "move", String(x), String(y)]);
+  await browserJson(["mouse", "down"]);
+  await browserJson(["mouse", "up"]);
+  return { selector, target };
+}
+
+async function clickRecordedRect(rect, description) {
+  assert(rect?.width > 0 && rect?.height > 0 && rect.x >= 0 && rect.y >= 0, `${description} is not visible in place`, rect);
+  const x = Math.round((rect.x + rect.right) / 2);
+  const y = Math.round((rect.y + rect.bottom) / 2);
+  await browserJson(["mouse", "move", String(x), String(y)]);
+  await browserJson(["mouse", "down"]);
+  await browserJson(["mouse", "up"]);
+  return { rect, x, y };
+}
+
 async function waitShort() { await browserRaw(["wait", "180"]); }
+
+async function waitForTooltip() {
+  const end = Date.now() + 5_000;
+  while (Date.now() < end) {
+    const result = await evalJson(probe);
+    if (result.tooltip) return result;
+    await browserRaw(["wait", "100"]);
+  }
+  return evalJson(probe);
+}
 
 function assertBase(label, result, expectedStatus) {
   assert(result.runtime?.pixelWorldRuntimeStatus === "ready", `${label}: runtime not ready`, result);
@@ -403,18 +494,16 @@ async function runInteractions(port) {
     assert(hotspot.tabIndex >= 0 || hotspot.role === "button" || hotspot.tag === "BUTTON" || visible(hotspot.label), `A4: hotspot ${hotspot.kind} has no keyboard/accessibility affordance`, hotspot);
   }
   const beforeInteractionState = before.runtime || {};
-  await clickVisible('[data-hotspot-kind="goal"]');
-  await waitShort();
-  const afterPointerHotspot = await evalJson(probe);
-  assert(afterPointerHotspot.tooltip?.text?.includes("Goal: stabilize the first production line"), "A4: visible hotspot click did not expose a goal explanation", afterPointerHotspot.tooltip);
-  await clickVisible('.pixel-world-canvas__hotspot-tooltip-close');
+  const goalClick = await clickVisibleInPlace('[data-hotspot-kind="goal"]');
+  const afterPointerHotspot = await waitForTooltip();
+  assert(afterPointerHotspot.tooltip?.text?.includes("Goal: stabilize the first production line"), "A4: visible hotspot click did not expose a goal explanation", { tooltip: afterPointerHotspot.tooltip, goalClick });
+  await clickRecordedRect(afterPointerHotspot.tooltip.close?.rect, "A4 tooltip close control");
   await waitShort();
   const afterPointerClose = await evalJson(probe);
   assert(!afterPointerClose.tooltip, "A4: visible tooltip close control did not dismiss the explanation", afterPointerClose);
   await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="blocker"]'); if (!node) throw new Error("missing blocker hotspot"); node.scrollIntoView({ block: "center" }); node.focus?.(); return JSON.stringify({ active: document.activeElement === node, tag: node.tagName }); })()`);
   await browserRaw(["press", "Enter"]);
-  await waitShort();
-  const afterHotspot = await evalJson(probe);
+  const afterHotspot = await waitForTooltip();
   const explanation = afterHotspot.bodyText.includes("Blocker: iron input is exhausted") || afterHotspot.bodyText.includes("阻塞") || afterHotspot.bodyText.includes("iron input");
   assert(explanation, "A4: blocker hotspot did not expose a readable explanation after keyboard activation", { hotspots: afterHotspot.hotspots, bodyText: afterHotspot.bodyText.slice(-2500) });
   const afterHotspotState = afterHotspot.runtime || {};
@@ -464,6 +553,89 @@ async function runViewportMatrix(port) {
   summary.viewports.resize = resized;
 }
 
+async function runShortLandscapeMatrix(port) {
+  for (const viewport of shortLandscapeViewports) {
+    await openFixture(port, { status: "ready", locale: "en", width: viewport.width, height: viewport.height });
+    const before = await waitForFeedStatus("ready");
+    await clickVisible('[data-viewer-overlay="feed"] > summary');
+    await waitShort();
+    const opened = await evalJson(probe);
+    const feedRect = opened.feed?.rect;
+    const summaryRect = opened.feed?.summaryRect;
+    assert(opened.feed?.open === true, `A3/${viewport.name}: Feed did not open`, opened.feed);
+    assert(feedRect?.width > 0 && feedRect?.height > 0, `A3/${viewport.name}: Feed has no usable area`, opened.feed);
+    const viewportHeight = Number(opened.viewport?.height);
+    const feedTop = Number(feedRect?.y);
+    const feedBottom = Number(feedRect?.bottom);
+    const feedWithinViewport = Number.isFinite(viewportHeight) && Number.isFinite(feedTop) && Number.isFinite(feedBottom)
+      && feedTop >= 0 && feedBottom <= viewportHeight;
+    assert(feedWithinViewport, `A3/${viewport.name}: Feed leaves the viewport`, { feed: feedRect, viewport: opened.viewport, feedTop, feedBottom, viewportHeight });
+    assert(feedRect.height >= Math.max(48, (summaryRect?.height || 0) + 8), `A3/${viewport.name}: Feed is too short for its summary`, { feed: feedRect, summary: summaryRect });
+    assert(opened.feed.clientHeight > 0, `A3/${viewport.name}: Feed client height is zero`, opened.feed);
+    assert(!intersects(feedRect, opened.primary?.rect), `A3/${viewport.name}: Feed overlaps Next Move`, { feed: feedRect, primary: opened.primary?.rect });
+    assert(!intersects(feedRect, opened.receipt?.rect), `A3/${viewport.name}: Feed overlaps Action Receipt`, { feed: feedRect, receipt: opened.receipt?.rect });
+    await browserRaw(["scroll", "down", "320", "--selector", '[data-viewer-overlay="feed"]']);
+    await waitShort();
+    const feedScrolled = await evalJson(probe);
+    assert(feedScrolled.feed?.scrollTop > 0 || feedScrolled.feed?.scrollHeight <= feedScrolled.feed?.clientHeight, `A3/${viewport.name}: expanded Feed detail could not scroll`, feedScrolled.feed);
+    await browserRaw(["scroll", "down", "320", "--selector", '[data-shell-region="next-move-primary"]']);
+    await waitShort();
+    const primaryScrolled = await evalJson(probe);
+    const actionRect = primaryScrolled.primary?.actionRect;
+    assert(primaryScrolled.primary?.scrollTop > 0 || primaryScrolled.primary?.scrollHeight <= primaryScrolled.primary?.clientHeight, `A3/${viewport.name}: Next Move detail could not scroll`, primaryScrolled.primary);
+    assert(actionRect?.width > 0 && actionRect?.height > 0 && actionRect.y >= 0 && actionRect.bottom <= viewportHeight, `A3/${viewport.name}: Next Move action control is not reachable after scroll`, { primary: primaryScrolled.primary, viewport: primaryScrolled.viewport });
+    const screenshot = join(outDir, `a3-${viewport.name}-feed-open.png`);
+    await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+    summary.shortLandscape[viewport.name] = { viewport, before, opened: { ...opened, screenshot, feedScrolled: feedScrolled.feed, primaryScrolled: primaryScrolled.primary } };
+    await clickVisible('[data-viewer-overlay="feed"] > summary');
+  }
+}
+
+async function runProductionHotspotRegression(port) {
+  // Keep the deterministic bridge/feed transport, but omit every visual-fixture
+  // query and body marker. This exercises production overlay enablement rather
+  // than allowing fixture-only controls to mask it.
+  await openFixture(port, { status: "ready", locale: "zh-CN", width: 390, height: 844, visualFixture: false });
+  await waitForFeedStatus("ready");
+  const initial = await waitForProductionHotspots();
+  assert(initial.visualFixture === false, "R2/production: visual fixture marker unexpectedly enabled", initial);
+  assert(initial.hotspots.length >= 2, "R2/production: production path did not expose hotspot buttons", initial.hotspots);
+  assert(initial.hotspots.every((hotspot) => hotspot.tag === "BUTTON" && hotspot.tabIndex >= 0), "R2/production: hotspot is not keyboard reachable", initial.hotspots);
+
+  const zhGoalClick = await clickVisibleInPlace('[data-hotspot-kind="goal"]');
+  const zhGoal = await waitForTooltip();
+  assert(zhGoal.visualFixture === false, "R2/zh-CN: visual fixture marker unexpectedly enabled", zhGoal);
+  assert(zhGoal.tooltip?.text?.includes("目标"), "R2/zh-CN: tooltip kind did not localize", { tooltip: zhGoal.tooltip, goalClick: zhGoalClick });
+  assert(zhGoal.tooltip?.close?.ariaLabel?.includes("关闭"), "R2/zh-CN: tooltip close label did not localize", zhGoal.tooltip);
+  await clickRecordedRect(zhGoal.tooltip.close?.rect, "R2/zh-CN tooltip close control");
+  await waitShort();
+  const zhClosed = await evalJson(probe);
+  assert(!zhClosed.tooltip, "R2/zh-CN: visible tooltip close did not dismiss", zhClosed);
+
+  await evalJson(`(() => { const node = document.querySelector('[data-hotspot-kind="blocker"]'); if (!node) throw new Error("missing production blocker hotspot"); node.scrollIntoView({ block: "center" }); node.focus(); return JSON.stringify({ active: document.activeElement === node }); })()`);
+  await browserRaw(["press", "Enter"]);
+  const keyboardOpened = await waitForTooltip();
+  assert(keyboardOpened.tooltip?.text?.includes("阻塞"), "R2/production: keyboard inspection did not expose localized blocker tooltip", keyboardOpened);
+  let closeFocused = false;
+  for (let tab = 0; tab < 8; tab += 1) {
+    await browserRaw(["press", "Tab"]);
+    const focus = await evalJson(probe);
+    if (focus.activeElement?.className?.includes("pixel-world-canvas__hotspot-tooltip-close")) {
+      closeFocused = true;
+      assert(focus.activeElement.ariaLabel?.includes("关闭"), "R2/production: focused close control has wrong localized label", focus.activeElement);
+      break;
+    }
+  }
+  assert(closeFocused, "R2/production: Tab could not focus the tooltip close control", await evalJson(probe));
+  await browserRaw(["press", "Escape"]);
+  await waitShort();
+  const afterTabEscape = await evalJson(probe);
+  assert(!afterTabEscape.tooltip, "R2/production: Escape on focused tooltip close did not dismiss", afterTabEscape);
+  const screenshot = join(outDir, "r2-production-zh-hotspot-tab-close.png");
+  await browserRaw(["screenshot", screenshot], { timeout: 20_000 });
+  summary.productionHotspot = { initial, zhGoal, zhClosed, keyboardOpened, afterTabEscape, screenshot };
+}
+
 async function main() {
   if (!skipBuild) {
     const build = spawnSync("npm", ["--prefix", "crates/oasis7_viewer", "run", "build:viewer:bundle"], { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
@@ -478,9 +650,15 @@ async function main() {
   const port = address.port;
   try {
     closeBrowser();
-    await runStatusMatrix(port);
-    await runViewportMatrix(port);
-    await runInteractions(port);
+    if (onlyProduction) {
+      await runProductionHotspotRegression(port);
+    } else {
+      await runStatusMatrix(port);
+      await runViewportMatrix(port);
+      await runShortLandscapeMatrix(port);
+      await runProductionHotspotRegression(port);
+      await runInteractions(port);
+    }
     const consoleOutput = await browserRaw(["console"]);
     writeFileSync(join(outDir, "browser-console.log"), consoleOutput, "utf8");
     assert(!/\[(?:error|pageerror)\]|\b(?:fatal|CONTEXT_LOST_WEBGL)\b/i.test(consoleOutput), "browser console contains runtime errors", { consoleOutput });

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -2131,7 +2131,7 @@
       }
       .pixel-world-hotspot {
         position: absolute;
-        z-index: 4;
+        z-index: 7;
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -2136,7 +2136,10 @@
         align-items: center;
         justify-content: center;
         border-radius: 999px;
-        pointer-events: none;
+        appearance: none;
+        padding: 0;
+        pointer-events: auto;
+        cursor: pointer;
         font-family: var(--font-mono);
         font-size: 10px;
         font-weight: 800;
@@ -2228,7 +2231,9 @@
         border-color: rgba(248, 113, 113, 0.4);
         color: var(--bad);
       }
-      .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 7; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: none; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+      .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 45; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); display: flex; align-items: flex-start; gap: 8px; padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: auto; overflow-wrap: anywhere; }
+      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; }
+      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 auto; min-width: 22px; min-height: 22px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 5px; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
       .pixel-world-canvas__selection {
         position: absolute;
         z-index: 6;

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -2244,8 +2244,8 @@
         color: var(--bad);
       }
       .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 45; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); display: flex; align-items: flex-start; gap: 8px; padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: auto; overflow-wrap: anywhere; }
-      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; }
-      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 auto; min-width: 22px; min-height: 22px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 5px; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
+      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; max-height: calc(var(--hotspot-tooltip-max-height, 100dvh - 20px) - 12px); overflow-y: auto; }
+      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 44px; width: 44px; height: 44px; min-width: 44px; min-height: 44px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 0; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
       .pixel-world-canvas__selection {
         position: absolute;
         z-index: 6;
@@ -2779,7 +2779,7 @@
           width: 20px;
           height: 20px;
         }
-        .pixel-world-hotspot {
+        .pixel-world-hotspot__glyph {
           font-size: 11px;
           box-shadow: 0 0 24px rgba(208, 168, 91, 0.54), 0 0 0 5px rgba(208, 168, 91, 0.08);
         }

--- a/crates/oasis7_viewer/software_safe.html
+++ b/crates/oasis7_viewer/software_safe.html
@@ -2132,10 +2132,12 @@
       .pixel-world-hotspot {
         position: absolute;
         z-index: 7;
+        width: 44px;
+        height: 44px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border-radius: 999px;
+        border-radius: 0;
         appearance: none;
         padding: 0;
         pointer-events: auto;
@@ -2143,18 +2145,28 @@
         font-family: var(--font-mono);
         font-size: 10px;
         font-weight: 800;
+        color: transparent;
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+      }
+      .pixel-world-hotspot__glyph {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
         color: var(--bg-deep);
         background: rgba(208, 168, 91, 0.88);
         border: 1px solid rgba(255, 230, 180, 0.8);
         box-shadow: 0 0 18px rgba(208, 168, 91, 0.35);
       }
-      .pixel-world-hotspot[data-hotspot-kind="blocker"] {
+      .pixel-world-hotspot[data-hotspot-kind="blocker"] .pixel-world-hotspot__glyph {
         color: #250b06;
         background: rgba(229, 143, 118, 0.95);
         border-color: rgba(255, 190, 170, 0.9);
         box-shadow: 0 0 24px rgba(229, 143, 118, 0.52), 0 0 0 5px rgba(229, 143, 118, 0.08);
       }
-      .pixel-world-hotspot[data-hotspot-kind="goal"] {
+      .pixel-world-hotspot[data-hotspot-kind="goal"] .pixel-world-hotspot__glyph {
         color: #1d1200;
         background: rgba(208, 168, 91, 0.96);
         border-color: rgba(255, 230, 180, 0.95);

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -400,6 +400,37 @@ describe("fullscreen map shell contract", () => {
     expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next[^{]*\{[^}]*grid-column\s*:\s*1\s*\/\s*-1/i);
     expect(mobileBlock).not.toMatch(/\[data-viewer-overlay=["']next-move["']\][^{]*\{[^}]*overflow\s*:\s*auto/i);
   });
+
+  it("keeps an expanded World Feed inside the safe area above Next Move and Action Receipt", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    const tabletBlock = terminalShellCss.match(/@media\s*\(max-width:\s*1240px\)[\s\S]*?(?=@media\s*\(max-width:\s*640px\))/i)?.[0] || "";
+    const mobileBlock = terminalShellCss.match(/@media\s*\(max-width:\s*640px\)[\s\S]*$/i)?.[0] || "";
+    expect(tabletBlock).toMatch(/\[data-viewer-overlay=["']feed["']\]\[open\][^{]*\{[^}]*position\s*:\s*fixed/i);
+    expect(tabletBlock).toMatch(/\[data-viewer-overlay=["']feed["']\]\[open\][^{]*\{[^}]*bottom\s*:\s*300px/i);
+    expect(tabletBlock).toMatch(/\[data-viewer-overlay=["']feed["']\]\[open\][^{]*\{[^}]*overflow-y\s*:\s*auto/i);
+    expect(mobileBlock).toMatch(/\[data-viewer-overlay=["']feed["']\]\[open\][^{]*\{[^}]*top\s*:\s*160px/i);
+    expect(mobileBlock).toMatch(/\[data-viewer-overlay=["']feed["']\]\[open\][^{]*\{[^}]*bottom\s*:\s*calc\(144px\s*\+\s*min\(38dvh,\s*280px\)\s*\+\s*8px\)/i);
+  });
+
+  it("moves the selected chip when normal AppShell places World Summary between Host and Feed", async () => {
+    const [{ terminalShellCss }, mainSource] = await Promise.all([
+      readViewerHtml(),
+      readFile("software_safe_src/main.jsx", "utf8"),
+    ]);
+    expect(mainSource).toMatch(/<PixelWorldHost[\s\S]*<WorldSummaryPanel[\s\S]*<WorldFeedSurface/);
+    const tabletBlock = terminalShellCss.match(/@media\s*\(max-width:\s*1240px\)[\s\S]*?(?=@media\s*\(max-width:\s*640px\))/i)?.[0] || "";
+    expect(tabletBlock).toMatch(/\.stack:has\(>\s*\[data-viewer-overlay=["']feed["']\]:not\(\[open\]\)\)\s*>\s*\[data-viewer-overlay=["']world-hud["']\][^{]*\{[^}]*top:\s*160px/i);
+  });
+
+  it("allows long Next Move and blocker copy to wrap and remain scrollable on mobile", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    const mobileBlock = terminalShellCss.match(/@media\s*\(max-width:\s*640px\)[\s\S]*$/i)?.[0] || "";
+    expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next\s+\.pixel-world-command-cell__detail[^{]*\{[^}]*display\s*:\s*block/i);
+    expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next\s+\.pixel-world-command-cell__detail[^{]*\{[^}]*overflow-y\s*:\s*auto/i);
+    expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next\s+\.pixel-world-command-cell__value[^{]*\{[^}]*display\s*:\s*block/i);
+    expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next\s+\.pixel-world-command-cell__value[^{]*\{[^}]*-webkit-line-clamp\s*:\s*unset/i);
+    expect(mobileBlock).toMatch(/\.pixel-world-command-cell--next\s+\.pixel-world-command-cell__value[^{]*\{[^}]*overflow-wrap\s*:\s*anywhere/i);
+  });
 });
 
 describe("headed visual smoke serving contract", () => {

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -188,6 +188,8 @@ describe("fullscreen map shell contract", () => {
     const { viewerHtml, compatHtml } = await readViewerHtml();
     for (const html of [viewerHtml, compatHtml]) {
       const hotspot = findRule(html, /\.pixel-world-hotspot(?:\s|$)/);
+      expect(numericDeclaration(hotspot, "border-radius")).toBe(0);
+      expect(numericDeclaration(findRule(html, /\.pixel-world-hotspot__glyph(?:\s|$)/), "border-radius")).toBe(999);
       const selectedEntity = findRule(html, /\.pixel-world-entity\[data-selected="true"\],/);
       expect(numericDeclaration(hotspot, "z-index")).toBeGreaterThan(numericDeclaration(selectedEntity, "z-index"));
     }
@@ -490,6 +492,24 @@ describe("headed visual smoke serving contract", () => {
   it("serves viewer CSS with text/css so fullscreen geometry is applied in the browser", async () => {
     const smokeSource = await readFile("scripts/pixel-world-fragment-visual-smoke.mjs", "utf8");
     expect(/case\s+["']\.css["']\s*:\s*return\s+["']text\/css(?:;\s*charset=utf-8)?["']/i.test(smokeSource)).toBe(true);
+  });
+});
+
+describe("hotspot overlay contract", () => {
+  it("renders hotspot explanations in a top-level overlay above expanded Feed", async () => {
+    const [hotspotSource, hostSource, terminalShellCss] = await Promise.all([
+      readFile("software_safe_src/pixel_world_hotspot.jsx", "utf8"),
+      readFile("software_safe_src/pixel_world_host.jsx", "utf8"),
+      readFile("viewer_terminal_shell.css", "utf8"),
+    ]);
+    expect(hostSource).toMatch(/PixelWorldHotspotTooltip/);
+    expect(hotspotSource).toMatch(/<Portal>/);
+    expect(hotspotSource).toMatch(/data-hotspot-tooltip/);
+
+    const tooltipRule = findRule(terminalShellCss, /\.pixel-world-canvas__hotspot-tooltip/);
+    expect(tooltipRule).not.toBeNull();
+    expect(hasDeclaration(tooltipRule, "position", /fixed/)).toBe(true);
+    expect(numericDeclaration(tooltipRule, "z-index")).toBeGreaterThan(60);
   });
 });
 

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -189,6 +189,10 @@ describe("fullscreen map shell contract", () => {
     for (const html of [viewerHtml, compatHtml]) {
       const hotspot = findRule(html, /\.pixel-world-hotspot(?:\s|$)/);
       expect(numericDeclaration(hotspot, "border-radius")).toBe(0);
+      const close = findRule(html, /\.pixel-world-canvas__hotspot-tooltip-close(?:\s|$)/);
+      expect(numericDeclaration(close, "min-width")).toBe(44);
+      expect(numericDeclaration(close, "min-height")).toBe(44);
+      expect(html).not.toMatch(/\.pixel-world-hotspot\s*\{[^}]*box-shadow:\s*0/);
       expect(numericDeclaration(findRule(html, /\.pixel-world-hotspot__glyph(?:\s|$)/), "border-radius")).toBe(999);
       const selectedEntity = findRule(html, /\.pixel-world-entity\[data-selected="true"\],/);
       expect(numericDeclaration(hotspot, "z-index")).toBeGreaterThan(numericDeclaration(selectedEntity, "z-index"));

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -21,6 +21,11 @@ function hasDeclaration(rule, property, valuePattern) {
   return Boolean(match && (!valuePattern || valuePattern.test(match[1])));
 }
 
+function numericDeclaration(rule, property) {
+  const declarationPattern = new RegExp(`(?:^|[;\\s])${property}\\s*:\\s*([0-9]+)`, "i");
+  return Number(rule?.declarations?.match(declarationPattern)?.[1]);
+}
+
 function findRule(source, selectorPattern) {
   return cssRules(source, selectorPattern)[0] || null;
 }
@@ -137,6 +142,54 @@ describe("fullscreen map shell contract", () => {
         expect(/bottom\s*:|inset\s*:[^;]*\d/i.test(sheetDeclarations), routePanel).toBe(true);
         expect(/max-height\s*:/i.test(sheetDeclarations), routePanel).toBe(true);
       }
+    }
+  });
+
+  it("keeps expanded Feed usable in short landscape viewports", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*1240px\)\s*and\s*\(max-height:\s*640px\)[\s\S]*?\[data-viewer-overlay="feed"\]\[open\][\s\S]*?top:\s*\d+px;[\s\S]*?bottom:\s*calc\([^;]+\);[\s\S]*?max-height:\s*calc\(100dvh[^;]*\)/i,
+    );
+  });
+
+  it("compacts short-landscape Feed chrome while preserving its title and status", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*1240px\)\s*and\s*\(max-height:\s*640px\)[\s\S]*?\[data-viewer-overlay="feed"\]\[open\]\s+\.panel__eyebrow,[\s\S]*?\[data-viewer-overlay="feed"\]\[open\]\s+\.panel__meta-copy\s*\{[\s\S]*?display:\s*none/i,
+    );
+  });
+
+  it("bounds short-landscape Next Move content inside its receipt-safe band", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*1240px\)\s*and\s*\(max-height:\s*640px\)[\s\S]*?\[data-viewer-overlay="next-move"\][\s\S]*?height:\s*min\(42dvh,\s*calc\(100dvh\s*-\s*72px\s*-\s*min\(12dvh,\s*48px\)\s*-\s*16px\s*-\s*8px\s*-\s*96px\)\);[\s\S]*?max-height:\s*none;[\s\S]*?overflow-y:\s*auto[\s\S]*?\[data-viewer-overlay="next-move"\]\s+\[data-shell-region="next-move-primary"\][\s\S]*?overflow-y:\s*auto/i,
+    );
+  });
+
+  it("reserves a meaningful Feed body at both supported short-landscape heights", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /height:\s*min\(42dvh,\s*calc\(100dvh\s*-\s*72px\s*-\s*min\(12dvh,\s*48px\)\s*-\s*16px\s*-\s*8px\s*-\s*96px\)\)/i,
+    );
+    const feedSummaryHeight = 64;
+    const feedBodyMinimum = 32;
+    for (const viewportHeight of [390, 360]) {
+      const receiptHeight = Math.min(viewportHeight * 0.12, 48);
+      const nextMoveHeight = Math.min(
+        viewportHeight * 0.42,
+        viewportHeight - 72 - receiptHeight - 16 - 8 - feedSummaryHeight - feedBodyMinimum,
+      );
+      const feedHeight = viewportHeight - 72 - receiptHeight - 16 - 8 - nextMoveHeight;
+      expect(feedHeight - feedSummaryHeight, `${viewportHeight}px`).toBeGreaterThanOrEqual(feedBodyMinimum);
+    }
+  });
+
+  it("keeps hotspots above selected entity markers for pointer inspection", async () => {
+    const { viewerHtml, compatHtml } = await readViewerHtml();
+    for (const html of [viewerHtml, compatHtml]) {
+      const hotspot = findRule(html, /\.pixel-world-hotspot(?:\s|$)/);
+      const selectedEntity = findRule(html, /\.pixel-world-entity\[data-selected="true"\],/);
+      expect(numericDeclaration(hotspot, "z-index")).toBeGreaterThan(numericDeclaration(selectedEntity, "z-index"));
     }
   });
 

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_bevy_bridge.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_bevy_bridge.js
@@ -1,3 +1,5 @@
+import { toCanvasPoint } from "./pixel_world_hotspot_projection.js";
+
 function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
@@ -11,27 +13,6 @@ function createInitialCameraState() {
 }
 
 const AMBIENT_FRAME_INTERVAL_MS = 1000 / 12;
-
-function toCanvasPoint(position, worldBounds, width, height, cameraState) {
-  if (!position || !worldBounds) {
-    return null;
-  }
-  const safeWidth = Math.max(1, Number(worldBounds.width_cm) || 1);
-  const safeDepth = Math.max(1, Number(worldBounds.depth_cm) || 1);
-  const normalizedX = clamp(position.x_cm / safeWidth, 0, 1);
-  const normalizedY = clamp(position.y_cm / safeDepth, 0, 1);
-  const baseX = 20 + (normalizedX * Math.max(1, width - 40));
-  const baseY = 20 + (normalizedY * Math.max(1, height - 40));
-  const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
-  const panX = Number(cameraState?.pan_x_px) || 0;
-  const panY = Number(cameraState?.pan_y_px) || 0;
-  const centeredX = baseX - (width / 2);
-  const centeredY = baseY - (height / 2);
-  return {
-    x: (width / 2) + (centeredX * zoom) + panX,
-    y: (height / 2) + (centeredY * zoom) + panY,
-  };
-}
 
 function fallbackPointForEntity(id, width, height, cameraState) {
   const baseX = 36 + ((Math.abs(id.length * 29) % Math.max(40, width - 72)));

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -222,6 +222,14 @@ function pixelWorldVisualState(renderState) {
     visualHotspots: arrayField(state, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity),
   };
 }
+function PixelWorldHostHotspotLayer(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return <For each={visualState().visualHotspots.slice(0, 8)}>{(hotspot, index) => (
+    <PixelWorldHotspot locale={props.locale()} hotspot={hotspot}
+      style={hotspotStyle(hotspot, visualState().worldBounds, index())} onHover={props.onHover}
+      onHotspotInspect={props.onHotspotInspect} onHotspotClear={props.onHotspotClear} />
+  )}</For>;
+}
 function PixelWorldHostVisualLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
   const selection = () => props.selection?.() || visualState().selection;
@@ -265,18 +273,6 @@ function PixelWorldHostVisualLayer(props) {
               title={`${link.kind}:target`}
             />
           </>
-        )}
-      </For>
-      <For each={visualState().visualHotspots.slice(0, 8)}>
-        {(hotspot, index) => (
-          <PixelWorldHotspot
-            locale={props.locale()}
-            hotspot={hotspot}
-            style={hotspotStyle(hotspot, visualState().worldBounds, index())}
-            onHover={props.onHover}
-            onHotspotInspect={props.onHotspotInspect}
-            onHotspotClear={props.onHotspotClear}
-          />
         )}
       </For>
       <Index each={visualState().locations.slice(0, 8)}>
@@ -601,9 +597,10 @@ function PixelWorldCanvasRenderer(props) {
           selection={props.selection}
           onSelect={props.onSelect}
           onHover={props.onHover}
-          onHotspotInspect={setInspectedHotspot}
-          onHotspotClear={() => setInspectedHotspot(null)}
         />
+        <PixelWorldHostHotspotLayer locale={props.locale} renderState={props.renderState}
+          onHover={props.onHover} onHotspotInspect={setInspectedHotspot}
+          onHotspotClear={() => setInspectedHotspot(null)} />
         <Show when={visualState().goalHighlight}>
           <div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">
             {`${tr(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`}
@@ -616,7 +613,7 @@ function PixelWorldCanvasRenderer(props) {
         </Show>
         <Show when={activeHotspot()}>
           <PixelWorldHotspotTooltip
-            locale={props.locale}
+            locale={props.locale()}
             hotspot={activeHotspot()}
             onClose={() => {
               setInspectedHotspot(null);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -7,8 +7,9 @@ import { installPixelWorldRenderDtoProbe, installPixelWorldVisualFixtureHook, pi
 import { pixelWorldSelectedBlockerVisualFixture } from "./pixel_world_visual_fixture_data.js";
 import { pixelWorldReadableAgentLabel, pixelWorldReadableEntityText, pixelWorldSelectedEntityLabel } from "./pixel_world_identity.js";
 import { applyPixelWorldMobileSelectionSafeArea, installPixelWorldMobileSelectionSafeArea } from "./pixel_world_mobile_safe_area.js";
-import { PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
+import { createHotspotFocusRestoration, PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
 import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
+import { pixelWorldHotspotGlyphSize, pixelWorldHotspotStyle } from "./pixel_world_hotspot_projection.js";
 export { pixelWorldSelectedBlockerVisualFixture };
 function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
 const PIXEL_WORLD_RUNTIME_CANVAS_ID = "pixel-world-embedded-runtime-canvas"; const PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID = "pixel-world-renderer-unavailable-message";
@@ -166,18 +167,6 @@ function routeWaypointStyle(link, worldBounds, index, stop) {
     top: `${(from.y + ((to.y - from.y) * ratio)).toFixed(1)}%`,
   };
 }
-function hotspotStyle(hotspot, worldBounds, index) {
-  const sizePx = Math.max(14, Math.min(32, safeNumber(hotspot.size_hint_px, 16)));
-  return {
-    ...toWorldPercentStyle(hotspot.pos, worldBounds, {
-      left: `${20 + ((index % 4) * 16)}%`,
-      top: `${22 + (Math.floor(index / 4) * 16)}%`,
-    }),
-    width: `${sizePx}px`,
-    height: `${sizePx}px`,
-    transform: "translate(-50%, -50%)",
-  };
-}
 function fieldValue(value, snakeName, camelName, fallback = undefined) {
   if (!value || typeof value !== "object") {
     return fallback;
@@ -224,11 +213,15 @@ function pixelWorldVisualState(renderState) {
 }
 function PixelWorldHostHotspotLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
-  return <For each={visualState().visualHotspots.slice(0, 8)}>{(hotspot, index) => (
-    <PixelWorldHotspot locale={props.locale()} hotspot={hotspot}
-      style={hotspotStyle(hotspot, visualState().worldBounds, index())} onHover={props.onHover}
-      onHotspotInspect={props.onHotspotInspect} onHotspotClear={props.onHotspotClear} />
-  )}</For>;
+  return <Index each={visualState().visualHotspots.slice(0, 8)}>{(hotspot, index) => (
+    <PixelWorldHotspot locale={props.locale()} hotspot={hotspot()}
+      style={pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.())}
+      glyphSize={pixelWorldHotspotGlyphSize(hotspot())}
+      onHover={props.onHover}
+      onHotspotInspect={props.onHotspotInspect} onHotspotClear={props.onHotspotClear}
+      onHotspotHoverIntent={props.onHotspotHoverIntent}
+      onHotspotTrigger={props.onHotspotTrigger} onHotspotRestoreFocus={props.onHotspotRestoreFocus} />
+  )}</Index>;
 }
 function PixelWorldHostVisualLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
@@ -539,14 +532,16 @@ export function buildPixelWorldRenderInput(locale = core.state.uiLocale) {
 }
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
+  const hotspotFocus = createHotspotFocusRestoration();
   const visualState = () => pixelWorldVisualState(props.renderState());
   const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
+  const [hoverDismissed, setHoverDismissed] = createSignal(false);
   const activeHotspot = () => {
     const inspected = inspectedHotspot();
     if (inspected?.kind === "hotspot") {
       return visualState().visualHotspots.find((hotspot) => hotspot.id === inspected.id) || null;
     }
-    return props.hoveredHotspot?.() || null;
+    return hoverDismissed() ? null : props.hoveredHotspot?.() || null;
   };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, core.isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
@@ -598,9 +593,11 @@ function PixelWorldCanvasRenderer(props) {
           onSelect={props.onSelect}
           onHover={props.onHover}
         />
-        <PixelWorldHostHotspotLayer locale={props.locale} renderState={props.renderState}
-          onHover={props.onHover} onHotspotInspect={setInspectedHotspot}
-          onHotspotClear={() => setInspectedHotspot(null)} />
+        <PixelWorldHostHotspotLayer locale={props.locale} renderState={props.renderState} cameraState={props.cameraState}
+          onHover={props.onHover} onHotspotInspect={(selection) => { setHoverDismissed(false); setInspectedHotspot(selection); }}
+          onHotspotHoverIntent={() => setHoverDismissed(false)}
+          onHotspotClear={() => { setHoverDismissed(true); setInspectedHotspot(null); }}
+          onHotspotTrigger={hotspotFocus.remember} onHotspotRestoreFocus={hotspotFocus.restore} />
         <Show when={visualState().goalHighlight}>
           <div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">
             {`${tr(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`}
@@ -612,14 +609,17 @@ function PixelWorldCanvasRenderer(props) {
           </div>
         </Show>
         <Show when={activeHotspot()}>
-          <PixelWorldHotspotTooltip
-            locale={props.locale()}
-            hotspot={activeHotspot()}
-            onClose={() => {
-              setInspectedHotspot(null);
-              props.onHover(null);
-            }}
-          />
+            <PixelWorldHotspotTooltip
+              locale={props.locale()}
+              hotspot={activeHotspot()}
+              onHoverLeave={() => props.onHover(null)}
+              onClose={() => {
+                setHoverDismissed(true);
+                setInspectedHotspot(null);
+                props.onHover(null);
+                hotspotFocus.restore();
+              }}
+            />
         </Show>
       </div>
       <Show when={visualState().selection}>
@@ -1521,6 +1521,7 @@ export function PixelWorldHost(props) {
         <PixelWorldCanvasRenderer
           locale={locale}
           rendererStatus={rendererStatus}
+          cameraState={cameraState}
           renderInput={renderInput}
           renderState={renderState}
           selection={selectedEntity}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -7,12 +7,11 @@ import { installPixelWorldRenderDtoProbe, installPixelWorldVisualFixtureHook, pi
 import { pixelWorldSelectedBlockerVisualFixture } from "./pixel_world_visual_fixture_data.js";
 import { pixelWorldReadableAgentLabel, pixelWorldReadableEntityText, pixelWorldSelectedEntityLabel } from "./pixel_world_identity.js";
 import { applyPixelWorldMobileSelectionSafeArea, installPixelWorldMobileSelectionSafeArea } from "./pixel_world_mobile_safe_area.js";
+import { PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
+import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
 export { pixelWorldSelectedBlockerVisualFixture };
-function tr(locale, zh, en) {
-  return core.isLocaleZh(locale) ? zh : en;
-}
-const PIXEL_WORLD_RUNTIME_CANVAS_ID = "pixel-world-embedded-runtime-canvas";
-const PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID = "pixel-world-renderer-unavailable-message";
+function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
+const PIXEL_WORLD_RUNTIME_CANVAS_ID = "pixel-world-embedded-runtime-canvas"; const PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID = "pixel-world-renderer-unavailable-message";
 const pixelWorldFocusUiSessionState = {
   focusMode: false,
   commandDrawerOpen: false,
@@ -270,14 +269,14 @@ function PixelWorldHostVisualLayer(props) {
       </For>
       <For each={visualState().visualHotspots.slice(0, 8)}>
         {(hotspot, index) => (
-          <div
-            class="pixel-world-hotspot"
-            data-hotspot-kind={hotspot.kind}
+          <PixelWorldHotspot
+            locale={props.locale()}
+            hotspot={hotspot}
             style={hotspotStyle(hotspot, visualState().worldBounds, index())}
-            title={`${hotspot.kind}:${hotspot.label}`}
-          >
-            <span>{hotspot.kind === "blocker" ? "!" : hotspot.kind === "goal" ? "G" : "i"}</span>
-          </div>
+            onHover={props.onHover}
+            onHotspotInspect={props.onHotspotInspect}
+            onHotspotClear={props.onHotspotClear}
+          />
         )}
       </For>
       <Index each={visualState().locations.slice(0, 8)}>
@@ -545,6 +544,14 @@ export function buildPixelWorldRenderInput(locale = core.state.uiLocale) {
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
   const visualState = () => pixelWorldVisualState(props.renderState());
+  const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
+  const activeHotspot = () => {
+    const inspected = inspectedHotspot();
+    if (inspected?.kind === "hotspot") {
+      return visualState().visualHotspots.find((hotspot) => hotspot.id === inspected.id) || null;
+    }
+    return props.hoveredHotspot?.() || null;
+  };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, core.isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
   createEffect(() => {
@@ -594,6 +601,8 @@ function PixelWorldCanvasRenderer(props) {
           selection={props.selection}
           onSelect={props.onSelect}
           onHover={props.onHover}
+          onHotspotInspect={setInspectedHotspot}
+          onHotspotClear={() => setInspectedHotspot(null)}
         />
         <Show when={visualState().goalHighlight}>
           <div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">
@@ -605,10 +614,15 @@ function PixelWorldCanvasRenderer(props) {
             {`${tr(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`}
           </div>
         </Show>
-        <Show when={props.hoveredHotspot?.()}>
-          <div class="pixel-world-canvas__hotspot-tooltip" data-hotspot-tooltip role="status">
-            {props.hoveredHotspot().label}
-          </div>
+        <Show when={activeHotspot()}>
+          <PixelWorldHotspotTooltip
+            locale={props.locale}
+            hotspot={activeHotspot()}
+            onClose={() => {
+              setInspectedHotspot(null);
+              props.onHover(null);
+            }}
+          />
         </Show>
       </div>
       <Show when={visualState().selection}>
@@ -662,13 +676,8 @@ function receiptConfidenceLabel(confidence, locale, state) {
   return value === "world_delta" ? tr(locale, "世界变化已确认", "World change confirmed") : value === "accepted_intent" ? tr(locale, "行动已接受", "Action accepted") : value === "none" ? tr(locale, "等待确认", "Waiting for confirmation") : tr(locale, "状态已记录", "Status recorded");
 }
 function worldReadoutStatus(locale, renderState) {
-  renderState?.(); const status = String(core.state.connectionStatus || "").toLowerCase(); const feed = core.state.worldFeed || {};
-  const warn = (label) => ({ label, className: "badge badge--warn" });
-  if (String(feed.status || "").toLowerCase() === "unavailable") return warn(tr(locale, "不可用", "UNAVAILABLE"));
-  if (feed.stale) return warn(tr(locale, "陈旧", "STALE"));
-  if (status === "connecting" || status === "reconnecting") return warn(tr(locale, "正在重连", "RECONNECTING"));
-  if (status !== "connected") return warn(tr(locale, "离线", "OFFLINE"));
-  return ["ready", "replay", "empty"].includes(String(feed.status || "").toLowerCase()) ? { label: "LIVE", className: "badge badge--good" } : warn(tr(locale, "同步中", "SYNCING"));
+  renderState?.();
+  return resolvePixelWorldReadoutStatus(locale, core.state.connectionStatus, core.state.worldFeed);
 }
 const DIRECT_PIXEL_WORLD_NEXT_MOVE_KINDS = new Set(["claim_first_agent", "claim_starter_oc"]);
 const PIXEL_WORLD_PENDING_GAMEPLAY_STAGES = new Set(["accepted", "submitted", "queued", "ack", "registering", "signing", "sent"]);
@@ -699,6 +708,7 @@ export function resolvePixelWorldDirectNextMoveAction(gameplay, executeKind) {
 }
 function PixelWorldCommercialHud(props) {
   const surface = () => props.renderState().commercial_surface; const readoutStatus = () => worldReadoutStatus(props.locale(), props.renderState);
+  const readoutFeedStatus = () => String(core.state.worldFeed?.status || "loading").trim().toLowerCase() || "loading";
   const activeAgentId = () => String(surface()?.active_agent_id || "").trim(); const activeAgent = () => props.renderState().agents.find((agent) => agent.id === activeAgentId()); const activeAgentLabel = () => pixelWorldReadableAgentLabel(activeAgent(), activeAgentId(), core.isLocaleZh(props.locale())) || tr(props.locale(), "未选择 Agent", "No Agent selected");
   const executableNextMoveKinds = new Set([
     "gameplay_action",
@@ -805,7 +815,7 @@ function PixelWorldCommercialHud(props) {
       </div>
       <Show when={!props.focusMode?.()}><PixelWorldActionReceipt id="viewer-action-receipt" locale={props.locale} surface={surface} /></Show>
       <div class="pixel-world-readout badge-row">
-        <span class={readoutStatus().className}>{readoutStatus().label}</span>
+        <span class={readoutStatus().className} data-world-feed-readout-status={readoutFeedStatus()}>{readoutStatus().label}</span>
         <Show when={surface().world_read.tick !== null && surface().world_read.tick !== undefined}>
           <span class="badge badge--accent" data-world-tick={String(surface().world_read.tick)}>{`tick=${surface().world_read.tick}`}</span>
         </Show>

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -393,7 +393,7 @@ function bindFirstSnapshotAgentForTest(core, snapshot) {
     boundAgentId: agentId,
   };
 }
-async function renderPixelWorldHost(snapshot = sampleSnapshot(), search = "?test_api=1&connect=0&locale=en") {
+async function renderPixelWorldHost(snapshot = sampleSnapshot(), search = "?test_api=1&connect=0&locale=en", locale = "en") {
   activeCleanup?.();
   activeCleanup = null;
   vi.resetModules();
@@ -402,10 +402,10 @@ async function renderPixelWorldHost(snapshot = sampleSnapshot(), search = "?test
   document.body.innerHTML = "";
   const core = await import("./legacy_core.js");
   const { PixelWorldHost } = await import("./pixel_world_host.jsx");
-  core.setViewerLocale("en");
+  core.setViewerLocale(locale);
   core.injectSnapshot(snapshot);
   bindFirstSnapshotAgentForTest(core, snapshot);
-  const view = render(() => <PixelWorldHost locale="en" />);
+  const view = render(() => <PixelWorldHost locale={locale} />);
   activeCleanup = view.unmount;
   return {
     core,
@@ -861,6 +861,45 @@ describe("pixel world host", () => {
     expect(canvas.querySelector(".pixel-world-route")).toBeNull();
     expect(canvas.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: Agent 0");
     expect(runtimeMock.deriveRenderState).toHaveBeenCalled();
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps read-only hotspot controls available in production and resolves tooltip locale", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => ({
+      ...buildTestRustRenderState(input),
+      visualHotspots: [{
+        id: "hotspot-blocker",
+        kind: "blocker",
+        label: "缺料阻塞",
+        pos: { x_cm: 5_020_000, y_cm: 2_510_000, z_cm: 0 },
+        sizeHintPx: 20,
+      }],
+    }));
+
+    await renderPixelWorldHost(
+      sampleSnapshot(),
+      "?test_api=1&connect=0&locale=zh-CN",
+      "zh-CN",
+    );
+
+    const marker = await screen.findByRole("button", { name: /阻塞热点：缺料阻塞/ });
+    expect(marker).toHaveProperty("tabIndex", 0);
+    fireEvent.focus(marker);
+    expect(screen.getByRole("status")).toHaveTextContent("阻塞: 缺料阻塞");
+    expect(screen.getByRole("button", { name: "关闭热点说明" })).toBeInTheDocument();
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps hotspot controls painted above decorative route waypoints", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => ({
+      ...buildTestRustRenderState(input),
+      visualHotspots: [{ id: "hotspot-goal", kind: "goal", label: "stabilize the first production line", pos: { x_cm: 5_020_000, y_cm: 2_510_000, z_cm: 0 } }],
+    }));
+
+    await renderPixelWorldHost(sampleSnapshot(), "?test_api=1&connect=0&locale=en&pixel_world_visual_fixture=selected_blocker");
+
+    const marker = await screen.findByRole("button", { name: /Goal hotspot/ });
+    const waypoint = document.querySelector(".pixel-world-route-waypoint--target");
+    expect(waypoint).not.toBeNull();
+    expect(Boolean(waypoint.compareDocumentPosition(marker) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("makes the rendered canvas focusable with a read-only accessible world description", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@solidjs/testing-library";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const runtimeMock = vi.hoisted(() => ({
@@ -861,44 +861,6 @@ describe("pixel world host", () => {
     expect(canvas.querySelector(".pixel-world-route")).toBeNull();
     expect(canvas.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: Agent 0");
     expect(runtimeMock.deriveRenderState).toHaveBeenCalled();
-  }, HEAVY_UI_TEST_TIMEOUT_MS);
-
-  it("shows the exact hotspot label only while its hover identity remains in render state", async () => {
-    runtimeMock.deriveRenderState = vi.fn((input) => ({
-      ...buildTestRustRenderState(input),
-      visualHotspots: [{
-        id: "hotspot-blocker",
-        label: "Blocked route",
-        kind: "blocker",
-        pos: { x_cm: 5_000_000, y_cm: 2_500_000, z_cm: 0 },
-      }],
-    }));
-
-    await renderPixelWorldHost();
-    await waitFor(() => {
-      expect(runtimeMock.onEvent).toEqual(expect.any(Function));
-    });
-
-    runtimeMock.onEvent({
-      type: "hover_entity",
-      selection: { kind: "hotspot", id: "hotspot-blocker" },
-    });
-    await waitFor(() => {
-      expect(document.querySelector("[data-hotspot-tooltip]")).toHaveTextContent("Blocked route");
-    });
-
-    runtimeMock.onEvent({ type: "hover_entity", selection: null });
-    await waitFor(() => {
-      expect(document.querySelector("[data-hotspot-tooltip]")).toBeNull();
-    });
-
-    runtimeMock.onEvent({
-      type: "hover_entity",
-      selection: { kind: "hotspot", id: "removed-hotspot" },
-    });
-    await waitFor(() => {
-      expect(document.querySelector("[data-hotspot-tooltip]")).toBeNull();
-    });
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("makes the rendered canvas focusable with a read-only accessible world description", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { verifyHotspotCameraAndFocus } from "./pixel_world_hotspot_test_helpers.js";
 const runtimeMock = vi.hoisted(() => ({
   deriveRenderState: null,
   mountError: null,
@@ -872,7 +873,7 @@ describe("pixel world host", () => {
         label: "缺料阻塞",
         pos: { x_cm: 5_020_000, y_cm: 2_510_000, z_cm: 0 },
         sizeHintPx: 20,
-      }],
+      }, { id: "hotspot-goal", kind: "goal", label: "稳定生产", pos: { x_cm: 6_000_000, y_cm: 2_000_000, z_cm: 0 } }],
     }));
 
     await renderPixelWorldHost(
@@ -883,9 +884,7 @@ describe("pixel world host", () => {
 
     const marker = await screen.findByRole("button", { name: /阻塞热点：缺料阻塞/ });
     expect(marker).toHaveProperty("tabIndex", 0);
-    fireEvent.focus(marker);
-    expect(screen.getByRole("status")).toHaveTextContent("阻塞: 缺料阻塞");
-    expect(screen.getByRole("button", { name: "关闭热点说明" })).toBeInTheDocument();
+    await verifyHotspotCameraAndFocus(marker, runtimeMock.onEvent);
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("keeps hotspot controls painted above decorative route waypoints", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -1,6 +1,7 @@
 import { createSignal, onCleanup, onMount } from "solid-js";
 import { Portal } from "solid-js/web";
 import { installHotspotTooltipPlacement } from "./pixel_world_tooltip_placement.js";
+import { moveFocusFromHotspotTooltip } from "./pixel_world_hotspot_focus.js";
 
 function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
@@ -168,12 +169,13 @@ export function PixelWorldHotspotTooltip(props) {
       }}
       role="status"
     >
-      <span>{`${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`}</span>
+      <span data-hotspot-tooltip-body>{`${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`}</span>
       <button
         type="button"
         class="pixel-world-canvas__hotspot-tooltip-close"
         aria-label={tr(props.locale, "关闭热点说明", "Close hotspot explanation")}
         onKeyDown={(event) => {
+          if (event.key === "Tab" && moveFocusFromHotspotTooltip(tooltipRef, event.shiftKey)) event.preventDefault();
           if (event.key === "Escape") {
             event.preventDefault();
             event.stopPropagation();

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -1,0 +1,97 @@
+function isZhLocale(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+
+function tr(locale, zh, en) {
+  return isZhLocale(locale) ? zh : en;
+}
+
+export function pixelWorldHotspotKindLabel(locale, kind) {
+  const normalizedKind = String(kind || "info").trim().toLowerCase();
+  if (normalizedKind === "blocker") return tr(locale, "阻塞", "Blocker");
+  if (normalizedKind === "goal") return tr(locale, "目标", "Goal");
+  return tr(locale, "信息", "Info");
+}
+
+export function pixelWorldHotspotAccessibleLabel(locale, hotspot) {
+  const kindLabel = pixelWorldHotspotKindLabel(locale, hotspot?.kind);
+  const label = String(hotspot?.label || hotspot?.id || "").trim();
+  return tr(
+    locale,
+    `${kindLabel}热点：${label}；只读说明。`,
+    `${kindLabel} hotspot: ${label}; read-only explanation.`,
+  );
+}
+
+export function pixelWorldHotspotTooltipId(hotspot) {
+  const id = String(hotspot?.id || hotspot?.kind || "hotspot")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-");
+  return `pixel-world-hotspot-tooltip-${id || "hotspot"}`;
+}
+
+export function PixelWorldHotspot(props) {
+  const hotspot = () => props.hotspot;
+  const selection = () => ({ kind: "hotspot", id: hotspot().id });
+  const inspect = () => {
+    props.onHotspotInspect?.(selection());
+    props.onHover?.(selection());
+  };
+  return (
+    <button
+      type="button"
+      class="pixel-world-hotspot"
+      data-hotspot-kind={hotspot().kind}
+      style={props.style}
+      title={`${hotspot().kind}:${hotspot().label}`}
+      aria-label={pixelWorldHotspotAccessibleLabel(props.locale, hotspot())}
+      aria-describedby={pixelWorldHotspotTooltipId(hotspot())}
+      onFocus={inspect}
+      onBlur={() => props.onHover?.(null)}
+      onMouseEnter={() => props.onHover?.(selection())}
+      onMouseLeave={() => props.onHover?.(null)}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          props.onHotspotClear?.();
+          props.onHover?.(null);
+          event.currentTarget.blur();
+        }
+      }}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        inspect();
+      }}
+    >
+      <span aria-hidden="true">{hotspot().kind === "blocker" ? "!" : hotspot().kind === "goal" ? "G" : "i"}</span>
+    </button>
+  );
+}
+
+export function PixelWorldHotspotTooltip(props) {
+  const hotspot = () => props.hotspot;
+  return (
+    <div
+      id={pixelWorldHotspotTooltipId(hotspot())}
+      class="pixel-world-canvas__hotspot-tooltip"
+      data-hotspot-tooltip
+      role="status"
+    >
+      <span>{`${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`}</span>
+      <button
+        type="button"
+        class="pixel-world-canvas__hotspot-tooltip-close"
+        aria-label={tr(props.locale, "关闭热点说明", "Close hotspot explanation")}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          props.onClose?.();
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -2,6 +2,7 @@ import { createSignal, onCleanup, onMount } from "solid-js";
 import { Portal } from "solid-js/web";
 import { installHotspotTooltipPlacement } from "./pixel_world_tooltip_placement.js";
 import { moveFocusFromHotspotTooltip } from "./pixel_world_hotspot_focus.js";
+import { pixelWorldHotspotIntersectsStage } from "./pixel_world_hotspot_projection.js";
 
 function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
@@ -73,6 +74,7 @@ export function PixelWorldHotspot(props) {
     return point - Math.max(22, Math.min(size - 22, point));
   };
   const hotspot = () => props.hotspot;
+  const visible = () => pixelWorldHotspotIntersectsStage(props.style, stageSize(), Number(props.glyphSize) || 20);
   const selection = () => ({ kind: "hotspot", id: hotspot().id });
   const inspect = () => {
     delete buttonRef.dataset.dismissedHover;
@@ -86,8 +88,12 @@ export function PixelWorldHotspot(props) {
       class="pixel-world-hotspot"
       data-hotspot-kind={hotspot().kind}
       data-hotspot-hit-target="44"
+      disabled={!visible()}
+      tabIndex={visible() ? 0 : -1}
+      aria-hidden={!visible()}
       ref={buttonRef}
       style={{ ...props.style,
+        display: visible() ? undefined : "none",
         "--hotspot-projected-x": props.style?.left,
         "--hotspot-projected-y": props.style?.top,
         left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -1,3 +1,7 @@
+import { createSignal, onCleanup, onMount } from "solid-js";
+import { Portal } from "solid-js/web";
+import { installHotspotTooltipPlacement } from "./pixel_world_tooltip_placement.js";
+
 function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
@@ -31,10 +35,47 @@ export function pixelWorldHotspotTooltipId(hotspot) {
   return `pixel-world-hotspot-tooltip-${id || "hotspot"}`;
 }
 
+export function createHotspotFocusRestoration() {
+  let trigger;
+  return {
+    remember: (element) => { trigger = element; },
+    restore: () => {
+      if (trigger) trigger.dataset.dismissedHover = "true";
+      queueMicrotask(() => {
+      if (!trigger || !document.contains(trigger)) return;
+      trigger.dataset.restoringFocus = "true";
+      trigger.focus();
+      delete trigger.dataset.restoringFocus;
+      });
+    },
+  };
+}
+
 export function PixelWorldHotspot(props) {
+  let buttonRef;
+  const [stageSize, setStageSize] = createSignal({ width: 960, height: 540 });
+  onMount(() => {
+    const stage = buttonRef.parentElement;
+    const update = () => {
+      const rect = stage.getBoundingClientRect();
+      if (rect.width && rect.height) setStageSize(rect);
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(stage);
+    onCleanup(() => observer.disconnect());
+  });
+  const glyphOffset = (axis, dimension) => {
+    const size = stageSize()[dimension];
+    const point = parseFloat(props.style?.[axis] || "50") * size / 100;
+    return point - Math.max(22, Math.min(size - 22, point));
+  };
   const hotspot = () => props.hotspot;
   const selection = () => ({ kind: "hotspot", id: hotspot().id });
   const inspect = () => {
+    delete buttonRef.dataset.dismissedHover;
+    props.onHotspotTrigger?.(buttonRef);
     props.onHotspotInspect?.(selection());
     props.onHover?.(selection());
   };
@@ -43,20 +84,51 @@ export function PixelWorldHotspot(props) {
       type="button"
       class="pixel-world-hotspot"
       data-hotspot-kind={hotspot().kind}
-      style={props.style}
+      data-hotspot-hit-target="44"
+      ref={buttonRef}
+      style={{ ...props.style,
+        "--hotspot-projected-x": props.style?.left,
+        "--hotspot-projected-y": props.style?.top,
+        left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
+        top: `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`,
+      }}
       title={`${hotspot().kind}:${hotspot().label}`}
       aria-label={pixelWorldHotspotAccessibleLabel(props.locale, hotspot())}
       aria-describedby={pixelWorldHotspotTooltipId(hotspot())}
-      onFocus={inspect}
+      onFocus={() => {
+        if (buttonRef.dataset.restoringFocus) return;
+        inspect();
+      }}
       onBlur={() => props.onHover?.(null)}
-      onMouseEnter={() => props.onHover?.(selection())}
-      onMouseLeave={() => props.onHover?.(null)}
+      onMouseEnter={() => {
+        if (buttonRef.dataset.dismissedHover) return;
+        props.onHotspotTrigger?.(buttonRef);
+        props.onHover?.(selection());
+      }}
+      onMouseMove={() => {
+        delete buttonRef.dataset.dismissedHover;
+        props.onHotspotHoverIntent?.();
+        props.onHotspotTrigger?.(buttonRef);
+        props.onHover?.(selection());
+      }}
+      onMouseLeave={(event) => {
+        if (event.relatedTarget?.closest?.("[data-hotspot-tooltip]")?.id === pixelWorldHotspotTooltipId(hotspot())) return;
+        delete buttonRef.dataset.dismissedHover;
+        props.onHover?.(null);
+      }}
       onKeyDown={(event) => {
+        if (event.key === "Tab" && !event.shiftKey) {
+          const close = document.getElementById(pixelWorldHotspotTooltipId(hotspot()))?.querySelector("button");
+          if (close) {
+            event.preventDefault();
+            close.focus();
+          }
+        }
         if (event.key === "Escape") {
           event.preventDefault();
           props.onHotspotClear?.();
           props.onHover?.(null);
-          event.currentTarget.blur();
+          props.onHotspotRestoreFocus?.();
         }
       }}
       onClick={(event) => {
@@ -65,18 +137,35 @@ export function PixelWorldHotspot(props) {
         inspect();
       }}
     >
-      <span aria-hidden="true">{hotspot().kind === "blocker" ? "!" : hotspot().kind === "goal" ? "G" : "i"}</span>
+      <span
+        class="pixel-world-hotspot__glyph"
+        aria-hidden="true"
+        style={{
+          width: `${Number(props.glyphSize) || 20}px`,
+          height: `${Number(props.glyphSize) || 20}px`,
+          transform: `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`,
+          "pointer-events": "none",
+        }}
+      >{hotspot().kind === "blocker" ? "!" : hotspot().kind === "goal" ? "G" : "i"}</span>
     </button>
   );
 }
 
 export function PixelWorldHotspotTooltip(props) {
+  let tooltipRef;
+  onMount(() => onCleanup(installHotspotTooltipPlacement(tooltipRef)));
   const hotspot = () => props.hotspot;
   return (
+    <Portal>
     <div
       id={pixelWorldHotspotTooltipId(hotspot())}
       class="pixel-world-canvas__hotspot-tooltip"
       data-hotspot-tooltip
+      ref={tooltipRef}
+      onMouseLeave={(event) => {
+        if (event.relatedTarget?.closest?.(".pixel-world-hotspot")?.getAttribute("aria-describedby") === pixelWorldHotspotTooltipId(hotspot())) return;
+        props.onHoverLeave?.();
+      }}
       role="status"
     >
       <span>{`${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`}</span>
@@ -100,5 +189,6 @@ export function PixelWorldHotspotTooltip(props) {
         ×
       </button>
     </div>
+    </Portal>
   );
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -84,6 +84,13 @@ export function PixelWorldHotspotTooltip(props) {
         type="button"
         class="pixel-world-canvas__hotspot-tooltip-close"
         aria-label={tr(props.locale, "关闭热点说明", "Close hotspot explanation")}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            event.stopPropagation();
+            props.onClose?.();
+          }
+        }}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
@@ -38,4 +38,12 @@ describe("pixel world hotspot controls", () => {
     fireEvent.click(close);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("closes the explanation when Escape is pressed from the close control", () => {
+    const onClose = vi.fn();
+    render(() => <PixelWorldHotspotTooltip locale="en" hotspot={hotspot} onClose={onClose} />);
+    const close = screen.getByRole("button", { name: "Close hotspot explanation" });
+    fireEvent.keyDown(close, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
@@ -1,10 +1,27 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 import { PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
 
 const hotspot = { id: "hotspot-blocker", kind: "blocker", label: "Blocked route" };
 
 describe("pixel world hotspot controls", () => {
+  it("removes fully offstage glyph controls and restores partially visible edge controls", () => {
+    const [left, setLeft] = createSignal("-10%");
+    const { container } = render(() => <PixelWorldHotspot locale="en" hotspot={{ id: "edge", kind: "goal", label: "Edge" }} glyphSize={20} style={{ left: left(), top: "50%", width: "44px", height: "44px" }} />);
+    const marker = container.querySelector("button");
+    expect(marker).toBeDisabled();
+    expect(marker).toHaveAttribute("tabindex", "-1");
+    expect(marker).not.toBeVisible();
+    setLeft("-0.5%");
+    expect(marker).not.toBeDisabled();
+    expect(marker).toHaveAttribute("tabindex", "0");
+    expect(marker).toBeVisible();
+    expect(marker).toHaveStyle({ width: "44px", height: "44px" });
+    setLeft("110%");
+    expect(marker).not.toBeVisible();
+    expect(marker).toBeDisabled();
+  });
   it("continues both directions from a portaled close control", () => {
     render(() => <><button class="pixel-world-hotspot" aria-describedby="pixel-world-hotspot-tooltip-test">Origin</button><button>Next control</button><PixelWorldHotspotTooltip locale="en" hotspot={{ id: "test", kind: "goal", label: "Goal" }} /></>);
     const close = screen.getByRole("button", { name: "Close hotspot explanation" });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
+
+const hotspot = { id: "hotspot-blocker", kind: "blocker", label: "Blocked route" };
+
+describe("pixel world hotspot controls", () => {
+  it("is touch and keyboard inspectable without selecting or executing gameplay", () => {
+    const onHover = vi.fn();
+    const onHotspotInspect = vi.fn();
+    const onHotspotClear = vi.fn();
+    render(() => (
+      <PixelWorldHotspot
+        locale="en"
+        hotspot={hotspot}
+        style={{ left: "20%", top: "20%" }}
+        onHover={onHover}
+        onHotspotInspect={onHotspotInspect}
+        onHotspotClear={onHotspotClear}
+      />
+    ));
+    const marker = screen.getByRole("button", { name: /Blocker hotspot: Blocked route/i });
+    expect(marker).toHaveAttribute("type", "button");
+    fireEvent.focus(marker);
+    fireEvent.click(marker);
+    expect(onHotspotInspect).toHaveBeenCalledWith({ kind: "hotspot", id: hotspot.id });
+    expect(onHover).toHaveBeenCalledWith({ kind: "hotspot", id: hotspot.id });
+    expect(onHover).not.toHaveBeenCalledWith({ kind: "agent", id: hotspot.id });
+    fireEvent.keyDown(marker, { key: "Escape" });
+    expect(onHotspotClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the explanation close control keyboard reachable and read-only", () => {
+    const onClose = vi.fn();
+    render(() => <PixelWorldHotspotTooltip locale="en" hotspot={hotspot} onClose={onClose} />);
+    expect(screen.getByRole("status")).toHaveTextContent("Blocker: Blocked route");
+    const close = screen.getByRole("button", { name: "Close hotspot explanation" });
+    fireEvent.click(close);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
@@ -5,6 +5,16 @@ import { PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotsp
 const hotspot = { id: "hotspot-blocker", kind: "blocker", label: "Blocked route" };
 
 describe("pixel world hotspot controls", () => {
+  it("continues both directions from a portaled close control", () => {
+    render(() => <><button class="pixel-world-hotspot" aria-describedby="pixel-world-hotspot-tooltip-test">Origin</button><button>Next control</button><PixelWorldHotspotTooltip locale="en" hotspot={{ id: "test", kind: "goal", label: "Goal" }} /></>);
+    const close = screen.getByRole("button", { name: "Close hotspot explanation" });
+    close.focus();
+    fireEvent.keyDown(close, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Origin" }));
+    close.focus();
+    fireEvent.keyDown(close, { key: "Tab" });
+    expect(document.activeElement).toBe(screen.getByRole("button", { name: "Next control" }));
+  });
   it("is touch and keyboard inspectable without selecting or executing gameplay", () => {
     const onHover = vi.fn();
     const onHotspotInspect = vi.fn();

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.test.jsx
@@ -9,6 +9,7 @@ describe("pixel world hotspot controls", () => {
     const onHover = vi.fn();
     const onHotspotInspect = vi.fn();
     const onHotspotClear = vi.fn();
+    const onHotspotRestoreFocus = vi.fn();
     render(() => (
       <PixelWorldHotspot
         locale="en"
@@ -17,17 +18,23 @@ describe("pixel world hotspot controls", () => {
         onHover={onHover}
         onHotspotInspect={onHotspotInspect}
         onHotspotClear={onHotspotClear}
+        onHotspotRestoreFocus={onHotspotRestoreFocus}
       />
     ));
     const marker = screen.getByRole("button", { name: /Blocker hotspot: Blocked route/i });
     expect(marker).toHaveAttribute("type", "button");
+    expect(marker).toHaveAttribute("data-hotspot-hit-target", "44");
+    expect(marker.querySelector(".pixel-world-hotspot__glyph")).not.toBeNull();
     fireEvent.focus(marker);
     fireEvent.click(marker);
     expect(onHotspotInspect).toHaveBeenCalledWith({ kind: "hotspot", id: hotspot.id });
     expect(onHover).toHaveBeenCalledWith({ kind: "hotspot", id: hotspot.id });
     expect(onHover).not.toHaveBeenCalledWith({ kind: "agent", id: hotspot.id });
+    marker.focus();
     fireEvent.keyDown(marker, { key: "Escape" });
     expect(onHotspotClear).toHaveBeenCalledTimes(1);
+    expect(onHotspotRestoreFocus).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(marker);
   });
 
   it("keeps the explanation close control keyboard reachable and read-only", () => {
@@ -46,4 +53,5 @@ describe("pixel world hotspot controls", () => {
     fireEvent.keyDown(close, { key: "Escape" });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.js
@@ -1,21 +1,31 @@
-const FOCUSABLE = 'button, a[href], input, select, textarea, [tabindex]';
+const FOCUSABLE = 'button, a[href], input, select, textarea, summary, [tabindex]';
+
+function firstSummary(details) {
+  return [...details.children].find((child) => child.tagName === 'SUMMARY');
+}
+
+function isAvailableControl(node) {
+  if (node.tabIndex < 0 || node.disabled) return false;
+  if (node.tagName === 'SUMMARY' && !node.hasAttribute('tabindex')
+      && (node.parentElement?.tagName !== 'DETAILS' || firstSummary(node.parentElement) !== node)) return false;
+  for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+    const style = getComputedStyle(ancestor);
+    if (ancestor.hidden || ancestor.inert || style.display === 'none' || style.visibility === 'hidden') return false;
+    if (ancestor.tagName === 'DETAILS' && !ancestor.open && !firstSummary(ancestor)?.contains(node)) return false;
+  }
+  return true;
+}
 
 export function moveFocusFromHotspotTooltip(tooltip, backwards) {
   const trigger = [...document.querySelectorAll('.pixel-world-hotspot')]
     .find((node) => node.getAttribute('aria-describedby') === tooltip.id);
-  if (!trigger) return false;
+  if (!trigger || !isAvailableControl(trigger)) return false;
   if (backwards) {
     trigger.focus();
     return true;
   }
-  const controls = [...document.querySelectorAll(FOCUSABLE)].filter((node) => {
-    if (node.tabIndex < 0 || node.disabled || tooltip.contains(node)) return false;
-    for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
-      const style = getComputedStyle(ancestor);
-      if (ancestor.hidden || ancestor.inert || style.display === 'none' || style.visibility === 'hidden') return false;
-    }
-    return true;
-  });
+  const controls = [...document.querySelectorAll(FOCUSABLE)]
+    .filter((node) => !tooltip.contains(node) && isAvailableControl(node));
   const next = controls[controls.indexOf(trigger) + 1];
   if (!next || next === trigger) return false;
   next.focus();

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.js
@@ -1,0 +1,23 @@
+const FOCUSABLE = 'button, a[href], input, select, textarea, [tabindex]';
+
+export function moveFocusFromHotspotTooltip(tooltip, backwards) {
+  const trigger = [...document.querySelectorAll('.pixel-world-hotspot')]
+    .find((node) => node.getAttribute('aria-describedby') === tooltip.id);
+  if (!trigger) return false;
+  if (backwards) {
+    trigger.focus();
+    return true;
+  }
+  const controls = [...document.querySelectorAll(FOCUSABLE)].filter((node) => {
+    if (node.tabIndex < 0 || node.disabled || tooltip.contains(node)) return false;
+    for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+      const style = getComputedStyle(ancestor);
+      if (ancestor.hidden || ancestor.inert || style.display === 'none' || style.visibility === 'hidden') return false;
+    }
+    return true;
+  });
+  const next = controls[controls.indexOf(trigger) + 1];
+  if (!next || next === trigger) return false;
+  next.focus();
+  return document.activeElement === next;
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.test.js
@@ -1,0 +1,14 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { moveFocusFromHotspotTooltip } from './pixel_world_hotspot_focus.js';
+
+afterEach(() => { document.body.innerHTML = ''; });
+describe('portaled hotspot focus order', () => {
+  it('returns backward to its trigger and continues forward past hidden controls', () => {
+    document.body.innerHTML = '<button class="pixel-world-hotspot" aria-describedby="explanation">Goal</button><div hidden><button>Hidden</button></div><button disabled>Disabled</button><button id="next">Next action</button><div id="explanation"><button>Close</button></div>';
+    const tooltip = document.getElementById('explanation');
+    expect(moveFocusFromHotspotTooltip(tooltip, true)).toBe(true);
+    expect(document.activeElement.textContent).toBe('Goal');
+    expect(moveFocusFromHotspotTooltip(tooltip, false)).toBe(true);
+    expect(document.activeElement.id).toBe('next');
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_focus.test.js
@@ -3,6 +3,20 @@ import { moveFocusFromHotspotTooltip } from './pixel_world_hotspot_focus.js';
 
 afterEach(() => { document.body.innerHTML = ''; });
 describe('portaled hotspot focus order', () => {
+  it('continues from the final hotspot to the first native summary in closed details', () => {
+    document.body.innerHTML = '<button class="pixel-world-hotspot" aria-describedby="tip">Info</button><details><summary id="feed">Feed</summary><button>Hidden reload</button></details><div id="tip"><button>Close</button></div>';
+    expect(moveFocusFromHotspotTooltip(document.getElementById('tip'), false)).toBe(true);
+    expect(document.activeElement.id).toBe('feed');
+  });
+  it('skips nested closed bodies and secondary summaries while honoring a closed first summary subtree', () => {
+    document.body.innerHTML = '<details><summary><button class="pixel-world-hotspot" aria-describedby="tip">Origin</button><button id="allowed">Summary action</button></summary><summary tabindex="0">Second summary</summary><details open><summary>Nested hidden</summary><button>Hidden</button></details></details><button id="outside">Outside</button><div id="tip"><button>Close</button></div>';
+    const tip = document.getElementById('tip');
+    expect(moveFocusFromHotspotTooltip(tip, false)).toBe(true);
+    expect(document.activeElement.id).toBe('allowed');
+    document.getElementById('allowed').disabled = true;
+    expect(moveFocusFromHotspotTooltip(tip, false)).toBe(true);
+    expect(document.activeElement.id).toBe('outside');
+  });
   it('returns backward to its trigger and continues forward past hidden controls', () => {
     document.body.innerHTML = '<button class="pixel-world-hotspot" aria-describedby="explanation">Goal</button><div hidden><button>Hidden</button></div><button disabled>Disabled</button><button id="next">Next action</button><div id="explanation"><button>Close</button></div>';
     const tooltip = document.getElementById('explanation');
@@ -10,5 +24,10 @@ describe('portaled hotspot focus order', () => {
     expect(document.activeElement.textContent).toBe('Goal');
     expect(moveFocusFromHotspotTooltip(tooltip, false)).toBe(true);
     expect(document.activeElement.id).toBe('next');
+  });
+  it('includes a nested disclosure summary when its outer details is open', () => {
+    document.body.innerHTML = '<button class="pixel-world-hotspot" aria-describedby="tip">Info</button><details open><summary tabindex="-1">Outer</summary><details><summary id="nested">Nested</summary><button>Hidden</button></details></details><div id="tip"><button>Close</button></div>';
+    expect(moveFocusFromHotspotTooltip(document.getElementById('tip'), false)).toBe(true);
+    expect(document.activeElement.id).toBe('nested');
   });
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
@@ -2,6 +2,14 @@ const PIXEL_WORLD_CANVAS_WIDTH = 960;
 const PIXEL_WORLD_CANVAS_HEIGHT = 540;
 export const PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX = 44;
 
+export function pixelWorldHotspotIntersectsStage(style, stageSize, glyphSize = 20) {
+  const x = parseFloat(style?.left || "50") * stageSize.width / 100;
+  const y = parseFloat(style?.top || "50") * stageSize.height / 100;
+  const radius = glyphSize / 2;
+  return x + radius > 0 && y + radius > 0
+    && x - radius < stageSize.width && y - radius < stageSize.height;
+}
+
 function safeNumber(value, fallback = 0) {
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
@@ -1,0 +1,61 @@
+const PIXEL_WORLD_CANVAS_WIDTH = 960;
+const PIXEL_WORLD_CANVAS_HEIGHT = 540;
+export const PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX = 44;
+
+function safeNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function clampRatio(value) {
+  return Math.min(1, Math.max(0, safeNumber(value)));
+}
+
+export function toCanvasPoint(position, worldBounds, width, height, cameraState) {
+  if (!position || !worldBounds) return null;
+  const x = clampRatio(safeNumber(position.x_cm ?? position.xCm) / Math.max(1, safeNumber(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
+  const y = clampRatio(safeNumber(position.y_cm ?? position.yCm) / Math.max(1, safeNumber(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
+  const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
+  return {
+    x: width / 2 + (20 + x * Math.max(1, width - 40) - width / 2) * zoom + (Number(cameraState?.pan_x_px ?? cameraState?.panX) || 0),
+    y: height / 2 + (20 + y * Math.max(1, height - 40) - height / 2) * zoom + (Number(cameraState?.pan_y_px ?? cameraState?.panY) || 0),
+  };
+}
+
+export function pixelWorldHotspotGlyphSize(hotspot) {
+  return Math.max(
+    14,
+    Math.min(32, safeNumber(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16)),
+  );
+}
+
+export function pixelWorldHotspotStyle(
+  hotspot,
+  worldBounds,
+  index = 0,
+  cameraState,
+) {
+  const fallback = {
+    left: `${20 + ((index % 4) * 16)}%`,
+    top: `${22 + (Math.floor(index / 4) * 16)}%`,
+  };
+  const position = hotspot?.pos;
+  if (!position || !worldBounds) {
+    return {
+      ...fallback,
+      width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      transform: "translate(-50%, -50%)",
+    };
+  }
+
+  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
+
+  return {
+    left: `${(point.x / PIXEL_WORLD_CANVAS_WIDTH) * 100}%`,
+    top: `${(point.y / PIXEL_WORLD_CANVAS_HEIGHT) * 100}%`,
+    width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    transform: "translate(-50%, -50%)",
+  };
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.test.js
@@ -4,11 +4,20 @@ import {
   pixelWorldHotspotGlyphSize,
   pixelWorldHotspotStyle,
   toCanvasPoint,
+  pixelWorldHotspotIntersectsStage,
 } from "./pixel_world_hotspot_projection.js";
 
 const worldBounds = { width_cm: 10_000_000, depth_cm: 5_000_000 };
 
 describe("pixel world hotspot projection", () => {
+  it.each([
+    ["-1%", "50%", false], ["-0.9%", "50%", true],
+    ["101%", "50%", false], ["100.9%", "50%", true],
+    ["50%", "-2%", false], ["50%", "-1.9%", true],
+    ["50%", "102%", false], ["50%", "101.9%", true],
+  ])("distinguishes full clipping from partial glyph visibility at %s,%s", (left, top, expected) => {
+    expect(pixelWorldHotspotIntersectsStage({ left, top }, { width: 1000, height: 500 }, 20)).toBe(expected);
+  });
   it("matches the bridge 20px inset and camera transform", () => {
     const style = pixelWorldHotspotStyle(
       { pos: { x_cm: 2_500_000, y_cm: 3_750_000 } },

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  pixelWorldHotspotGlyphSize,
+  pixelWorldHotspotStyle,
+  toCanvasPoint,
+} from "./pixel_world_hotspot_projection.js";
+
+const worldBounds = { width_cm: 10_000_000, depth_cm: 5_000_000 };
+
+describe("pixel world hotspot projection", () => {
+  it("matches the bridge 20px inset and camera transform", () => {
+    const style = pixelWorldHotspotStyle(
+      { pos: { x_cm: 2_500_000, y_cm: 3_750_000 } },
+      worldBounds,
+      0,
+      { zoom: 2, pan_x_px: 40, pan_y_px: -20 },
+    );
+
+    expect(parseFloat(style.left)).toBeCloseTo(6.25);
+    expect(parseFloat(style.top)).toBeCloseTo(92.59259);
+    expect(style.width).toBe("44px");
+    expect(style.height).toBe("44px");
+  });
+
+  it("retains inset anchors and scales pan and centered zoom with the canvas", () => {
+    const origin = { x_cm: 0, y_cm: 0 };
+    expect(toCanvasPoint(origin, worldBounds, 960, 540)).toEqual({ x: 20, y: 20 });
+    expect(toCanvasPoint(origin, worldBounds, 960, 540, { zoom: 0.5, pan_x_px: 30, pan_y_px: -10 })).toEqual({ x: 280, y: 135 });
+    expect(toCanvasPoint({ x_cm: 10_000_000, y_cm: 5_000_000 }, worldBounds, 960, 540)).toEqual({ x: 940, y: 520 });
+  });
+
+  it("keeps a separate glyph size inside the touch target", () => {
+    const hotspot = { size_hint_px: 14 };
+
+    expect(pixelWorldHotspotGlyphSize(hotspot)).toBe(14);
+    expect(pixelWorldHotspotStyle(hotspot, null, 0).width).toBe("44px");
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_test_helpers.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_test_helpers.js
@@ -1,0 +1,35 @@
+import { fireEvent, screen, waitFor } from "@solidjs/testing-library";
+import { expect } from "vitest";
+
+export async function verifyHotspotCameraAndFocus(marker, onCameraEvent) {
+  expect(marker).toHaveAttribute("data-hotspot-hit-target", "44");
+  expect(marker.querySelector(".pixel-world-hotspot__glyph")).toHaveStyle({ width: "20px", height: "20px" });
+  const initialLeft = marker.style.getPropertyValue("--hotspot-projected-x");
+  onCameraEvent({ type: "camera_state_changed", camera: { zoom: 2, pan_x_px: 40, pan_y_px: -20 } });
+  await waitFor(() => expect(marker.style.getPropertyValue("--hotspot-projected-x")).not.toBe(initialLeft));
+  fireEvent.mouseEnter(marker);
+  const hoverClose = screen.getByRole("button", { name: "关闭热点说明" });
+  fireEvent.mouseLeave(marker, { relatedTarget: hoverClose });
+  expect(hoverClose).toBeInTheDocument();
+  fireEvent.click(hoverClose);
+  await waitFor(() => expect(document.activeElement).toBe(marker));
+  fireEvent.mouseEnter(marker);
+  expect(screen.queryByRole("button", { name: "关闭热点说明" })).not.toBeInTheDocument();
+  for (const method of ["click", "Escape"]) {
+    fireEvent.click(marker);
+    expect(screen.getByRole("status")).toHaveTextContent("阻塞: 缺料阻塞");
+    const close = screen.getByRole("button", { name: "关闭热点说明" });
+    marker.focus();
+    fireEvent.keyDown(marker, { key: "Tab" });
+    expect(document.activeElement).toBe(close);
+    if (method === "click") fireEvent.click(close);
+    else fireEvent.keyDown(close, { key: "Escape" });
+    await waitFor(() => expect(document.activeElement).toBe(marker));
+    fireEvent.mouseEnter(marker);
+    expect(screen.queryByRole("button", { name: "关闭热点说明" })).not.toBeInTheDocument();
+    onCameraEvent({ type: "hover_entity", selection: { kind: "hotspot", id: "hotspot-goal" } });
+    expect(screen.queryByRole("button", { name: "关闭热点说明" })).not.toBeInTheDocument();
+  }
+  fireEvent.mouseMove(screen.getByRole("button", { name: /目标热点：稳定生产/ }));
+  expect(screen.getByRole("status")).toHaveTextContent("目标: 稳定生产");
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
@@ -7,15 +7,34 @@ export function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, comma
   return Math.max(clearCommandOffset, clearFeedOffset);
 }
 
+export function pixelWorldMobileSelectionChipOffset({ chipTop, feedBottom = 0, feedOpen = false }) {
+  if (feedOpen || !Number.isFinite(chipTop) || !Number.isFinite(feedBottom) || feedBottom <= 0) return 0;
+  return Math.max(0, feedBottom + SAFE_AREA_GAP_PX - chipTop);
+}
+
 export function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
   return hudRight + SAFE_AREA_GAP_PX - markerLeft;
 }
 
 export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
-  if (!marker) return;
-  marker.style.translate = "";
+  const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
+  const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const feedVisible = feed && getComputedStyle(feed).display !== "none";
+  const feedRect = feedVisible ? feed.getBoundingClientRect() : null;
+  selectionChip?.style.setProperty("translate", "");
+  marker?.style.setProperty("translate", "");
   if (window.innerWidth > MOBILE_SHELL_MAX_WIDTH) return;
+  if (selectionChip && feedRect && !feed.open) {
+    const chipRect = selectionChip.getBoundingClientRect();
+    const chipOffset = pixelWorldMobileSelectionChipOffset({
+      chipTop: chipRect.top,
+      feedBottom: feedRect.bottom,
+      feedOpen: feed.open,
+    });
+    selectionChip.style.translate = `0 ${Math.ceil(chipOffset)}px`;
+  }
+  if (!marker) return;
   const focusHost = canvasRoot.closest(".pixel-world-host--focus");
   if (focusHost) {
     const focusHud = focusHost.querySelector("[data-focus-hud='true']");
@@ -28,10 +47,8 @@ export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   }
   const command = document.querySelector('[data-viewer-overlay="next-move"]');
   if (!command || getComputedStyle(command).display === "none") return;
-  const feed = document.querySelector('[data-viewer-overlay="feed"]');
   const markerRect = marker.getBoundingClientRect();
   const commandRect = command.getBoundingClientRect();
-  const feedRect = feed && getComputedStyle(feed).display !== "none" ? feed.getBoundingClientRect() : null;
   const offset = pixelWorldMobileSelectionOffset({
     markerTop: markerRect.top,
     markerBottom: markerRect.bottom,

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pixelWorldMobileFocusSelectionOffset, pixelWorldMobileSelectionOffset } from "./pixel_world_mobile_safe_area.js";
+import { pixelWorldMobileFocusSelectionOffset, pixelWorldMobileSelectionChipOffset, pixelWorldMobileSelectionOffset } from "./pixel_world_mobile_safe_area.js";
 
 describe("pixel world mobile selection safe area", () => {
   it("clears the command band while preserving the Feed gap", () => {
@@ -9,5 +9,19 @@ describe("pixel world mobile selection safe area", () => {
 
   it("moves the selected marker beside an expanded Focus HUD", () => {
     expect(pixelWorldMobileFocusSelectionOffset({ markerLeft: 178, hudRight: 300 })).toBe(130);
+  });
+
+  it("derives collapsed Feed chip clearance from the rendered bottom for every status height", () => {
+    const statusHeights = [
+      ["ready", 165],
+      ["replay", 165],
+      ["empty", 173],
+      ["gap", 181],
+      ["unavailable", 189],
+    ];
+    for (const [, feedBottom] of statusHeights) {
+      expect(pixelWorldMobileSelectionChipOffset({ chipTop: 160, feedBottom })).toBe(feedBottom - 152);
+    }
+    expect(pixelWorldMobileSelectionChipOffset({ chipTop: 104, feedBottom: 400, feedOpen: true })).toBe(0);
   });
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_readout.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_readout.js
@@ -1,0 +1,29 @@
+function isZhLocale(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+
+function tr(locale, zh, en) {
+  return isZhLocale(locale) ? zh : en;
+}
+
+function warn(label, state) {
+  return {
+    label,
+    className: `badge badge--warn pixel-world-readout__status pixel-world-readout__status--${state}`,
+  };
+}
+
+export function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}) {
+  const status = String(connectionStatus || "").trim().toLowerCase();
+  const feedStatus = String(worldFeed.status || "").trim().toLowerCase();
+  if (feedStatus === "unavailable") return warn(tr(locale, "不可用", "UNAVAILABLE"), "unavailable");
+  if (feedStatus === "gap") return warn(tr(locale, "断档", "GAP"), "gap");
+  if (feedStatus === "replay") return { label: tr(locale, "回放", "REPLAY"), className: "badge badge--accent pixel-world-readout__status pixel-world-readout__status--replay" };
+  if (feedStatus === "empty") return { label: tr(locale, "暂无动态", "NO EVENTS"), className: "badge pixel-world-readout__status pixel-world-readout__status--empty" };
+  if (worldFeed.stale) return warn(tr(locale, "陈旧", "STALE"), "stale");
+  if (status === "connecting" || status === "reconnecting") return warn(tr(locale, "正在重连", "RECONNECTING"), "reconnecting");
+  if (status !== "connected") return warn(tr(locale, "离线", "OFFLINE"), "offline");
+  return feedStatus === "ready"
+    ? { label: tr(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" }
+    : warn(tr(locale, "同步中", "SYNCING"), "syncing");
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_readout.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_readout.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
+
+describe("pixel world readout status", () => {
+  it("distinguishes live, replay, empty, gap, and unavailable feed states", () => {
+    expect([
+      ["ready", "LIVE", "badge--good"],
+      ["replay", "REPLAY", "badge--accent"],
+      ["empty", "NO EVENTS", "pixel-world-readout__status--empty"],
+      ["gap", "GAP", "badge--warn"],
+      ["unavailable", "UNAVAILABLE", "badge--warn"],
+    ].map(([status]) => resolvePixelWorldReadoutStatus("en", "connected", { status }).label)).toEqual([
+      "LIVE",
+      "REPLAY",
+      "NO EVENTS",
+      "GAP",
+      "UNAVAILABLE",
+    ]);
+  });
+
+  it("keeps CJK labels explicit and distinct from action success", () => {
+    expect(resolvePixelWorldReadoutStatus("zh-CN", "connected", { status: "replay" })).toMatchObject({ label: "回放" });
+    expect(resolvePixelWorldReadoutStatus("zh-CN", "connected", { status: "empty" })).toMatchObject({ label: "暂无动态" });
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.js
@@ -1,0 +1,33 @@
+export function hotspotTooltipSafeBand(summary, command, viewportHeight) {
+  const top = Math.max(10, summary.bottom + 4);
+  const bottom = Math.min(viewportHeight - 10, command?.top ?? viewportHeight - 10) - 4;
+  return { top, maxHeight: Math.max(26, bottom - top) };
+}
+
+export function installHotspotTooltipPlacement(tooltip) {
+  const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const command = document.querySelector('[data-viewer-overlay="next-move"]');
+  const update = () => {
+    for (const property of ["top", "bottom", "max-height", "overflow-y", "padding"]) tooltip.style.removeProperty(property);
+    if (!feed?.open) return;
+    const summary = feed.querySelector("summary");
+    if (!summary) return;
+    const summaryRect = summary.getBoundingClientRect();
+    const rect = tooltip.getBoundingClientRect();
+    if (rect.bottom <= summaryRect.top || rect.top >= summaryRect.bottom) return;
+    const commandRect = command && getComputedStyle(command).display !== "none" ? command.getBoundingClientRect() : null;
+    const band = hotspotTooltipSafeBand(summaryRect, commandRect, window.innerHeight);
+    tooltip.style.top = `${band.top}px`;
+    tooltip.style.bottom = "auto";
+    tooltip.style.maxHeight = `${band.maxHeight}px`;
+    tooltip.style.overflowY = "auto";
+    if (band.maxHeight < 40) tooltip.style.padding = "1px 7px";
+  };
+  update();
+  window.addEventListener("resize", update);
+  feed?.addEventListener("toggle", update);
+  return () => {
+    window.removeEventListener("resize", update);
+    feed?.removeEventListener("toggle", update);
+  };
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.js
@@ -1,33 +1,44 @@
-export function hotspotTooltipSafeBand(summary, command, viewportHeight) {
-  const top = Math.max(10, summary.bottom + 4);
-  const bottom = Math.min(viewportHeight - 10, command?.top ?? viewportHeight - 10) - 4;
-  return { top, maxHeight: Math.max(26, bottom - top) };
+const MARGIN = 10;
+const MIN_HEIGHT = 56;
+
+export function hotspotTooltipSafeBand(summary, command, viewportHeight, preferredTop = 52) {
+  const obstacles = [summary, command].filter(Boolean).map((rect) => ({
+    top: Math.max(MARGIN, rect.top - 4),
+    bottom: Math.min(viewportHeight - MARGIN, (rect.bottom ?? viewportHeight) + 4),
+  })).sort((a, b) => a.top - b.top);
+  const bands = [];
+  let cursor = MARGIN;
+  for (const obstacle of obstacles) {
+    if (obstacle.top - cursor >= MIN_HEIGHT) bands.push({ top: cursor, bottom: obstacle.top });
+    cursor = Math.max(cursor, obstacle.bottom);
+  }
+  if (viewportHeight - MARGIN - cursor >= MIN_HEIGHT) bands.push({ top: cursor, bottom: viewportHeight - MARGIN });
+  // Keep the close reachable even on smaller viewports with no unoccupied HUD band.
+  if (!bands.length) bands.push({ top: MARGIN, bottom: Math.max(MARGIN + MIN_HEIGHT, viewportHeight - MARGIN) });
+  const distance = (band) => Math.abs(Math.max(band.top, Math.min(band.bottom - MIN_HEIGHT, preferredTop)) - preferredTop);
+  bands.sort((a, b) => distance(a) - distance(b));
+  const band = bands[0];
+  return { top: band.top, maxHeight: band.bottom - band.top };
 }
 
 export function installHotspotTooltipPlacement(tooltip) {
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
   const command = document.querySelector('[data-viewer-overlay="next-move"]');
+  const summary = feed?.querySelector("summary");
+  const visibleRect = (node) => node && getComputedStyle(node).display !== "none" ? node.getBoundingClientRect() : null;
   const update = () => {
-    for (const property of ["top", "bottom", "max-height", "overflow-y", "padding"]) tooltip.style.removeProperty(property);
-    if (!feed?.open) return;
-    const summary = feed.querySelector("summary");
-    if (!summary) return;
-    const summaryRect = summary.getBoundingClientRect();
-    const rect = tooltip.getBoundingClientRect();
-    if (rect.bottom <= summaryRect.top || rect.top >= summaryRect.bottom) return;
-    const commandRect = command && getComputedStyle(command).display !== "none" ? command.getBoundingClientRect() : null;
-    const band = hotspotTooltipSafeBand(summaryRect, commandRect, window.innerHeight);
+    tooltip.style.removeProperty("top");
+    tooltip.style.removeProperty("bottom");
+    const preferredTop = tooltip.getBoundingClientRect().top;
+    const band = hotspotTooltipSafeBand(visibleRect(summary), visibleRect(command), window.innerHeight, preferredTop);
     tooltip.style.top = `${band.top}px`;
     tooltip.style.bottom = "auto";
-    tooltip.style.maxHeight = `${band.maxHeight}px`;
-    tooltip.style.overflowY = "auto";
-    if (band.maxHeight < 40) tooltip.style.padding = "1px 7px";
+    tooltip.style.setProperty("--hotspot-tooltip-max-height", `${band.maxHeight}px`);
   };
   update();
+  const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+  for (const node of [summary, command]) if (node) observer?.observe(node);
   window.addEventListener("resize", update);
   feed?.addEventListener("toggle", update);
-  return () => {
-    window.removeEventListener("resize", update);
-    feed?.removeEventListener("toggle", update);
-  };
+  return () => { observer?.disconnect(); window.removeEventListener("resize", update); feed?.removeEventListener("toggle", update); };
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { hotspotTooltipSafeBand } from "./pixel_world_tooltip_placement.js";
+
+describe("hotspot tooltip safe band", () => {
+  it.each([
+    [844, 224, 420],
+    [390, 137, 174.8],
+    [360, 137, 171.2],
+  ])("keeps summary and command actions clear at viewport height %s", (height, summaryBottom, commandTop) => {
+    const band = hotspotTooltipSafeBand({ bottom: summaryBottom }, { top: commandTop }, height);
+    expect(band.top).toBeGreaterThan(summaryBottom);
+    expect(band.maxHeight).toBeGreaterThanOrEqual(26);
+    expect(band.top + band.maxHeight).toBeLessThan(commandTop);
+    expect(band.top + band.maxHeight).toBeLessThan(height);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_tooltip_placement.test.js
@@ -3,13 +3,14 @@ import { hotspotTooltipSafeBand } from "./pixel_world_tooltip_placement.js";
 
 describe("hotspot tooltip safe band", () => {
   it.each([
-    [844, 224, 420],
-    [390, 137, 174.8],
-    [360, 137, 171.2],
-  ])("keeps summary and command actions clear at viewport height %s", (height, summaryBottom, commandTop) => {
-    const band = hotspotTooltipSafeBand({ bottom: summaryBottom }, { top: commandTop }, height);
-    expect(band.top).toBeGreaterThan(summaryBottom);
-    expect(band.maxHeight).toBeGreaterThanOrEqual(26);
+    [844, 160, 224, 420],
+    [390, 73, 137, 174.8],
+    [360, 73, 137, 171.2],
+    [360, 104, 220, 171.2],
+  ])("keeps summary and command actions clear at viewport height %s", (height, summaryTop, summaryBottom, commandTop) => {
+    const band = hotspotTooltipSafeBand({ top: summaryTop, bottom: summaryBottom }, { top: commandTop }, height);
+    expect(band.top >= summaryBottom || band.top + band.maxHeight <= summaryTop).toBe(true);
+    expect(band.maxHeight).toBeGreaterThanOrEqual(56);
     expect(band.top + band.maxHeight).toBeLessThan(commandTop);
     expect(band.top + band.maxHeight).toBeLessThan(height);
   });

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
@@ -17,11 +17,24 @@ function statusCopy(locale, tr, status) {
   return tr(locale, copy[0], copy[1]);
 }
 
+function statusBadgeLabel(locale, tr, status) {
+  const copy = {
+    loading: ["同步中", "SYNCING"],
+    ready: ["实时", "LIVE"],
+    empty: ["暂无动态", "NO EVENTS"],
+    replay: ["回放", "REPLAY"],
+    gap: ["断档", "GAP"],
+    unavailable: ["不可用", "UNAVAILABLE"],
+  }[status] || ["不可用", "UNAVAILABLE"];
+  return tr(locale, copy[0], copy[1]);
+}
+
 function statusBadgeClass(status) {
-  if (status === "ready") return "badge badge--accent";
-  if (status === "replay") return "badge badge--accent";
-  if (status === "gap" || status === "unavailable") return "badge badge--warn";
-  return "badge";
+  const stateClass = `world-feed__status-badge world-feed__status-badge--${status || "unknown"}`;
+  if (status === "ready") return `badge badge--accent ${stateClass}`;
+  if (status === "replay") return `badge badge--accent ${stateClass}`;
+  if (status === "gap" || status === "unavailable") return `badge badge--warn ${stateClass}`;
+  return `badge ${stateClass}`;
 }
 
 function reasonCopy(locale, tr, feed) {
@@ -101,6 +114,7 @@ function WorldFeedPanel(props) {
   );
   const status = () => String(feed().status || "unavailable");
   const statusLabel = () => statusCopy(locale(), tr, status());
+  const summaryStatusLabel = () => statusBadgeLabel(locale(), tr, status());
   const shouldReload = () => status() !== "unavailable"
     && Boolean(feed().snapshotReloadRequired || status() === "gap");
 
@@ -115,7 +129,10 @@ function WorldFeedPanel(props) {
     >
       <summary class="panel__header panel__header--stack world-feed__summary">
         <div class="panel__eyebrow">{tr(locale(), "环境上下文", "Ambient Context")}</div>
-        <div class="panel__title">{tr(locale(), "World Feed", "World Feed")}</div>
+        <div class="world-feed__summary-line">
+          <div class="panel__title">{tr(locale(), "World Feed", "World Feed")}</div>
+          <span class={statusBadgeClass(status())} data-world-feed-summary-status={status()}>{summaryStatusLabel()}</span>
+        </div>
         <div class="panel__meta-copy">
           {tr(locale(), "只读的运行时环境投影；不会替代 Action Receipt，也不会证明玩家动作成功。", "Read-only runtime context; it never replaces Action Receipt or proves a player action succeeded.")}
         </div>

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
@@ -41,7 +41,8 @@ describe("WorldFeedPanel", () => {
       />
     ));
     expect(container.querySelector("#viewer-world-feed")).toBeTruthy();
-    expect(screen.getByText("World activity is stale")).toBeInTheDocument();
+    expect(container.querySelector('[data-world-feed-summary-status="gap"]')).toHaveTextContent("GAP");
+    expect(screen.getByText("GAP", { selector: '[data-world-feed-summary-status]' })).toBeInTheDocument();
     const reloadButton = screen.getByRole("button", { name: /reload authoritative snapshot/i });
     expect(reloadButton).toBeInTheDocument();
     fireEvent.click(reloadButton);
@@ -69,7 +70,7 @@ describe("WorldFeedPanel", () => {
         onRetryFeed={onRetryFeed}
       />
     ));
-    expect(screen.getByText("World activity unavailable")).toBeInTheDocument();
+    expect(screen.getByText("UNAVAILABLE", { selector: '[data-world-feed-summary-status]' })).toBeInTheDocument();
     const retryButton = screen.getByRole("button", { name: /retry world feed/i });
     expect(retryButton).toBeInTheDocument();
     fireEvent.click(retryButton);
@@ -114,7 +115,7 @@ describe("WorldFeedPanel", () => {
       />
     ));
 
-    expect(screen.getByText("No world activity yet")).toBeInTheDocument();
+    expect(screen.getByText("NO EVENTS", { selector: '[data-world-feed-summary-status]' })).toBeInTheDocument();
     expect(screen.getByText(
       "No authoritative world update has published events yet. This feed is context only—continue your Player goal; the feed will update after the next authoritative world update.",
     )).toBeInTheDocument();
@@ -309,7 +310,7 @@ describe("WorldFeedPanel", () => {
       />
     ));
 
-    expect(screen.getByText("World activity unavailable")).toBeInTheDocument();
+    expect(screen.getByText("UNAVAILABLE", { selector: '[data-world-feed-summary-status]' })).toBeInTheDocument();
     expect(document.querySelector("[data-world-feed-major-event]")).toBeNull();
     expect(document.querySelector("[data-world-feed-major-event-toast]")).toBeNull();
   });

--- a/crates/oasis7_viewer/viewer.html
+++ b/crates/oasis7_viewer/viewer.html
@@ -2131,7 +2131,7 @@
       }
       .pixel-world-hotspot {
         position: absolute;
-        z-index: 4;
+        z-index: 7;
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/crates/oasis7_viewer/viewer.html
+++ b/crates/oasis7_viewer/viewer.html
@@ -2136,7 +2136,10 @@
         align-items: center;
         justify-content: center;
         border-radius: 999px;
-        pointer-events: none;
+        appearance: none;
+        padding: 0;
+        pointer-events: auto;
+        cursor: pointer;
         font-family: var(--font-mono);
         font-size: 10px;
         font-weight: 800;
@@ -2228,7 +2231,9 @@
         border-color: rgba(248, 113, 113, 0.4);
         color: var(--bad);
       }
-      .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 7; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: none; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+      .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 45; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); display: flex; align-items: flex-start; gap: 8px; padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: auto; overflow-wrap: anywhere; }
+      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; }
+      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 auto; min-width: 22px; min-height: 22px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 5px; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
       .pixel-world-canvas__selection {
         position: absolute;
         z-index: 6;

--- a/crates/oasis7_viewer/viewer.html
+++ b/crates/oasis7_viewer/viewer.html
@@ -2244,8 +2244,8 @@
         color: var(--bad);
       }
       .pixel-world-canvas__hotspot-tooltip { position: absolute; z-index: 45; right: 10px; top: 52px; width: min(42vw, 320px); max-width: calc(100% - 20px); display: flex; align-items: flex-start; gap: 8px; padding: 7px 9px; border: 1px solid rgba(237, 241, 230, 0.88); border-radius: 7px; color: #f8fafc; background: rgba(7, 12, 18, 0.94); box-shadow: var(--shadow-inset-stage), 0 8px 20px rgba(0, 0, 0, 0.28); font-size: 12px; font-weight: 700; line-height: 1.25; pointer-events: auto; overflow-wrap: anywhere; }
-      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; }
-      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 auto; min-width: 22px; min-height: 22px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 5px; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
+      .pixel-world-canvas__hotspot-tooltip > span { min-width: 0; overflow-wrap: anywhere; max-height: calc(var(--hotspot-tooltip-max-height, 100dvh - 20px) - 12px); overflow-y: auto; }
+      .pixel-world-canvas__hotspot-tooltip-close { flex: 0 0 44px; width: 44px; height: 44px; min-width: 44px; min-height: 44px; padding: 0; border: 1px solid rgba(237, 241, 230, 0.42); border-radius: 0; color: #f8fafc; background: rgba(237, 241, 230, 0.1); cursor: pointer; line-height: 1; }
       .pixel-world-canvas__selection {
         position: absolute;
         z-index: 6;
@@ -2779,7 +2779,7 @@
           width: 20px;
           height: 20px;
         }
-        .pixel-world-hotspot {
+        .pixel-world-hotspot__glyph {
           font-size: 11px;
           box-shadow: 0 0 24px rgba(208, 168, 91, 0.54), 0 0 0 5px rgba(208, 168, 91, 0.08);
         }

--- a/crates/oasis7_viewer/viewer.html
+++ b/crates/oasis7_viewer/viewer.html
@@ -2132,10 +2132,12 @@
       .pixel-world-hotspot {
         position: absolute;
         z-index: 7;
+        width: 44px;
+        height: 44px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border-radius: 999px;
+        border-radius: 0;
         appearance: none;
         padding: 0;
         pointer-events: auto;
@@ -2143,18 +2145,28 @@
         font-family: var(--font-mono);
         font-size: 10px;
         font-weight: 800;
+        color: transparent;
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+      }
+      .pixel-world-hotspot__glyph {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 999px;
         color: var(--bg-deep);
         background: rgba(208, 168, 91, 0.88);
         border: 1px solid rgba(255, 230, 180, 0.8);
         box-shadow: 0 0 18px rgba(208, 168, 91, 0.35);
       }
-      .pixel-world-hotspot[data-hotspot-kind="blocker"] {
+      .pixel-world-hotspot[data-hotspot-kind="blocker"] .pixel-world-hotspot__glyph {
         color: #250b06;
         background: rgba(229, 143, 118, 0.95);
         border-color: rgba(255, 190, 170, 0.9);
         box-shadow: 0 0 24px rgba(229, 143, 118, 0.52), 0 0 0 5px rgba(229, 143, 118, 0.08);
       }
-      .pixel-world-hotspot[data-hotspot-kind="goal"] {
+      .pixel-world-hotspot[data-hotspot-kind="goal"] .pixel-world-hotspot__glyph {
         color: #1d1200;
         background: rgba(208, 168, 91, 0.96);
         border-color: rgba(255, 230, 180, 0.95);

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10427,6 +10427,13 @@ function PixelWorldHotspotTooltip(props) {
       event.stopPropagation();
       props.onClose?.();
     };
+    _el$5.$$keydown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        props.onClose?.();
+      }
+    };
     createRenderEffect((_p$) => {
       var _v$6 = pixelWorldHotspotTooltipId(hotspot()), _v$7 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
       _v$6 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$6);
@@ -10660,6 +10667,32 @@ function pixelWorldVisualState(renderState) {
     visualHotspots: arrayField(state2, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity)
   };
 }
+function PixelWorldHostHotspotLayer(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return createComponent(For, {
+    get each() {
+      return visualState().visualHotspots.slice(0, 8);
+    },
+    children: (hotspot, index) => createComponent(PixelWorldHotspot, {
+      get locale() {
+        return props.locale();
+      },
+      hotspot,
+      get style() {
+        return hotspotStyle(hotspot, visualState().worldBounds, index());
+      },
+      get onHover() {
+        return props.onHover;
+      },
+      get onHotspotInspect() {
+        return props.onHotspotInspect;
+      },
+      get onHotspotClear() {
+        return props.onHotspotClear;
+      }
+    })
+  });
+}
 function PixelWorldHostVisualLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
   const selection = () => props.selection?.() || visualState().selection;
@@ -10732,28 +10765,6 @@ function PixelWorldHostVisualLayer(props) {
       });
       return _el$7;
     })()]
-  }), createComponent(For, {
-    get each() {
-      return visualState().visualHotspots.slice(0, 8);
-    },
-    children: (hotspot, index) => createComponent(PixelWorldHotspot, {
-      get locale() {
-        return props.locale();
-      },
-      hotspot,
-      get style() {
-        return hotspotStyle(hotspot, visualState().worldBounds, index());
-      },
-      get onHover() {
-        return props.onHover;
-      },
-      get onHotspotInspect() {
-        return props.onHotspotInspect;
-      },
-      get onHotspotClear() {
-        return props.onHotspotClear;
-      }
-    })
   }), createComponent(Index, {
     get each() {
       return visualState().locations.slice(0, 8);
@@ -11169,6 +11180,17 @@ function PixelWorldCanvasRenderer(props) {
       },
       get onHover() {
         return props.onHover;
+      }
+    }), null);
+    insert(_el$15, createComponent(PixelWorldHostHotspotLayer, {
+      get locale() {
+        return props.locale;
+      },
+      get renderState() {
+        return props.renderState;
+      },
+      get onHover() {
+        return props.onHover;
       },
       onHotspotInspect: setInspectedHotspot,
       onHotspotClear: () => setInspectedHotspot(null)
@@ -11200,7 +11222,7 @@ function PixelWorldCanvasRenderer(props) {
       get children() {
         return createComponent(PixelWorldHotspotTooltip, {
           get locale() {
-            return props.locale;
+            return props.locale();
           },
           get hotspot() {
             return activeHotspot();

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10481,6 +10481,61 @@ function moveFocusFromHotspotTooltip(tooltip, backwards) {
   next.focus();
   return document.activeElement === next;
 }
+const PIXEL_WORLD_CANVAS_WIDTH = 960;
+const PIXEL_WORLD_CANVAS_HEIGHT = 540;
+const PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX = 44;
+function pixelWorldHotspotIntersectsStage(style2, stageSize, glyphSize = 20) {
+  const x = parseFloat(style2?.left || "50") * stageSize.width / 100;
+  const y = parseFloat(style2?.top || "50") * stageSize.height / 100;
+  const radius = glyphSize / 2;
+  return x + radius > 0 && y + radius > 0 && x - radius < stageSize.width && y - radius < stageSize.height;
+}
+function safeNumber$1(value2, fallback = 0) {
+  const number = Number(value2);
+  return Number.isFinite(number) ? number : fallback;
+}
+function clampRatio$1(value2) {
+  return Math.min(1, Math.max(0, safeNumber$1(value2)));
+}
+function toCanvasPoint(position, worldBounds, width, height, cameraState) {
+  if (!position || !worldBounds) return null;
+  const x = clampRatio$1(safeNumber$1(position.x_cm ?? position.xCm) / Math.max(1, safeNumber$1(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
+  const y = clampRatio$1(safeNumber$1(position.y_cm ?? position.yCm) / Math.max(1, safeNumber$1(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
+  const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
+  return {
+    x: width / 2 + (20 + x * Math.max(1, width - 40) - width / 2) * zoom + (Number(cameraState?.pan_x_px ?? cameraState?.panX) || 0),
+    y: height / 2 + (20 + y * Math.max(1, height - 40) - height / 2) * zoom + (Number(cameraState?.pan_y_px ?? cameraState?.panY) || 0)
+  };
+}
+function pixelWorldHotspotGlyphSize(hotspot) {
+  return Math.max(
+    14,
+    Math.min(32, safeNumber$1(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
+  );
+}
+function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
+  const fallback = {
+    left: `${20 + index % 4 * 16}%`,
+    top: `${22 + Math.floor(index / 4) * 16}%`
+  };
+  const position = hotspot?.pos;
+  if (!position || !worldBounds) {
+    return {
+      ...fallback,
+      width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      transform: "translate(-50%, -50%)"
+    };
+  }
+  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
+  return {
+    left: `${point.x / PIXEL_WORLD_CANVAS_WIDTH * 100}%`,
+    top: `${point.y / PIXEL_WORLD_CANVAS_HEIGHT * 100}%`,
+    width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    transform: "translate(-50%, -50%)"
+  };
+}
 var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span data-hotspot-tooltip-body></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
 function isZhLocale$1(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
@@ -10544,6 +10599,7 @@ function PixelWorldHotspot(props) {
     return point - Math.max(22, Math.min(size - 22, point));
   };
   const hotspot = () => props.hotspot;
+  const visible = () => pixelWorldHotspotIntersectsStage(props.style, stageSize(), Number(props.glyphSize) || 20);
   const selection = () => ({
     kind: "hotspot",
     id: hotspot().id
@@ -10604,21 +10660,25 @@ function PixelWorldHotspot(props) {
       return () => _c$() ? "!" : hotspot().kind === "goal" ? "G" : "i";
     })());
     createRenderEffect((_p$) => {
-      var _v$ = hotspot().kind, _v$2 = {
+      var _v$ = hotspot().kind, _v$2 = !visible(), _v$3 = visible() ? 0 : -1, _v$4 = !visible(), _v$5 = {
         ...props.style,
+        display: visible() ? void 0 : "none",
         "--hotspot-projected-x": props.style?.left,
         "--hotspot-projected-y": props.style?.top,
         left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
         top: `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`
-      }, _v$3 = `${hotspot().kind}:${hotspot().label}`, _v$4 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$5 = pixelWorldHotspotTooltipId(hotspot()), _v$6 = `${Number(props.glyphSize) || 20}px`, _v$7 = `${Number(props.glyphSize) || 20}px`, _v$8 = `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`;
+      }, _v$6 = `${hotspot().kind}:${hotspot().label}`, _v$7 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$8 = pixelWorldHotspotTooltipId(hotspot()), _v$9 = `${Number(props.glyphSize) || 20}px`, _v$0 = `${Number(props.glyphSize) || 20}px`, _v$1 = `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`;
       _v$ !== _p$.e && setAttribute(_el$, "data-hotspot-kind", _p$.e = _v$);
-      _p$.t = style(_el$, _v$2, _p$.t);
-      _v$3 !== _p$.a && setAttribute(_el$, "title", _p$.a = _v$3);
-      _v$4 !== _p$.o && setAttribute(_el$, "aria-label", _p$.o = _v$4);
-      _v$5 !== _p$.i && setAttribute(_el$, "aria-describedby", _p$.i = _v$5);
-      _v$6 !== _p$.n && setStyleProperty(_el$2, "width", _p$.n = _v$6);
-      _v$7 !== _p$.s && setStyleProperty(_el$2, "height", _p$.s = _v$7);
-      _v$8 !== _p$.h && setStyleProperty(_el$2, "transform", _p$.h = _v$8);
+      _v$2 !== _p$.t && (_el$.disabled = _p$.t = _v$2);
+      _v$3 !== _p$.a && setAttribute(_el$, "tabindex", _p$.a = _v$3);
+      _v$4 !== _p$.o && setAttribute(_el$, "aria-hidden", _p$.o = _v$4);
+      _p$.i = style(_el$, _v$5, _p$.i);
+      _v$6 !== _p$.n && setAttribute(_el$, "title", _p$.n = _v$6);
+      _v$7 !== _p$.s && setAttribute(_el$, "aria-label", _p$.s = _v$7);
+      _v$8 !== _p$.h && setAttribute(_el$, "aria-describedby", _p$.h = _v$8);
+      _v$9 !== _p$.r && setStyleProperty(_el$2, "width", _p$.r = _v$9);
+      _v$0 !== _p$.d && setStyleProperty(_el$2, "height", _p$.d = _v$0);
+      _v$1 !== _p$.l && setStyleProperty(_el$2, "transform", _p$.l = _v$1);
       return _p$;
     }, {
       e: void 0,
@@ -10628,7 +10688,10 @@ function PixelWorldHotspot(props) {
       i: void 0,
       n: void 0,
       s: void 0,
-      h: void 0
+      h: void 0,
+      r: void 0,
+      d: void 0,
+      l: void 0
     });
     return _el$;
   })();
@@ -10661,9 +10724,9 @@ function PixelWorldHotspotTooltip(props) {
         }
       };
       createRenderEffect((_p$) => {
-        var _v$9 = pixelWorldHotspotTooltipId(hotspot()), _v$0 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
-        _v$9 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$9);
-        _v$0 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$0);
+        var _v$10 = pixelWorldHotspotTooltipId(hotspot()), _v$11 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
+        _v$10 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$10);
+        _v$11 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$11);
         return _p$;
       }, {
         e: void 0,
@@ -10697,55 +10760,6 @@ function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}
   if (status === "connecting" || status === "reconnecting") return warn(tr$2(locale, "正在重连", "RECONNECTING"), "reconnecting");
   if (status !== "connected") return warn(tr$2(locale, "离线", "OFFLINE"), "offline");
   return feedStatus === "ready" ? { label: tr$2(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" } : warn(tr$2(locale, "同步中", "SYNCING"), "syncing");
-}
-const PIXEL_WORLD_CANVAS_WIDTH = 960;
-const PIXEL_WORLD_CANVAS_HEIGHT = 540;
-const PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX = 44;
-function safeNumber$1(value2, fallback = 0) {
-  const number = Number(value2);
-  return Number.isFinite(number) ? number : fallback;
-}
-function clampRatio$1(value2) {
-  return Math.min(1, Math.max(0, safeNumber$1(value2)));
-}
-function toCanvasPoint(position, worldBounds, width, height, cameraState) {
-  if (!position || !worldBounds) return null;
-  const x = clampRatio$1(safeNumber$1(position.x_cm ?? position.xCm) / Math.max(1, safeNumber$1(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
-  const y = clampRatio$1(safeNumber$1(position.y_cm ?? position.yCm) / Math.max(1, safeNumber$1(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
-  const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
-  return {
-    x: width / 2 + (20 + x * Math.max(1, width - 40) - width / 2) * zoom + (Number(cameraState?.pan_x_px ?? cameraState?.panX) || 0),
-    y: height / 2 + (20 + y * Math.max(1, height - 40) - height / 2) * zoom + (Number(cameraState?.pan_y_px ?? cameraState?.panY) || 0)
-  };
-}
-function pixelWorldHotspotGlyphSize(hotspot) {
-  return Math.max(
-    14,
-    Math.min(32, safeNumber$1(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
-  );
-}
-function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
-  const fallback = {
-    left: `${20 + index % 4 * 16}%`,
-    top: `${22 + Math.floor(index / 4) * 16}%`
-  };
-  const position = hotspot?.pos;
-  if (!position || !worldBounds) {
-    return {
-      ...fallback,
-      width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
-      height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
-      transform: "translate(-50%, -50%)"
-    };
-  }
-  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
-  return {
-    left: `${point.x / PIXEL_WORLD_CANVAS_WIDTH * 100}%`,
-    top: `${point.y / PIXEL_WORLD_CANVAS_HEIGHT * 100}%`,
-    width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
-    height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
-    transform: "translate(-50%, -50%)"
-  };
 }
 var _tmpl$$p = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$4$j = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--mid">`), _tmpl$7$8 = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--target">`), _tmpl$8$5 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span>`), _tmpl$0$4 = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span>`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$14$1 = /* @__PURE__ */ template(`<span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$23$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$24$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$25$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$29$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$32$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$33$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$37$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$39$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$40$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$44$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$45$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$46$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$47$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$48$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$49$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$50$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$51$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$52$1 = /* @__PURE__ */ template(`<div>`), _tmpl$53$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -61,7 +61,7 @@ function createRenderEffect(fn, value2, options) {
 function createEffect(fn, value2, options) {
   runEffects = runUserEffects;
   const c = createComputation(fn, value2, false, STALE);
-  c.user = true;
+  if (!options || !options.render) c.user = true;
   Effects ? Effects.push(c) : updateComputation(c);
 }
 function createMemo(fn, value2, options) {
@@ -99,6 +99,23 @@ function onCleanup(fn) {
 function getListener() {
   return Listener;
 }
+function getOwner() {
+  return Owner;
+}
+function runWithOwner(o, fn) {
+  const prev = Owner;
+  const prevListener = Listener;
+  Owner = o;
+  Listener = null;
+  try {
+    return runUpdates(fn, true);
+  } catch (err) {
+    handleError(err);
+  } finally {
+    Owner = prev;
+    Listener = prevListener;
+  }
+}
 const [transPending, setTransPending] = /* @__PURE__ */ createSignal(false);
 function readSignal() {
   if (this.sources && this.state) {
@@ -111,20 +128,23 @@ function readSignal() {
     }
   }
   if (Listener) {
-    const sSlot = this.observers ? this.observers.length : 0;
-    if (!Listener.sources) {
-      Listener.sources = [this];
-      Listener.sourceSlots = [sSlot];
-    } else {
-      Listener.sources.push(this);
-      Listener.sourceSlots.push(sSlot);
-    }
-    if (!this.observers) {
-      this.observers = [Listener];
-      this.observerSlots = [Listener.sources.length - 1];
-    } else {
-      this.observers.push(Listener);
-      this.observerSlots.push(Listener.sources.length - 1);
+    const observers = this.observers;
+    if (!observers || observers[observers.length - 1] !== Listener) {
+      const sSlot = observers ? observers.length : 0;
+      if (!Listener.sources) {
+        Listener.sources = [this];
+        Listener.sourceSlots = [sSlot];
+      } else {
+        Listener.sources.push(this);
+        Listener.sourceSlots.push(sSlot);
+      }
+      if (!observers) {
+        this.observers = [Listener];
+        this.observerSlots = [Listener.sources.length - 1];
+      } else {
+        observers.push(Listener);
+        this.observerSlots.push(Listener.sources.length - 1);
+      }
     }
   }
   return this.value;
@@ -633,6 +653,9 @@ function style(node, value2, prev) {
   }
   return prev;
 }
+function setStyleProperty(node, name, value2) {
+  value2 != null ? node.style.setProperty(name, value2) : node.style.removeProperty(name);
+}
 function use(fn, element, arg) {
   return untrack(() => fn(element, arg));
 }
@@ -790,6 +813,45 @@ function cleanChildren(parent, current, marker, replacement) {
     }
   } else parent.insertBefore(node, marker);
   return [node];
+}
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+function createElement(tagName, isSVG = false, is = void 0) {
+  return isSVG ? document.createElementNS(SVG_NAMESPACE, tagName) : document.createElement(tagName, {
+    is
+  });
+}
+function Portal(props) {
+  const {
+    useShadow
+  } = props, marker = document.createTextNode(""), mount = () => props.mount || document.body, owner = getOwner();
+  let content;
+  createEffect(() => {
+    content || (content = runWithOwner(owner, () => createMemo(() => props.children)));
+    const el = mount();
+    if (el instanceof HTMLHeadElement) {
+      const [clean, setClean] = createSignal(false);
+      const cleanup = () => setClean(true);
+      createRoot((dispose2) => insert(el, () => !clean() ? content() : dispose2(), null));
+      onCleanup(cleanup);
+    } else {
+      const container = createElement(props.isSVG ? "g" : "div", props.isSVG), renderRoot = useShadow && container.attachShadow ? container.attachShadow({
+        mode: "open"
+      }) : container;
+      Object.defineProperty(container, "_$host", {
+        get() {
+          return marker.parentNode;
+        },
+        configurable: true
+      });
+      insert(renderRoot, content);
+      el.appendChild(container);
+      props.ref && props.ref(container);
+      onCleanup(() => el.contains(container) && el.removeChild(container));
+    }
+  }, void 0, {
+    render: true
+  });
+  return marker;
 }
 const TEST_API_GLOBAL_NAME = "__AW_TEST__";
 const RENDER_META_GLOBAL_NAME = "__AW_VIEWER_RENDER_META__";
@@ -4497,6 +4559,9 @@ function ownKeys(target) {
   return Reflect.ownKeys(target);
 }
 function setProperty(state2, property, value2, deleting = false) {
+  if (property === "__proto__") {
+    return;
+  }
   if (!deleting && state2[property] === value2) return;
   const prev = state2[property], len = state2.length;
   if (value2 === void 0) {
@@ -4538,7 +4603,7 @@ const proxyTraps = {
     if (!tracked) {
       const desc = Object.getOwnPropertyDescriptor(target, property);
       const isFunction = typeof value2 === "function";
-      if (getListener() && (!isFunction || target.hasOwnProperty(property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
+      if (getListener() && (!isFunction || Object.prototype.hasOwnProperty.call(target, property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
       else if (value2 != null && isFunction && value2 === Array.prototype[property]) {
         return (...args) => batch(() => Array.prototype[property].apply(receiver, args));
       }
@@ -10344,7 +10409,39 @@ function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
     feed?.removeEventListener("toggle", sync, true);
   };
 }
-var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot><span aria-hidden=true>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
+function hotspotTooltipSafeBand(summary, command, viewportHeight) {
+  const top = Math.max(10, summary.bottom + 4);
+  const bottom = Math.min(viewportHeight - 10, command?.top ?? viewportHeight - 10) - 4;
+  return { top, maxHeight: Math.max(26, bottom - top) };
+}
+function installHotspotTooltipPlacement(tooltip) {
+  const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const command = document.querySelector('[data-viewer-overlay="next-move"]');
+  const update = () => {
+    for (const property of ["top", "bottom", "max-height", "overflow-y", "padding"]) tooltip.style.removeProperty(property);
+    if (!feed?.open) return;
+    const summary = feed.querySelector("summary");
+    if (!summary) return;
+    const summaryRect = summary.getBoundingClientRect();
+    const rect = tooltip.getBoundingClientRect();
+    if (rect.bottom <= summaryRect.top || rect.top >= summaryRect.bottom) return;
+    const commandRect = command && getComputedStyle(command).display !== "none" ? command.getBoundingClientRect() : null;
+    const band = hotspotTooltipSafeBand(summaryRect, commandRect, window.innerHeight);
+    tooltip.style.top = `${band.top}px`;
+    tooltip.style.bottom = "auto";
+    tooltip.style.maxHeight = `${band.maxHeight}px`;
+    tooltip.style.overflowY = "auto";
+    if (band.maxHeight < 40) tooltip.style.padding = "1px 7px";
+  };
+  update();
+  window.addEventListener("resize", update);
+  feed?.addEventListener("toggle", update);
+  return () => {
+    window.removeEventListener("resize", update);
+    feed?.removeEventListener("toggle", update);
+  };
+}
+var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
 function isZhLocale$1(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
@@ -10366,13 +10463,54 @@ function pixelWorldHotspotTooltipId(hotspot) {
   const id = String(hotspot?.id || hotspot?.kind || "hotspot").trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
   return `pixel-world-hotspot-tooltip-${id || "hotspot"}`;
 }
+function createHotspotFocusRestoration() {
+  let trigger;
+  return {
+    remember: (element) => {
+      trigger = element;
+    },
+    restore: () => {
+      if (trigger) trigger.dataset.dismissedHover = "true";
+      queueMicrotask(() => {
+        if (!trigger || !document.contains(trigger)) return;
+        trigger.dataset.restoringFocus = "true";
+        trigger.focus();
+        delete trigger.dataset.restoringFocus;
+      });
+    }
+  };
+}
 function PixelWorldHotspot(props) {
+  let buttonRef;
+  const [stageSize, setStageSize] = createSignal({
+    width: 960,
+    height: 540
+  });
+  onMount(() => {
+    const stage = buttonRef.parentElement;
+    const update = () => {
+      const rect = stage.getBoundingClientRect();
+      if (rect.width && rect.height) setStageSize(rect);
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(stage);
+    onCleanup(() => observer.disconnect());
+  });
+  const glyphOffset = (axis, dimension) => {
+    const size = stageSize()[dimension];
+    const point = parseFloat(props.style?.[axis] || "50") * size / 100;
+    return point - Math.max(22, Math.min(size - 22, point));
+  };
   const hotspot = () => props.hotspot;
   const selection = () => ({
     kind: "hotspot",
     id: hotspot().id
   });
   const inspect = () => {
+    delete buttonRef.dataset.dismissedHover;
+    props.onHotspotTrigger?.(buttonRef);
     props.onHotspotInspect?.(selection());
     props.onHover?.(selection());
   };
@@ -10384,69 +10522,117 @@ function PixelWorldHotspot(props) {
       inspect();
     };
     _el$.$$keydown = (event) => {
+      if (event.key === "Tab" && !event.shiftKey) {
+        const close = document.getElementById(pixelWorldHotspotTooltipId(hotspot()))?.querySelector("button");
+        if (close) {
+          event.preventDefault();
+          close.focus();
+        }
+      }
       if (event.key === "Escape") {
         event.preventDefault();
         props.onHotspotClear?.();
         props.onHover?.(null);
-        event.currentTarget.blur();
+        props.onHotspotRestoreFocus?.();
       }
     };
-    _el$.addEventListener("mouseleave", () => props.onHover?.(null));
-    _el$.addEventListener("mouseenter", () => props.onHover?.(selection()));
+    _el$.addEventListener("mouseleave", (event) => {
+      if (event.relatedTarget?.closest?.("[data-hotspot-tooltip]")?.id === pixelWorldHotspotTooltipId(hotspot())) return;
+      delete buttonRef.dataset.dismissedHover;
+      props.onHover?.(null);
+    });
+    _el$.$$mousemove = () => {
+      delete buttonRef.dataset.dismissedHover;
+      props.onHotspotHoverIntent?.();
+      props.onHotspotTrigger?.(buttonRef);
+      props.onHover?.(selection());
+    };
+    _el$.addEventListener("mouseenter", () => {
+      if (buttonRef.dataset.dismissedHover) return;
+      props.onHotspotTrigger?.(buttonRef);
+      props.onHover?.(selection());
+    });
     _el$.addEventListener("blur", () => props.onHover?.(null));
-    _el$.addEventListener("focus", inspect);
+    _el$.addEventListener("focus", () => {
+      if (buttonRef.dataset.restoringFocus) return;
+      inspect();
+    });
+    var _ref$ = buttonRef;
+    typeof _ref$ === "function" ? use(_ref$, _el$) : buttonRef = _el$;
     insert(_el$2, (() => {
       var _c$ = memo(() => hotspot().kind === "blocker");
       return () => _c$() ? "!" : hotspot().kind === "goal" ? "G" : "i";
     })());
     createRenderEffect((_p$) => {
-      var _v$ = hotspot().kind, _v$2 = props.style, _v$3 = `${hotspot().kind}:${hotspot().label}`, _v$4 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$5 = pixelWorldHotspotTooltipId(hotspot());
+      var _v$ = hotspot().kind, _v$2 = {
+        ...props.style,
+        "--hotspot-projected-x": props.style?.left,
+        "--hotspot-projected-y": props.style?.top,
+        left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
+        top: `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`
+      }, _v$3 = `${hotspot().kind}:${hotspot().label}`, _v$4 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$5 = pixelWorldHotspotTooltipId(hotspot()), _v$6 = `${Number(props.glyphSize) || 20}px`, _v$7 = `${Number(props.glyphSize) || 20}px`, _v$8 = `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`;
       _v$ !== _p$.e && setAttribute(_el$, "data-hotspot-kind", _p$.e = _v$);
       _p$.t = style(_el$, _v$2, _p$.t);
       _v$3 !== _p$.a && setAttribute(_el$, "title", _p$.a = _v$3);
       _v$4 !== _p$.o && setAttribute(_el$, "aria-label", _p$.o = _v$4);
       _v$5 !== _p$.i && setAttribute(_el$, "aria-describedby", _p$.i = _v$5);
+      _v$6 !== _p$.n && setStyleProperty(_el$2, "width", _p$.n = _v$6);
+      _v$7 !== _p$.s && setStyleProperty(_el$2, "height", _p$.s = _v$7);
+      _v$8 !== _p$.h && setStyleProperty(_el$2, "transform", _p$.h = _v$8);
       return _p$;
     }, {
       e: void 0,
       t: void 0,
       a: void 0,
       o: void 0,
-      i: void 0
+      i: void 0,
+      n: void 0,
+      s: void 0,
+      h: void 0
     });
     return _el$;
   })();
 }
 function PixelWorldHotspotTooltip(props) {
+  let tooltipRef;
+  onMount(() => onCleanup(installHotspotTooltipPlacement(tooltipRef)));
   const hotspot = () => props.hotspot;
-  return (() => {
-    var _el$3 = _tmpl$2$q(), _el$4 = _el$3.firstChild, _el$5 = _el$4.nextSibling;
-    insert(_el$4, () => `${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`);
-    _el$5.$$click = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      props.onClose?.();
-    };
-    _el$5.$$keydown = (event) => {
-      if (event.key === "Escape") {
+  return createComponent(Portal, {
+    get children() {
+      var _el$3 = _tmpl$2$q(), _el$4 = _el$3.firstChild, _el$5 = _el$4.nextSibling;
+      _el$3.addEventListener("mouseleave", (event) => {
+        if (event.relatedTarget?.closest?.(".pixel-world-hotspot")?.getAttribute("aria-describedby") === pixelWorldHotspotTooltipId(hotspot())) return;
+        props.onHoverLeave?.();
+      });
+      var _ref$2 = tooltipRef;
+      typeof _ref$2 === "function" ? use(_ref$2, _el$3) : tooltipRef = _el$3;
+      insert(_el$4, () => `${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`);
+      _el$5.$$click = (event) => {
         event.preventDefault();
         event.stopPropagation();
         props.onClose?.();
-      }
-    };
-    createRenderEffect((_p$) => {
-      var _v$6 = pixelWorldHotspotTooltipId(hotspot()), _v$7 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
-      _v$6 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$6);
-      _v$7 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$7);
-      return _p$;
-    }, {
-      e: void 0,
-      t: void 0
-    });
-    return _el$3;
-  })();
+      };
+      _el$5.$$keydown = (event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          props.onClose?.();
+        }
+      };
+      createRenderEffect((_p$) => {
+        var _v$9 = pixelWorldHotspotTooltipId(hotspot()), _v$0 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
+        _v$9 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$9);
+        _v$0 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$0);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0
+      });
+      return _el$3;
+    }
+  });
 }
-delegateEvents(["keydown", "click"]);
+delegateEvents(["mousemove", "keydown", "click"]);
 function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
@@ -10470,6 +10656,55 @@ function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}
   if (status === "connecting" || status === "reconnecting") return warn(tr$2(locale, "正在重连", "RECONNECTING"), "reconnecting");
   if (status !== "connected") return warn(tr$2(locale, "离线", "OFFLINE"), "offline");
   return feedStatus === "ready" ? { label: tr$2(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" } : warn(tr$2(locale, "同步中", "SYNCING"), "syncing");
+}
+const PIXEL_WORLD_CANVAS_WIDTH = 960;
+const PIXEL_WORLD_CANVAS_HEIGHT = 540;
+const PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX = 44;
+function safeNumber$1(value2, fallback = 0) {
+  const number = Number(value2);
+  return Number.isFinite(number) ? number : fallback;
+}
+function clampRatio$1(value2) {
+  return Math.min(1, Math.max(0, safeNumber$1(value2)));
+}
+function toCanvasPoint(position, worldBounds, width, height, cameraState) {
+  if (!position || !worldBounds) return null;
+  const x = clampRatio$1(safeNumber$1(position.x_cm ?? position.xCm) / Math.max(1, safeNumber$1(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
+  const y = clampRatio$1(safeNumber$1(position.y_cm ?? position.yCm) / Math.max(1, safeNumber$1(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
+  const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
+  return {
+    x: width / 2 + (20 + x * Math.max(1, width - 40) - width / 2) * zoom + (Number(cameraState?.pan_x_px ?? cameraState?.panX) || 0),
+    y: height / 2 + (20 + y * Math.max(1, height - 40) - height / 2) * zoom + (Number(cameraState?.pan_y_px ?? cameraState?.panY) || 0)
+  };
+}
+function pixelWorldHotspotGlyphSize(hotspot) {
+  return Math.max(
+    14,
+    Math.min(32, safeNumber$1(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
+  );
+}
+function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
+  const fallback = {
+    left: `${20 + index % 4 * 16}%`,
+    top: `${22 + Math.floor(index / 4) * 16}%`
+  };
+  const position = hotspot?.pos;
+  if (!position || !worldBounds) {
+    return {
+      ...fallback,
+      width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+      transform: "translate(-50%, -50%)"
+    };
+  }
+  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
+  return {
+    left: `${point.x / PIXEL_WORLD_CANVAS_WIDTH * 100}%`,
+    top: `${point.y / PIXEL_WORLD_CANVAS_HEIGHT * 100}%`,
+    width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
+    transform: "translate(-50%, -50%)"
+  };
 }
 var _tmpl$$p = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$4$j = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--mid">`), _tmpl$7$8 = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--target">`), _tmpl$8$5 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span>`), _tmpl$0$4 = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span>`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$14$1 = /* @__PURE__ */ template(`<span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$23$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$24$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$25$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$29$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$32$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$33$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$37$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$39$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$40$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$44$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$45$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$46$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$47$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$48$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$49$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$50$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$51$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$52$1 = /* @__PURE__ */ template(`<div>`), _tmpl$53$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
@@ -10611,18 +10846,6 @@ function routeWaypointStyle(link, worldBounds, index, stop) {
     top: `${(from.y + (to.y - from.y) * ratio).toFixed(1)}%`
   };
 }
-function hotspotStyle(hotspot, worldBounds, index) {
-  const sizePx = Math.max(14, Math.min(32, safeNumber(hotspot.size_hint_px, 16)));
-  return {
-    ...toWorldPercentStyle(hotspot.pos, worldBounds, {
-      left: `${20 + index % 4 * 16}%`,
-      top: `${22 + Math.floor(index / 4) * 16}%`
-    }),
-    width: `${sizePx}px`,
-    height: `${sizePx}px`,
-    transform: "translate(-50%, -50%)"
-  };
-}
 function fieldValue(value2, snakeName, camelName, fallback = void 0) {
   if (!value2 || typeof value2 !== "object") {
     return fallback;
@@ -10669,7 +10892,7 @@ function pixelWorldVisualState(renderState) {
 }
 function PixelWorldHostHotspotLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
-  return createComponent(For, {
+  return createComponent(Index, {
     get each() {
       return visualState().visualHotspots.slice(0, 8);
     },
@@ -10677,9 +10900,14 @@ function PixelWorldHostHotspotLayer(props) {
       get locale() {
         return props.locale();
       },
-      hotspot,
+      get hotspot() {
+        return hotspot();
+      },
       get style() {
-        return hotspotStyle(hotspot, visualState().worldBounds, index());
+        return pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.());
+      },
+      get glyphSize() {
+        return pixelWorldHotspotGlyphSize(hotspot());
       },
       get onHover() {
         return props.onHover;
@@ -10689,6 +10917,15 @@ function PixelWorldHostHotspotLayer(props) {
       },
       get onHotspotClear() {
         return props.onHotspotClear;
+      },
+      get onHotspotHoverIntent() {
+        return props.onHotspotHoverIntent;
+      },
+      get onHotspotTrigger() {
+        return props.onHotspotTrigger;
+      },
+      get onHotspotRestoreFocus() {
+        return props.onHotspotRestoreFocus;
       }
     })
   });
@@ -11115,14 +11352,16 @@ function buildPixelWorldRenderInput(locale = state.uiLocale) {
 }
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
+  const hotspotFocus = createHotspotFocusRestoration();
   const visualState = () => pixelWorldVisualState(props.renderState());
   const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
+  const [hoverDismissed, setHoverDismissed] = createSignal(false);
   const activeHotspot = () => {
     const inspected = inspectedHotspot();
     if (inspected?.kind === "hotspot") {
       return visualState().visualHotspots.find((hotspot) => hotspot.id === inspected.id) || null;
     }
-    return props.hoveredHotspot?.() || null;
+    return hoverDismissed() ? null : props.hoveredHotspot?.() || null;
   };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
@@ -11189,11 +11428,27 @@ function PixelWorldCanvasRenderer(props) {
       get renderState() {
         return props.renderState;
       },
+      get cameraState() {
+        return props.cameraState;
+      },
       get onHover() {
         return props.onHover;
       },
-      onHotspotInspect: setInspectedHotspot,
-      onHotspotClear: () => setInspectedHotspot(null)
+      onHotspotInspect: (selection) => {
+        setHoverDismissed(false);
+        setInspectedHotspot(selection);
+      },
+      onHotspotHoverIntent: () => setHoverDismissed(false),
+      onHotspotClear: () => {
+        setHoverDismissed(true);
+        setInspectedHotspot(null);
+      },
+      get onHotspotTrigger() {
+        return hotspotFocus.remember;
+      },
+      get onHotspotRestoreFocus() {
+        return hotspotFocus.restore;
+      }
     }), null);
     insert(_el$15, createComponent(Show, {
       get when() {
@@ -11227,9 +11482,12 @@ function PixelWorldCanvasRenderer(props) {
           get hotspot() {
             return activeHotspot();
           },
+          onHoverLeave: () => props.onHover(null),
           onClose: () => {
+            setHoverDismissed(true);
             setInspectedHotspot(null);
             props.onHover(null);
+            hotspotFocus.restore();
           }
         });
       }
@@ -12302,6 +12560,7 @@ function PixelWorldHost(props) {
         return createComponent(PixelWorldCanvasRenderer, {
           locale,
           rendererStatus,
+          cameraState,
           renderInput,
           renderState,
           selection: selectedEntity,

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10409,39 +10409,73 @@ function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
     feed?.removeEventListener("toggle", sync, true);
   };
 }
-function hotspotTooltipSafeBand(summary, command, viewportHeight) {
-  const top = Math.max(10, summary.bottom + 4);
-  const bottom = Math.min(viewportHeight - 10, command?.top ?? viewportHeight - 10) - 4;
-  return { top, maxHeight: Math.max(26, bottom - top) };
+const MARGIN = 10;
+const MIN_HEIGHT = 56;
+function hotspotTooltipSafeBand(summary, command, viewportHeight, preferredTop = 52) {
+  const obstacles = [summary, command].filter(Boolean).map((rect) => ({
+    top: Math.max(MARGIN, rect.top - 4),
+    bottom: Math.min(viewportHeight - MARGIN, (rect.bottom ?? viewportHeight) + 4)
+  })).sort((a, b) => a.top - b.top);
+  const bands = [];
+  let cursor = MARGIN;
+  for (const obstacle of obstacles) {
+    if (obstacle.top - cursor >= MIN_HEIGHT) bands.push({ top: cursor, bottom: obstacle.top });
+    cursor = Math.max(cursor, obstacle.bottom);
+  }
+  if (viewportHeight - MARGIN - cursor >= MIN_HEIGHT) bands.push({ top: cursor, bottom: viewportHeight - MARGIN });
+  if (!bands.length) bands.push({ top: MARGIN, bottom: Math.max(MARGIN + MIN_HEIGHT, viewportHeight - MARGIN) });
+  const distance = (band2) => Math.abs(Math.max(band2.top, Math.min(band2.bottom - MIN_HEIGHT, preferredTop)) - preferredTop);
+  bands.sort((a, b) => distance(a) - distance(b));
+  const band = bands[0];
+  return { top: band.top, maxHeight: band.bottom - band.top };
 }
 function installHotspotTooltipPlacement(tooltip) {
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
   const command = document.querySelector('[data-viewer-overlay="next-move"]');
+  const summary = feed?.querySelector("summary");
+  const visibleRect = (node) => node && getComputedStyle(node).display !== "none" ? node.getBoundingClientRect() : null;
   const update = () => {
-    for (const property of ["top", "bottom", "max-height", "overflow-y", "padding"]) tooltip.style.removeProperty(property);
-    if (!feed?.open) return;
-    const summary = feed.querySelector("summary");
-    if (!summary) return;
-    const summaryRect = summary.getBoundingClientRect();
-    const rect = tooltip.getBoundingClientRect();
-    if (rect.bottom <= summaryRect.top || rect.top >= summaryRect.bottom) return;
-    const commandRect = command && getComputedStyle(command).display !== "none" ? command.getBoundingClientRect() : null;
-    const band = hotspotTooltipSafeBand(summaryRect, commandRect, window.innerHeight);
+    tooltip.style.removeProperty("top");
+    tooltip.style.removeProperty("bottom");
+    const preferredTop = tooltip.getBoundingClientRect().top;
+    const band = hotspotTooltipSafeBand(visibleRect(summary), visibleRect(command), window.innerHeight, preferredTop);
     tooltip.style.top = `${band.top}px`;
     tooltip.style.bottom = "auto";
-    tooltip.style.maxHeight = `${band.maxHeight}px`;
-    tooltip.style.overflowY = "auto";
-    if (band.maxHeight < 40) tooltip.style.padding = "1px 7px";
+    tooltip.style.setProperty("--hotspot-tooltip-max-height", `${band.maxHeight}px`);
   };
   update();
+  const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
+  for (const node of [summary, command]) if (node) observer?.observe(node);
   window.addEventListener("resize", update);
   feed?.addEventListener("toggle", update);
   return () => {
+    observer?.disconnect();
     window.removeEventListener("resize", update);
     feed?.removeEventListener("toggle", update);
   };
 }
-var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
+const FOCUSABLE = "button, a[href], input, select, textarea, [tabindex]";
+function moveFocusFromHotspotTooltip(tooltip, backwards) {
+  const trigger = [...document.querySelectorAll(".pixel-world-hotspot")].find((node) => node.getAttribute("aria-describedby") === tooltip.id);
+  if (!trigger) return false;
+  if (backwards) {
+    trigger.focus();
+    return true;
+  }
+  const controls = [...document.querySelectorAll(FOCUSABLE)].filter((node) => {
+    if (node.tabIndex < 0 || node.disabled || tooltip.contains(node)) return false;
+    for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+      const style2 = getComputedStyle(ancestor);
+      if (ancestor.hidden || ancestor.inert || style2.display === "none" || style2.visibility === "hidden") return false;
+    }
+    return true;
+  });
+  const next = controls[controls.indexOf(trigger) + 1];
+  if (!next || next === trigger) return false;
+  next.focus();
+  return document.activeElement === next;
+}
+var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span data-hotspot-tooltip-body></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
 function isZhLocale$1(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
@@ -10613,6 +10647,7 @@ function PixelWorldHotspotTooltip(props) {
         props.onClose?.();
       };
       _el$5.$$keydown = (event) => {
+        if (event.key === "Tab" && moveFocusFromHotspotTooltip(tooltipRef, event.shiftKey)) event.preventDefault();
         if (event.key === "Escape") {
           event.preventDefault();
           event.stopPropagation();

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10454,22 +10454,28 @@ function installHotspotTooltipPlacement(tooltip) {
     feed?.removeEventListener("toggle", update);
   };
 }
-const FOCUSABLE = "button, a[href], input, select, textarea, [tabindex]";
+const FOCUSABLE = "button, a[href], input, select, textarea, summary, [tabindex]";
+function firstSummary(details) {
+  return [...details.children].find((child) => child.tagName === "SUMMARY");
+}
+function isAvailableControl(node) {
+  if (node.tabIndex < 0 || node.disabled) return false;
+  if (node.tagName === "SUMMARY" && !node.hasAttribute("tabindex") && (node.parentElement?.tagName !== "DETAILS" || firstSummary(node.parentElement) !== node)) return false;
+  for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
+    const style2 = getComputedStyle(ancestor);
+    if (ancestor.hidden || ancestor.inert || style2.display === "none" || style2.visibility === "hidden") return false;
+    if (ancestor.tagName === "DETAILS" && !ancestor.open && !firstSummary(ancestor)?.contains(node)) return false;
+  }
+  return true;
+}
 function moveFocusFromHotspotTooltip(tooltip, backwards) {
   const trigger = [...document.querySelectorAll(".pixel-world-hotspot")].find((node) => node.getAttribute("aria-describedby") === tooltip.id);
-  if (!trigger) return false;
+  if (!trigger || !isAvailableControl(trigger)) return false;
   if (backwards) {
     trigger.focus();
     return true;
   }
-  const controls = [...document.querySelectorAll(FOCUSABLE)].filter((node) => {
-    if (node.tabIndex < 0 || node.disabled || tooltip.contains(node)) return false;
-    for (let ancestor = node; ancestor; ancestor = ancestor.parentElement) {
-      const style2 = getComputedStyle(ancestor);
-      if (ancestor.hidden || ancestor.inert || style2.display === "none" || style2.visibility === "hidden") return false;
-    }
-    return true;
-  });
+  const controls = [...document.querySelectorAll(FOCUSABLE)].filter((node) => !tooltip.contains(node) && isAvailableControl(node));
   const next = controls[controls.indexOf(trigger) + 1];
   if (!next || next === trigger) return false;
   next.focus();

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -111,23 +111,20 @@ function readSignal() {
     }
   }
   if (Listener) {
-    const observers = this.observers;
-    if (!observers || observers[observers.length - 1] !== Listener) {
-      const sSlot = observers ? observers.length : 0;
-      if (!Listener.sources) {
-        Listener.sources = [this];
-        Listener.sourceSlots = [sSlot];
-      } else {
-        Listener.sources.push(this);
-        Listener.sourceSlots.push(sSlot);
-      }
-      if (!observers) {
-        this.observers = [Listener];
-        this.observerSlots = [Listener.sources.length - 1];
-      } else {
-        observers.push(Listener);
-        this.observerSlots.push(Listener.sources.length - 1);
-      }
+    const sSlot = this.observers ? this.observers.length : 0;
+    if (!Listener.sources) {
+      Listener.sources = [this];
+      Listener.sourceSlots = [sSlot];
+    } else {
+      Listener.sources.push(this);
+      Listener.sourceSlots.push(sSlot);
+    }
+    if (!this.observers) {
+      this.observers = [Listener];
+      this.observerSlots = [Listener.sources.length - 1];
+    } else {
+      this.observers.push(Listener);
+      this.observerSlots.push(Listener.sources.length - 1);
     }
   }
   return this.value;
@@ -4500,9 +4497,6 @@ function ownKeys(target) {
   return Reflect.ownKeys(target);
 }
 function setProperty(state2, property, value2, deleting = false) {
-  if (property === "__proto__") {
-    return;
-  }
   if (!deleting && state2[property] === value2) return;
   const prev = state2[property], len = state2.length;
   if (value2 === void 0) {
@@ -4544,7 +4538,7 @@ const proxyTraps = {
     if (!tracked) {
       const desc = Object.getOwnPropertyDescriptor(target, property);
       const isFunction = typeof value2 === "function";
-      if (getListener() && (!isFunction || Object.prototype.hasOwnProperty.call(target, property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
+      if (getListener() && (!isFunction || target.hasOwnProperty(property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
       else if (value2 != null && isFunction && value2 === Array.prototype[property]) {
         return (...args) => batch(() => Array.prototype[property].apply(receiver, args));
       }
@@ -9509,7 +9503,7 @@ const core = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty
   toggleViewerLocale,
   updatePixelWorldRuntimeMeta
 }, Symbol.toStringTag, { value: "Module" }));
-var _tmpl$$q = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
+var _tmpl$$r = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
 const ZH_VALUE_MAP = {
   chat_purpose: {
     "Start a first conversation with your claimed Agent.": "与已认领的 Agent 开始第一次对话。"
@@ -9540,13 +9534,13 @@ function FirstChatUnlockPreview(props) {
   const fields = () => [["chat_purpose", tr2("目的", "Purpose")], ["immediate_playable_help", tr2("即时帮助", "Immediate help")], ["first_question_or_action_hint", tr2("先试试", "Try first")], ["resource_boundary", tr2("资源边界", "Resource boundary")], ["defer_effect", tr2("如果等待", "If you wait")], ["recommended_unlock_action", tr2("建议操作", "Recommended action")]];
   const value2 = (field) => field === "recommended_unlock_action" ? recommendedActionValue(props.preview[field], locale()) : previewValue(field, props.preview[field], locale());
   return (() => {
-    var _el$ = _tmpl$$q();
+    var _el$ = _tmpl$$r();
     insert(_el$, createComponent(For, {
       get each() {
         return fields();
       },
       children: ([field, label]) => (() => {
-        var _el$2 = _tmpl$2$q(), _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling;
+        var _el$2 = _tmpl$2$r(), _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling;
         setAttribute(_el$2, "data-preview-field", field);
         insert(_el$3, label);
         className(_el$4, field === "chat_purpose" ? "feedback-summary" : "feedback-detail");
@@ -10288,14 +10282,32 @@ function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, commandTop, 
   const clearFeedOffset = feedBottom + SAFE_AREA_GAP_PX - markerTop;
   return Math.max(clearCommandOffset, clearFeedOffset);
 }
+function pixelWorldMobileSelectionChipOffset({ chipTop, feedBottom = 0, feedOpen = false }) {
+  if (feedOpen || !Number.isFinite(chipTop) || !Number.isFinite(feedBottom) || feedBottom <= 0) return 0;
+  return Math.max(0, feedBottom + SAFE_AREA_GAP_PX - chipTop);
+}
 function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
   return hudRight + SAFE_AREA_GAP_PX - markerLeft;
 }
 function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
-  if (!marker) return;
-  marker.style.translate = "";
+  const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
+  const feed = document.querySelector('[data-viewer-overlay="feed"]');
+  const feedVisible = feed && getComputedStyle(feed).display !== "none";
+  const feedRect = feedVisible ? feed.getBoundingClientRect() : null;
+  selectionChip?.style.setProperty("translate", "");
+  marker?.style.setProperty("translate", "");
   if (window.innerWidth > MOBILE_SHELL_MAX_WIDTH) return;
+  if (selectionChip && feedRect && !feed.open) {
+    const chipRect = selectionChip.getBoundingClientRect();
+    const chipOffset = pixelWorldMobileSelectionChipOffset({
+      chipTop: chipRect.top,
+      feedBottom: feedRect.bottom,
+      feedOpen: feed.open
+    });
+    selectionChip.style.translate = `0 ${Math.ceil(chipOffset)}px`;
+  }
+  if (!marker) return;
   const focusHost = canvasRoot.closest(".pixel-world-host--focus");
   if (focusHost) {
     const focusHud = focusHost.querySelector("[data-focus-hud='true']");
@@ -10308,10 +10320,8 @@ function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   }
   const command = document.querySelector('[data-viewer-overlay="next-move"]');
   if (!command || getComputedStyle(command).display === "none") return;
-  const feed = document.querySelector('[data-viewer-overlay="feed"]');
   const markerRect = marker.getBoundingClientRect();
   const commandRect = command.getBoundingClientRect();
-  const feedRect = feed && getComputedStyle(feed).display !== "none" ? feed.getBoundingClientRect() : null;
   const offset = pixelWorldMobileSelectionOffset({
     markerTop: markerRect.top,
     markerBottom: markerRect.bottom,
@@ -10334,7 +10344,127 @@ function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
     feed?.removeEventListener("toggle", sync, true);
   };
 }
-var _tmpl$$p = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$4$j = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--mid">`), _tmpl$7$8 = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--target">`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-hotspot><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span>`), _tmpl$0$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span>`), _tmpl$1$1 = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span>`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status>`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$16$1 = /* @__PURE__ */ template(`<span>`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$19$1 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$20$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$23$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$24$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$25$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$26$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$31$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$34$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$35$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$36$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$37$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$39$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$40$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$42$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$44$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$45$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$46$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$47$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$48$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$49$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$50$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$51$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$52$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$53$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$54$1 = /* @__PURE__ */ template(`<div>`), _tmpl$55$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
+var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot><span aria-hidden=true>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
+function isZhLocale$1(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+function tr$3(locale, zh, en) {
+  return isZhLocale$1(locale) ? zh : en;
+}
+function pixelWorldHotspotKindLabel(locale, kind) {
+  const normalizedKind = String(kind || "info").trim().toLowerCase();
+  if (normalizedKind === "blocker") return tr$3(locale, "阻塞", "Blocker");
+  if (normalizedKind === "goal") return tr$3(locale, "目标", "Goal");
+  return tr$3(locale, "信息", "Info");
+}
+function pixelWorldHotspotAccessibleLabel(locale, hotspot) {
+  const kindLabel = pixelWorldHotspotKindLabel(locale, hotspot?.kind);
+  const label = String(hotspot?.label || hotspot?.id || "").trim();
+  return tr$3(locale, `${kindLabel}热点：${label}；只读说明。`, `${kindLabel} hotspot: ${label}; read-only explanation.`);
+}
+function pixelWorldHotspotTooltipId(hotspot) {
+  const id = String(hotspot?.id || hotspot?.kind || "hotspot").trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  return `pixel-world-hotspot-tooltip-${id || "hotspot"}`;
+}
+function PixelWorldHotspot(props) {
+  const hotspot = () => props.hotspot;
+  const selection = () => ({
+    kind: "hotspot",
+    id: hotspot().id
+  });
+  const inspect = () => {
+    props.onHotspotInspect?.(selection());
+    props.onHover?.(selection());
+  };
+  return (() => {
+    var _el$ = _tmpl$$q(), _el$2 = _el$.firstChild;
+    _el$.$$click = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      inspect();
+    };
+    _el$.$$keydown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        props.onHotspotClear?.();
+        props.onHover?.(null);
+        event.currentTarget.blur();
+      }
+    };
+    _el$.addEventListener("mouseleave", () => props.onHover?.(null));
+    _el$.addEventListener("mouseenter", () => props.onHover?.(selection()));
+    _el$.addEventListener("blur", () => props.onHover?.(null));
+    _el$.addEventListener("focus", inspect);
+    insert(_el$2, (() => {
+      var _c$ = memo(() => hotspot().kind === "blocker");
+      return () => _c$() ? "!" : hotspot().kind === "goal" ? "G" : "i";
+    })());
+    createRenderEffect((_p$) => {
+      var _v$ = hotspot().kind, _v$2 = props.style, _v$3 = `${hotspot().kind}:${hotspot().label}`, _v$4 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$5 = pixelWorldHotspotTooltipId(hotspot());
+      _v$ !== _p$.e && setAttribute(_el$, "data-hotspot-kind", _p$.e = _v$);
+      _p$.t = style(_el$, _v$2, _p$.t);
+      _v$3 !== _p$.a && setAttribute(_el$, "title", _p$.a = _v$3);
+      _v$4 !== _p$.o && setAttribute(_el$, "aria-label", _p$.o = _v$4);
+      _v$5 !== _p$.i && setAttribute(_el$, "aria-describedby", _p$.i = _v$5);
+      return _p$;
+    }, {
+      e: void 0,
+      t: void 0,
+      a: void 0,
+      o: void 0,
+      i: void 0
+    });
+    return _el$;
+  })();
+}
+function PixelWorldHotspotTooltip(props) {
+  const hotspot = () => props.hotspot;
+  return (() => {
+    var _el$3 = _tmpl$2$q(), _el$4 = _el$3.firstChild, _el$5 = _el$4.nextSibling;
+    insert(_el$4, () => `${pixelWorldHotspotKindLabel(props.locale, hotspot().kind)}: ${hotspot().label}`);
+    _el$5.$$click = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      props.onClose?.();
+    };
+    createRenderEffect((_p$) => {
+      var _v$6 = pixelWorldHotspotTooltipId(hotspot()), _v$7 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
+      _v$6 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$6);
+      _v$7 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$7);
+      return _p$;
+    }, {
+      e: void 0,
+      t: void 0
+    });
+    return _el$3;
+  })();
+}
+delegateEvents(["keydown", "click"]);
+function isZhLocale(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+function tr$2(locale, zh, en) {
+  return isZhLocale(locale) ? zh : en;
+}
+function warn(label, state2) {
+  return {
+    label,
+    className: `badge badge--warn pixel-world-readout__status pixel-world-readout__status--${state2}`
+  };
+}
+function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}) {
+  const status = String(connectionStatus || "").trim().toLowerCase();
+  const feedStatus = String(worldFeed.status || "").trim().toLowerCase();
+  if (feedStatus === "unavailable") return warn(tr$2(locale, "不可用", "UNAVAILABLE"), "unavailable");
+  if (feedStatus === "gap") return warn(tr$2(locale, "断档", "GAP"), "gap");
+  if (feedStatus === "replay") return { label: tr$2(locale, "回放", "REPLAY"), className: "badge badge--accent pixel-world-readout__status pixel-world-readout__status--replay" };
+  if (feedStatus === "empty") return { label: tr$2(locale, "暂无动态", "NO EVENTS"), className: "badge pixel-world-readout__status pixel-world-readout__status--empty" };
+  if (worldFeed.stale) return warn(tr$2(locale, "陈旧", "STALE"), "stale");
+  if (status === "connecting" || status === "reconnecting") return warn(tr$2(locale, "正在重连", "RECONNECTING"), "reconnecting");
+  if (status !== "connected") return warn(tr$2(locale, "离线", "OFFLINE"), "offline");
+  return feedStatus === "ready" ? { label: tr$2(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" } : warn(tr$2(locale, "同步中", "SYNCING"), "syncing");
+}
+var _tmpl$$p = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$4$j = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--mid">`), _tmpl$7$8 = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--target">`), _tmpl$8$5 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span>`), _tmpl$0$4 = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span>`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$14$1 = /* @__PURE__ */ template(`<span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$23$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$24$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$25$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$29$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$32$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$33$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$37$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$39$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$40$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$44$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$45$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$46$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$47$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$48$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$49$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$50$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$51$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$52$1 = /* @__PURE__ */ template(`<div>`), _tmpl$53$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
 }
@@ -10606,56 +10736,55 @@ function PixelWorldHostVisualLayer(props) {
     get each() {
       return visualState().visualHotspots.slice(0, 8);
     },
-    children: (hotspot, index) => (() => {
-      var _el$8 = _tmpl$8$5(), _el$9 = _el$8.firstChild;
-      insert(_el$9, (() => {
-        var _c$ = memo(() => hotspot.kind === "blocker");
-        return () => _c$() ? "!" : hotspot.kind === "goal" ? "G" : "i";
-      })());
-      createRenderEffect((_p$) => {
-        var _v$11 = hotspot.kind, _v$12 = hotspotStyle(hotspot, visualState().worldBounds, index()), _v$13 = `${hotspot.kind}:${hotspot.label}`;
-        _v$11 !== _p$.e && setAttribute(_el$8, "data-hotspot-kind", _p$.e = _v$11);
-        _p$.t = style(_el$8, _v$12, _p$.t);
-        _v$13 !== _p$.a && setAttribute(_el$8, "title", _p$.a = _v$13);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0
-      });
-      return _el$8;
-    })()
+    children: (hotspot, index) => createComponent(PixelWorldHotspot, {
+      get locale() {
+        return props.locale();
+      },
+      hotspot,
+      get style() {
+        return hotspotStyle(hotspot, visualState().worldBounds, index());
+      },
+      get onHover() {
+        return props.onHover;
+      },
+      get onHotspotInspect() {
+        return props.onHotspotInspect;
+      },
+      get onHotspotClear() {
+        return props.onHotspotClear;
+      }
+    })
   }), createComponent(Index, {
     get each() {
       return visualState().locations.slice(0, 8);
     },
     children: (location, index) => (() => {
-      var _el$0 = _tmpl$9$4(), _el$1 = _el$0.firstChild;
-      _el$0.$$click = () => props.onSelect({
+      var _el$8 = _tmpl$8$5(), _el$9 = _el$8.firstChild;
+      _el$8.$$click = () => props.onSelect({
         kind: "location",
         id: location().id
       });
-      _el$0.addEventListener("mouseleave", () => props.onHover(null));
-      _el$0.addEventListener("mouseenter", () => props.onHover({
+      _el$8.addEventListener("mouseleave", () => props.onHover(null));
+      _el$8.addEventListener("mouseenter", () => props.onHover({
         kind: "location",
         id: location().id
       }));
-      insert(_el$1, () => location().label.slice(0, 2).toUpperCase());
+      insert(_el$9, () => location().label.slice(0, 2).toUpperCase());
       createRenderEffect((_p$) => {
-        var _v$14 = location().id, _v$15 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$16 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$17 = `${tr$1(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$18 = location().marker_role, _v$19 = {
+        var _v$11 = location().id, _v$12 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$13 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$14 = `${tr$1(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$15 = location().marker_role, _v$16 = {
           ...toWorldPercentStyle(location().pos, visualState().worldBounds, {
             left: `${12 + index % 4 * 21}%`,
             top: `${18 + Math.floor(index / 4) * 26}%`
           }),
           opacity: location().marker_alpha
-        }, _v$20 = location().label;
-        _v$14 !== _p$.e && setAttribute(_el$0, "data-location-id", _p$.e = _v$14);
-        _v$15 !== _p$.t && setAttribute(_el$0, "data-selected", _p$.t = _v$15);
-        _v$16 !== _p$.a && setAttribute(_el$0, "aria-pressed", _p$.a = _v$16);
-        _v$17 !== _p$.o && setAttribute(_el$0, "aria-label", _p$.o = _v$17);
-        _v$18 !== _p$.i && setAttribute(_el$0, "data-marker-role", _p$.i = _v$18);
-        _p$.n = style(_el$0, _v$19, _p$.n);
-        _v$20 !== _p$.s && setAttribute(_el$0, "title", _p$.s = _v$20);
+        }, _v$17 = location().label;
+        _v$11 !== _p$.e && setAttribute(_el$8, "data-location-id", _p$.e = _v$11);
+        _v$12 !== _p$.t && setAttribute(_el$8, "data-selected", _p$.t = _v$12);
+        _v$13 !== _p$.a && setAttribute(_el$8, "aria-pressed", _p$.a = _v$13);
+        _v$14 !== _p$.o && setAttribute(_el$8, "aria-label", _p$.o = _v$14);
+        _v$15 !== _p$.i && setAttribute(_el$8, "data-marker-role", _p$.i = _v$15);
+        _p$.n = style(_el$8, _v$16, _p$.n);
+        _v$17 !== _p$.s && setAttribute(_el$8, "title", _p$.s = _v$17);
         return _p$;
       }, {
         e: void 0,
@@ -10666,7 +10795,7 @@ function PixelWorldHostVisualLayer(props) {
         n: void 0,
         s: void 0
       });
-      return _el$0;
+      return _el$8;
     })()
   }), createComponent(Index, {
     get each() {
@@ -10675,26 +10804,26 @@ function PixelWorldHostVisualLayer(props) {
     children: (agent, index) => {
       const label = () => pixelWorldReadableAgentLabel(agent(), agent().id, isLocaleZh(props.locale()));
       return (() => {
-        var _el$10 = _tmpl$0$4(), _el$11 = _el$10.firstChild;
-        _el$10.$$click = () => props.onSelect({
+        var _el$0 = _tmpl$9$4(), _el$1 = _el$0.firstChild;
+        _el$0.$$click = () => props.onSelect({
           kind: "agent",
           id: agent().id
         });
-        _el$10.addEventListener("mouseleave", () => props.onHover(null));
-        _el$10.addEventListener("mouseenter", () => props.onHover({
+        _el$0.addEventListener("mouseleave", () => props.onHover(null));
+        _el$0.addEventListener("mouseenter", () => props.onHover({
           kind: "agent",
           id: agent().id
         }));
-        insert(_el$11, () => label().slice(0, 1).toUpperCase());
+        insert(_el$1, () => label().slice(0, 1).toUpperCase());
         createRenderEffect((_p$) => {
-          var _v$21 = agent().id, _v$22 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$23 = agent().position_source, _v$24 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$25 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$26 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$27 = label();
-          _v$21 !== _p$.e && setAttribute(_el$10, "data-agent-id", _p$.e = _v$21);
-          _v$22 !== _p$.t && setAttribute(_el$10, "data-selected", _p$.t = _v$22);
-          _v$23 !== _p$.a && setAttribute(_el$10, "data-position-source", _p$.a = _v$23);
-          _v$24 !== _p$.o && setAttribute(_el$10, "aria-pressed", _p$.o = _v$24);
-          _v$25 !== _p$.i && setAttribute(_el$10, "aria-label", _p$.i = _v$25);
-          _p$.n = style(_el$10, _v$26, _p$.n);
-          _v$27 !== _p$.s && setAttribute(_el$10, "title", _p$.s = _v$27);
+          var _v$18 = agent().id, _v$19 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$20 = agent().position_source, _v$21 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$22 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$23 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$24 = label();
+          _v$18 !== _p$.e && setAttribute(_el$0, "data-agent-id", _p$.e = _v$18);
+          _v$19 !== _p$.t && setAttribute(_el$0, "data-selected", _p$.t = _v$19);
+          _v$20 !== _p$.a && setAttribute(_el$0, "data-position-source", _p$.a = _v$20);
+          _v$21 !== _p$.o && setAttribute(_el$0, "aria-pressed", _p$.o = _v$21);
+          _v$22 !== _p$.i && setAttribute(_el$0, "aria-label", _p$.i = _v$22);
+          _p$.n = style(_el$0, _v$23, _p$.n);
+          _v$24 !== _p$.s && setAttribute(_el$0, "title", _p$.s = _v$24);
           return _p$;
         }, {
           e: void 0,
@@ -10705,7 +10834,7 @@ function PixelWorldHostVisualLayer(props) {
           n: void 0,
           s: void 0
         });
-        return _el$10;
+        return _el$0;
       })();
     }
   })];
@@ -10719,26 +10848,26 @@ function PixelWorldCanvasAgentHitTargets(props) {
     children: (agent, index) => {
       const label = pixelWorldReadableAgentLabel(agent, agent.id, isLocaleZh(props.locale()));
       return (() => {
-        var _el$12 = _tmpl$1$1(), _el$13 = _el$12.firstChild;
-        _el$12.$$click = () => props.onSelect({
+        var _el$10 = _tmpl$0$4(), _el$11 = _el$10.firstChild;
+        _el$10.$$click = () => props.onSelect({
           kind: "agent",
           id: agent.id
         });
-        _el$12.addEventListener("mouseleave", () => props.onHover(null));
-        _el$12.addEventListener("mouseenter", () => props.onHover({
+        _el$10.addEventListener("mouseleave", () => props.onHover(null));
+        _el$10.addEventListener("mouseenter", () => props.onHover({
           kind: "agent",
           id: agent.id
         }));
-        setAttribute(_el$12, "title", label);
-        insert(_el$13, () => label.slice(0, 1).toUpperCase());
+        setAttribute(_el$10, "title", label);
+        insert(_el$11, () => label.slice(0, 1).toUpperCase());
         createRenderEffect((_p$) => {
-          var _v$28 = agent.id, _v$29 = agent.position_source, _v$30 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$31 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$32 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$33 = agentMarkerStyle(agent, index(), visualState().worldBounds);
-          _v$28 !== _p$.e && setAttribute(_el$12, "data-agent-id", _p$.e = _v$28);
-          _v$29 !== _p$.t && setAttribute(_el$12, "data-position-source", _p$.t = _v$29);
-          _v$30 !== _p$.a && setAttribute(_el$12, "data-selected", _p$.a = _v$30);
-          _v$31 !== _p$.o && setAttribute(_el$12, "aria-pressed", _p$.o = _v$31);
-          _v$32 !== _p$.i && setAttribute(_el$12, "aria-label", _p$.i = _v$32);
-          _p$.n = style(_el$12, _v$33, _p$.n);
+          var _v$25 = agent.id, _v$26 = agent.position_source, _v$27 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$28 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$29 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$30 = agentMarkerStyle(agent, index(), visualState().worldBounds);
+          _v$25 !== _p$.e && setAttribute(_el$10, "data-agent-id", _p$.e = _v$25);
+          _v$26 !== _p$.t && setAttribute(_el$10, "data-position-source", _p$.t = _v$26);
+          _v$27 !== _p$.a && setAttribute(_el$10, "data-selected", _p$.a = _v$27);
+          _v$28 !== _p$.o && setAttribute(_el$10, "aria-pressed", _p$.o = _v$28);
+          _v$29 !== _p$.i && setAttribute(_el$10, "aria-label", _p$.i = _v$29);
+          _p$.n = style(_el$10, _v$30, _p$.n);
           return _p$;
         }, {
           e: void 0,
@@ -10748,7 +10877,7 @@ function PixelWorldCanvasAgentHitTargets(props) {
           i: void 0,
           n: void 0
         });
-        return _el$12;
+        return _el$10;
       })();
     }
   });
@@ -10976,6 +11105,14 @@ function buildPixelWorldRenderInput(locale = state.uiLocale) {
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
   const visualState = () => pixelWorldVisualState(props.renderState());
+  const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
+  const activeHotspot = () => {
+    const inspected = inspectedHotspot();
+    if (inspected?.kind === "hotspot") {
+      return visualState().visualHotspots.find((hotspot) => hotspot.id === inspected.id) || null;
+    }
+    return props.hoveredHotspot?.() || null;
+  };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
   createEffect(() => {
@@ -10993,11 +11130,11 @@ function PixelWorldCanvasRenderer(props) {
     requestAnimationFrame(() => applyPixelWorldMobileSelectionSafeArea(canvasRef?.closest(".pixel-world-canvas")));
   });
   return (() => {
-    var _el$14 = _tmpl$14$1(), _el$15 = _el$14.firstChild, _el$16 = _el$15.nextSibling, _el$17 = _el$16.nextSibling;
+    var _el$12 = _tmpl$12$1(), _el$13 = _el$12.firstChild, _el$14 = _el$13.nextSibling, _el$15 = _el$14.nextSibling;
     var _ref$ = canvasRef;
-    typeof _ref$ === "function" ? use(_ref$, _el$15) : canvasRef = _el$15;
-    insert(_el$16, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
-    insert(_el$17, createComponent(PixelWorldCanvasAgentHitTargets, {
+    typeof _ref$ === "function" ? use(_ref$, _el$13) : canvasRef = _el$13;
+    insert(_el$14, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
+    insert(_el$15, createComponent(PixelWorldCanvasAgentHitTargets, {
       get locale() {
         return props.locale;
       },
@@ -11014,7 +11151,7 @@ function PixelWorldCanvasRenderer(props) {
         return props.onHover;
       }
     }), null);
-    insert(_el$17, createComponent(PixelWorldHostVisualLayer, {
+    insert(_el$15, createComponent(PixelWorldHostVisualLayer, {
       get enabled() {
         return props.visualOverlayEnabled?.() ?? false;
       },
@@ -11032,104 +11169,115 @@ function PixelWorldCanvasRenderer(props) {
       },
       get onHover() {
         return props.onHover;
-      }
+      },
+      onHotspotInspect: setInspectedHotspot,
+      onHotspotClear: () => setInspectedHotspot(null)
     }), null);
-    insert(_el$17, createComponent(Show, {
+    insert(_el$15, createComponent(Show, {
       get when() {
         return visualState().goalHighlight;
       },
       get children() {
-        var _el$18 = _tmpl$10$1();
-        insert(_el$18, () => `${tr$1(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`);
-        return _el$18;
+        var _el$16 = _tmpl$1$1();
+        insert(_el$16, () => `${tr$1(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`);
+        return _el$16;
       }
     }), null);
-    insert(_el$17, createComponent(Show, {
+    insert(_el$15, createComponent(Show, {
       get when() {
         return visualState().blockerHighlight;
       },
       get children() {
-        var _el$19 = _tmpl$11$1();
-        insert(_el$19, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`);
-        return _el$19;
+        var _el$17 = _tmpl$10$1();
+        insert(_el$17, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`);
+        return _el$17;
       }
     }), null);
-    insert(_el$17, createComponent(Show, {
+    insert(_el$15, createComponent(Show, {
       get when() {
-        return props.hoveredHotspot?.();
+        return activeHotspot();
       },
       get children() {
-        var _el$20 = _tmpl$12$1();
-        insert(_el$20, () => props.hoveredHotspot().label);
-        return _el$20;
+        return createComponent(PixelWorldHotspotTooltip, {
+          get locale() {
+            return props.locale;
+          },
+          get hotspot() {
+            return activeHotspot();
+          },
+          onClose: () => {
+            setInspectedHotspot(null);
+            props.onHover(null);
+          }
+        });
       }
     }), null);
-    insert(_el$14, createComponent(Show, {
+    insert(_el$12, createComponent(Show, {
       get when() {
         return visualState().selection;
       },
       get children() {
-        var _el$21 = _tmpl$13$1();
-        insert(_el$21, () => `${tr$1(props.locale(), "已选中", "Selected")}: ${selectedEntityLabel()}`);
-        return _el$21;
+        var _el$18 = _tmpl$11$1();
+        insert(_el$18, () => `${tr$1(props.locale(), "已选中", "Selected")}: ${selectedEntityLabel()}`);
+        return _el$18;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$34 = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$35 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
-      _v$34 !== _p$.e && setAttribute(_el$14, "data-renderer-ready", _p$.e = _v$34);
-      _v$35 !== _p$.t && setAttribute(_el$15, "aria-label", _p$.t = _v$35);
+      var _v$31 = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$32 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
+      _v$31 !== _p$.e && setAttribute(_el$12, "data-renderer-ready", _p$.e = _v$31);
+      _v$32 !== _p$.t && setAttribute(_el$13, "aria-label", _p$.t = _v$32);
       return _p$;
     }, {
       e: void 0,
       t: void 0
     });
-    return _el$14;
+    return _el$12;
   })();
 }
 function PixelWorldActionReceipt(props) {
   const receipt = () => props.surface().action_receipt;
   return (() => {
-    var _el$22 = _tmpl$18$1(), _el$23 = _el$22.firstChild, _el$24 = _el$23.nextSibling, _el$25 = _el$24.firstChild, _el$26 = _el$25.nextSibling;
-    insert(_el$23, () => tr$1(props.locale(), "行动回执", "Action Receipt"));
-    insert(_el$25, () => receipt().title);
-    insert(_el$26, () => receipt().summary);
-    insert(_el$24, createComponent(Show, {
+    var _el$19 = _tmpl$16$1(), _el$20 = _el$19.firstChild, _el$21 = _el$20.nextSibling, _el$22 = _el$21.firstChild, _el$23 = _el$22.nextSibling;
+    insert(_el$20, () => tr$1(props.locale(), "行动回执", "Action Receipt"));
+    insert(_el$22, () => receipt().title);
+    insert(_el$23, () => receipt().summary);
+    insert(_el$21, createComponent(Show, {
       get when() {
         return receipt().detail;
       },
       get children() {
-        var _el$27 = _tmpl$15$1();
-        insert(_el$27, () => receipt().detail);
-        return _el$27;
+        var _el$24 = _tmpl$13$1();
+        insert(_el$24, () => receipt().detail);
+        return _el$24;
       }
     }), null);
-    insert(_el$22, createComponent(Show, {
+    insert(_el$19, createComponent(Show, {
       get when() {
         return receipt().present;
       },
       get children() {
-        var _el$28 = _tmpl$17$1(), _el$29 = _el$28.firstChild;
-        insert(_el$29, () => receiptConfidenceLabel(receipt().confidence, props.locale(), receipt().state));
-        insert(_el$28, createComponent(Show, {
+        var _el$25 = _tmpl$15$1(), _el$26 = _el$25.firstChild;
+        insert(_el$26, () => receiptConfidenceLabel(receipt().confidence, props.locale(), receipt().state));
+        insert(_el$25, createComponent(Show, {
           get when() {
             return receipt().target_agent_id;
           },
           get children() {
-            var _el$30 = _tmpl$16$1();
-            insert(_el$30, () => `${tr$1(props.locale(), "行动体", "Agent")} ${String(receipt().target_agent_id).replace(/^agent[-_]/i, "")}`);
-            return _el$30;
+            var _el$27 = _tmpl$14$1();
+            insert(_el$27, () => `${tr$1(props.locale(), "行动体", "Agent")} ${String(receipt().target_agent_id).replace(/^agent[-_]/i, "")}`);
+            return _el$27;
           }
         }), null);
-        return _el$28;
+        return _el$25;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$36 = props.id, _v$37 = `pixel-world-action-receipt ${props.class ?? ""}`, _v$38 = receipt().present ? "true" : "false", _v$39 = receipt().state, _v$40 = receipt().confidence;
-      _v$36 !== _p$.e && setAttribute(_el$22, "id", _p$.e = _v$36);
-      _v$37 !== _p$.t && className(_el$22, _p$.t = _v$37);
-      _v$38 !== _p$.a && setAttribute(_el$22, "data-receipt-present", _p$.a = _v$38);
-      _v$39 !== _p$.o && setAttribute(_el$22, "data-receipt-state", _p$.o = _v$39);
-      _v$40 !== _p$.i && setAttribute(_el$22, "data-receipt-confidence", _p$.i = _v$40);
+      var _v$33 = props.id, _v$34 = `pixel-world-action-receipt ${props.class ?? ""}`, _v$35 = receipt().present ? "true" : "false", _v$36 = receipt().state, _v$37 = receipt().confidence;
+      _v$33 !== _p$.e && setAttribute(_el$19, "id", _p$.e = _v$33);
+      _v$34 !== _p$.t && className(_el$19, _p$.t = _v$34);
+      _v$35 !== _p$.a && setAttribute(_el$19, "data-receipt-present", _p$.a = _v$35);
+      _v$36 !== _p$.o && setAttribute(_el$19, "data-receipt-state", _p$.o = _v$36);
+      _v$37 !== _p$.i && setAttribute(_el$19, "data-receipt-confidence", _p$.i = _v$37);
       return _p$;
     }, {
       e: void 0,
@@ -11138,7 +11286,7 @@ function PixelWorldActionReceipt(props) {
       o: void 0,
       i: void 0
     });
-    return _el$22;
+    return _el$19;
   })();
 }
 function receiptConfidenceLabel(confidence, locale, state2) {
@@ -11149,20 +11297,7 @@ function receiptConfidenceLabel(confidence, locale, state2) {
 }
 function worldReadoutStatus(locale, renderState) {
   renderState?.();
-  const status = String(state.connectionStatus || "").toLowerCase();
-  const feed = state.worldFeed || {};
-  const warn = (label) => ({
-    label,
-    className: "badge badge--warn"
-  });
-  if (String(feed.status || "").toLowerCase() === "unavailable") return warn(tr$1(locale, "不可用", "UNAVAILABLE"));
-  if (feed.stale) return warn(tr$1(locale, "陈旧", "STALE"));
-  if (status === "connecting" || status === "reconnecting") return warn(tr$1(locale, "正在重连", "RECONNECTING"));
-  if (status !== "connected") return warn(tr$1(locale, "离线", "OFFLINE"));
-  return ["ready", "replay", "empty"].includes(String(feed.status || "").toLowerCase()) ? {
-    label: "LIVE",
-    className: "badge badge--good"
-  } : warn(tr$1(locale, "同步中", "SYNCING"));
+  return resolvePixelWorldReadoutStatus(locale, state.connectionStatus, state.worldFeed);
 }
 const DIRECT_PIXEL_WORLD_NEXT_MOVE_KINDS = /* @__PURE__ */ new Set(["claim_first_agent", "claim_starter_oc"]);
 const PIXEL_WORLD_PENDING_GAMEPLAY_STAGES = /* @__PURE__ */ new Set(["accepted", "submitted", "queued", "ack", "registering", "signing", "sent"]);
@@ -11214,6 +11349,7 @@ function resolvePixelWorldDirectNextMoveAction(gameplay, executeKind) {
 function PixelWorldCommercialHud(props) {
   const surface = () => props.renderState().commercial_surface;
   const readoutStatus = () => worldReadoutStatus(props.locale(), props.renderState);
+  const readoutFeedStatus = () => String(state.worldFeed?.status || "loading").trim().toLowerCase() || "loading";
   const activeAgentId = () => String(surface()?.active_agent_id || "").trim();
   const activeAgent = () => props.renderState().agents.find((agent) => agent.id === activeAgentId());
   const activeAgentLabel = () => pixelWorldReadableAgentLabel(activeAgent(), activeAgentId(), isLocaleZh(props.locale())) || tr$1(props.locale(), "未选择 Agent", "No Agent selected");
@@ -11254,55 +11390,55 @@ function PixelWorldCommercialHud(props) {
     },
     get children() {
       return [(() => {
-        var _el$31 = _tmpl$21$1(), _el$32 = _el$31.firstChild, _el$33 = _el$32.firstChild, _el$34 = _el$33.firstChild, _el$36 = _el$33.nextSibling, _el$38 = _el$36.nextSibling, _el$39 = _el$32.nextSibling, _el$40 = _el$39.firstChild, _el$41 = _el$40.firstChild, _el$42 = _el$41.nextSibling, _el$43 = _el$42.nextSibling, _el$44 = _el$40.nextSibling, _el$45 = _el$44.firstChild, _el$46 = _el$45.nextSibling, _el$47 = _el$46.nextSibling, _el$48 = _el$47.nextSibling, _el$49 = _el$48.firstChild, _el$50 = _el$49.nextSibling;
-        insert(_el$34, () => tr$1(props.locale(), "下一步", "Next Move"));
-        insert(_el$33, createComponent(Show, {
+        var _el$28 = _tmpl$19$1(), _el$29 = _el$28.firstChild, _el$30 = _el$29.firstChild, _el$31 = _el$30.firstChild, _el$33 = _el$30.nextSibling, _el$35 = _el$33.nextSibling, _el$36 = _el$29.nextSibling, _el$37 = _el$36.firstChild, _el$38 = _el$37.firstChild, _el$39 = _el$38.nextSibling, _el$40 = _el$39.nextSibling, _el$41 = _el$37.nextSibling, _el$42 = _el$41.firstChild, _el$43 = _el$42.nextSibling, _el$44 = _el$43.nextSibling, _el$45 = _el$44.nextSibling, _el$46 = _el$45.firstChild, _el$47 = _el$46.nextSibling;
+        insert(_el$31, () => tr$1(props.locale(), "下一步", "Next Move"));
+        insert(_el$30, createComponent(Show, {
           get when() {
             return surface().blocker.label;
           },
           get children() {
-            var _el$35 = _tmpl$19$1();
-            insert(_el$35, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`);
-            return _el$35;
+            var _el$32 = _tmpl$17$1();
+            insert(_el$32, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`);
+            return _el$32;
           }
         }), null);
-        insert(_el$36, () => surface().next_action.label);
-        insert(_el$32, createComponent(Show, {
+        insert(_el$33, () => surface().next_action.label);
+        insert(_el$29, createComponent(Show, {
           get when() {
             return surface().next_action.detail;
           },
           get children() {
-            var _el$37 = _tmpl$20$1();
-            insert(_el$37, () => surface().next_action.detail);
-            return _el$37;
+            var _el$34 = _tmpl$18$1();
+            insert(_el$34, () => surface().next_action.detail);
+            return _el$34;
           }
-        }), _el$38);
-        _el$38.$$click = activateNextMove;
-        insert(_el$38, (() => {
-          var _c$2 = memo(() => !!directNextMoveAction());
-          return () => _c$2() ? surface().next_action.label : memo(() => !!nextMoveRoutesToGameplayDetails())() ? tr$1(props.locale(), "打开玩法明细", "Open Gameplay Details") : tr$1(props.locale(), "去指挥面板", "Go to Command");
+        }), _el$35);
+        _el$35.$$click = activateNextMove;
+        insert(_el$35, (() => {
+          var _c$ = memo(() => !!directNextMoveAction());
+          return () => _c$() ? surface().next_action.label : memo(() => !!nextMoveRoutesToGameplayDetails())() ? tr$1(props.locale(), "打开玩法明细", "Open Gameplay Details") : tr$1(props.locale(), "去指挥面板", "Go to Command");
         })());
-        insert(_el$41, () => tr$1(props.locale(), "目标", "Objective"));
-        insert(_el$42, () => surface().objective.title);
-        insert(_el$43, () => surface().objective.detail);
-        insert(_el$45, () => tr$1(props.locale(), "玩家杠杆", "Player Leverage"));
-        insert(_el$46, () => pixelWorldReadableEntityText(surface().player_leverage.summary, props.renderState(), isLocaleZh(props.locale())));
-        insert(_el$47, () => surface().player_leverage.label);
-        insert(_el$49, () => tr$1(props.locale(), "当前 Agent", "Selected Agent"));
-        insert(_el$50, activeAgentLabel);
+        insert(_el$38, () => tr$1(props.locale(), "目标", "Objective"));
+        insert(_el$39, () => surface().objective.title);
+        insert(_el$40, () => surface().objective.detail);
+        insert(_el$42, () => tr$1(props.locale(), "玩家杠杆", "Player Leverage"));
+        insert(_el$43, () => pixelWorldReadableEntityText(surface().player_leverage.summary, props.renderState(), isLocaleZh(props.locale())));
+        insert(_el$44, () => surface().player_leverage.label);
+        insert(_el$46, () => tr$1(props.locale(), "当前 Agent", "Selected Agent"));
+        insert(_el$47, activeAgentLabel);
         createRenderEffect((_p$) => {
-          var _v$41 = activeAgentId(), _v$42 = surface().player_leverage.state, _v$43 = nextMoveRoute(), _v$44 = surface().next_action.execute_kind || "none", _v$45 = surface().blocker.label ? "true" : "false", _v$46 = nextMoveHref(), _v$47 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$48 = nextMoveDisabledReason() ? "true" : void 0, _v$49 = nextMovePending() ? "true" : "false", _v$50 = nextMoveDisabledReason() ? -1 : void 0, _v$51 = activeAgentLabel();
-          _v$41 !== _p$.e && setAttribute(_el$31, "data-active-agent", _p$.e = _v$41);
-          _v$42 !== _p$.t && setAttribute(_el$31, "data-leverage-state", _p$.t = _v$42);
-          _v$43 !== _p$.a && setAttribute(_el$32, "data-next-move-route", _p$.a = _v$43);
-          _v$44 !== _p$.o && setAttribute(_el$32, "data-execute-kind", _p$.o = _v$44);
-          _v$45 !== _p$.i && setAttribute(_el$32, "data-blocker-present", _p$.i = _v$45);
-          _v$46 !== _p$.n && setAttribute(_el$38, "href", _p$.n = _v$46);
-          _v$47 !== _p$.s && setAttribute(_el$38, "aria-label", _p$.s = _v$47);
-          _v$48 !== _p$.h && setAttribute(_el$38, "aria-disabled", _p$.h = _v$48);
-          _v$49 !== _p$.r && setAttribute(_el$38, "aria-busy", _p$.r = _v$49);
-          _v$50 !== _p$.d && setAttribute(_el$38, "tabindex", _p$.d = _v$50);
-          _v$51 !== _p$.l && setAttribute(_el$48, "data-selected-agent-label", _p$.l = _v$51);
+          var _v$38 = activeAgentId(), _v$39 = surface().player_leverage.state, _v$40 = nextMoveRoute(), _v$41 = surface().next_action.execute_kind || "none", _v$42 = surface().blocker.label ? "true" : "false", _v$43 = nextMoveHref(), _v$44 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$45 = nextMoveDisabledReason() ? "true" : void 0, _v$46 = nextMovePending() ? "true" : "false", _v$47 = nextMoveDisabledReason() ? -1 : void 0, _v$48 = activeAgentLabel();
+          _v$38 !== _p$.e && setAttribute(_el$28, "data-active-agent", _p$.e = _v$38);
+          _v$39 !== _p$.t && setAttribute(_el$28, "data-leverage-state", _p$.t = _v$39);
+          _v$40 !== _p$.a && setAttribute(_el$29, "data-next-move-route", _p$.a = _v$40);
+          _v$41 !== _p$.o && setAttribute(_el$29, "data-execute-kind", _p$.o = _v$41);
+          _v$42 !== _p$.i && setAttribute(_el$29, "data-blocker-present", _p$.i = _v$42);
+          _v$43 !== _p$.n && setAttribute(_el$35, "href", _p$.n = _v$43);
+          _v$44 !== _p$.s && setAttribute(_el$35, "aria-label", _p$.s = _v$44);
+          _v$45 !== _p$.h && setAttribute(_el$35, "aria-disabled", _p$.h = _v$45);
+          _v$46 !== _p$.r && setAttribute(_el$35, "aria-busy", _p$.r = _v$46);
+          _v$47 !== _p$.d && setAttribute(_el$35, "tabindex", _p$.d = _v$47);
+          _v$48 !== _p$.l && setAttribute(_el$45, "data-selected-agent-label", _p$.l = _v$48);
           return _p$;
         }, {
           e: void 0,
@@ -11317,7 +11453,7 @@ function PixelWorldCommercialHud(props) {
           d: void 0,
           l: void 0
         });
-        return _el$31;
+        return _el$28;
       })(), createComponent(Show, {
         get when() {
           return !props.focusMode?.();
@@ -11332,22 +11468,30 @@ function PixelWorldCommercialHud(props) {
           });
         }
       }), (() => {
-        var _el$51 = _tmpl$23$1(), _el$52 = _el$51.firstChild, _el$54 = _el$52.nextSibling;
-        insert(_el$52, () => readoutStatus().label);
-        insert(_el$51, createComponent(Show, {
+        var _el$48 = _tmpl$21$1(), _el$49 = _el$48.firstChild, _el$51 = _el$49.nextSibling;
+        insert(_el$49, () => readoutStatus().label);
+        insert(_el$48, createComponent(Show, {
           get when() {
             return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
           },
           get children() {
-            var _el$53 = _tmpl$22$1();
-            insert(_el$53, () => `tick=${surface().world_read.tick}`);
-            createRenderEffect(() => setAttribute(_el$53, "data-world-tick", String(surface().world_read.tick)));
-            return _el$53;
+            var _el$50 = _tmpl$20$1();
+            insert(_el$50, () => `tick=${surface().world_read.tick}`);
+            createRenderEffect(() => setAttribute(_el$50, "data-world-tick", String(surface().world_read.tick)));
+            return _el$50;
           }
-        }), _el$54);
-        insert(_el$54, () => `agents=${surface().world_read.agents}`);
-        createRenderEffect(() => className(_el$52, readoutStatus().className));
-        return _el$51;
+        }), _el$51);
+        insert(_el$51, () => `agents=${surface().world_read.agents}`);
+        createRenderEffect((_p$) => {
+          var _v$49 = readoutStatus().className, _v$50 = readoutFeedStatus();
+          _v$49 !== _p$.e && className(_el$49, _p$.e = _v$49);
+          _v$50 !== _p$.t && setAttribute(_el$49, "data-world-feed-readout-status", _p$.t = _v$50);
+          return _p$;
+        }, {
+          e: void 0,
+          t: void 0
+        });
+        return _el$48;
       })()];
     }
   });
@@ -11359,57 +11503,57 @@ function PixelWorldFocusHud(props) {
       return surface();
     },
     get children() {
-      var _el$55 = _tmpl$25$1(), _el$56 = _el$55.firstChild, _el$57 = _el$56.firstChild, _el$58 = _el$57.nextSibling, _el$59 = _el$56.nextSibling, _el$60 = _el$59.firstChild, _el$61 = _el$60.nextSibling, _el$62 = _el$61.nextSibling, _el$63 = _el$59.nextSibling, _el$64 = _el$63.firstChild, _el$65 = _el$64.nextSibling, _el$66 = _el$65.nextSibling, _el$71 = _el$63.nextSibling, _el$72 = _el$71.firstChild, _el$73 = _el$72.nextSibling, _el$74 = _el$71.nextSibling, _el$75 = _el$74.firstChild, _el$76 = _el$75.nextSibling, _el$77 = _el$76.nextSibling, _el$78 = _el$77.firstChild, _el$79 = _el$78.nextSibling, _el$80 = _el$79.nextSibling;
-      insert(_el$57, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
-      insert(_el$58, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
-      insert(_el$60, () => tr$1(props.locale(), "当前目标", "Current Objective"));
-      insert(_el$61, () => surface().objective.title);
-      insert(_el$62, () => surface().next_action.label);
-      insert(_el$64, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
-      insert(_el$65, (() => {
-        var _c$3 = memo(() => surface().objective.progress_percent == null);
-        return () => _c$3() ? tr$1(props.locale(), "进行中", "In Progress") : `${surface().objective.progress_percent}%`;
+      var _el$52 = _tmpl$23$1(), _el$53 = _el$52.firstChild, _el$54 = _el$53.firstChild, _el$55 = _el$54.nextSibling, _el$56 = _el$53.nextSibling, _el$57 = _el$56.firstChild, _el$58 = _el$57.nextSibling, _el$59 = _el$58.nextSibling, _el$60 = _el$56.nextSibling, _el$61 = _el$60.firstChild, _el$62 = _el$61.nextSibling, _el$63 = _el$62.nextSibling, _el$68 = _el$60.nextSibling, _el$69 = _el$68.firstChild, _el$70 = _el$69.nextSibling, _el$71 = _el$68.nextSibling, _el$72 = _el$71.firstChild, _el$73 = _el$72.nextSibling, _el$74 = _el$73.nextSibling, _el$75 = _el$74.firstChild, _el$76 = _el$75.nextSibling, _el$77 = _el$76.nextSibling;
+      insert(_el$54, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
+      insert(_el$55, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
+      insert(_el$57, () => tr$1(props.locale(), "当前目标", "Current Objective"));
+      insert(_el$58, () => surface().objective.title);
+      insert(_el$59, () => surface().next_action.label);
+      insert(_el$61, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
+      insert(_el$62, (() => {
+        var _c$2 = memo(() => surface().objective.progress_percent == null);
+        return () => _c$2() ? tr$1(props.locale(), "进行中", "In Progress") : `${surface().objective.progress_percent}%`;
       })());
-      insert(_el$66, () => surface().next_action.detail || surface().objective.detail);
-      insert(_el$55, createComponent(Show, {
+      insert(_el$63, () => surface().next_action.detail || surface().objective.detail);
+      insert(_el$52, createComponent(Show, {
         get when() {
           return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
         },
         get children() {
-          var _el$67 = _tmpl$24$1(), _el$68 = _el$67.firstChild, _el$69 = _el$68.nextSibling, _el$70 = _el$69.nextSibling;
-          insert(_el$68, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
-          insert(_el$69, () => surface().world_read.tick);
-          insert(_el$70, () => `tick=${surface().world_read.tick}`);
-          createRenderEffect(() => setAttribute(_el$67, "data-world-tick", String(surface().world_read.tick)));
-          return _el$67;
+          var _el$64 = _tmpl$22$1(), _el$65 = _el$64.firstChild, _el$66 = _el$65.nextSibling, _el$67 = _el$66.nextSibling;
+          insert(_el$65, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
+          insert(_el$66, () => surface().world_read.tick);
+          insert(_el$67, () => `tick=${surface().world_read.tick}`);
+          createRenderEffect(() => setAttribute(_el$64, "data-world-tick", String(surface().world_read.tick)));
+          return _el$64;
         }
-      }), _el$71);
-      insert(_el$72, () => tr$1(props.locale(), "阻塞", "Blocker"));
-      insert(_el$73, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
-      addEventListener(_el$75, "click", props.onOpenCommand);
-      insert(_el$75, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
-      addEventListener(_el$76, "click", props.onExit);
-      insert(_el$76, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
-      insert(_el$78, () => tr$1(props.locale(), "更多控制", "More controls"));
-      addEventListener(_el$79, "click", props.onOpenDiagnostics);
-      insert(_el$79, () => tr$1(props.locale(), "世界状态", "World Status"));
-      addEventListener(_el$80, "click", props.onToggleMaximized);
-      insert(_el$80, (() => {
-        var _c$4 = memo(() => !!props.maximized());
-        return () => _c$4() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
+      }), _el$68);
+      insert(_el$69, () => tr$1(props.locale(), "阻塞", "Blocker"));
+      insert(_el$70, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
+      addEventListener(_el$72, "click", props.onOpenCommand);
+      insert(_el$72, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
+      addEventListener(_el$73, "click", props.onExit);
+      insert(_el$73, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
+      insert(_el$75, () => tr$1(props.locale(), "更多控制", "More controls"));
+      addEventListener(_el$76, "click", props.onOpenDiagnostics);
+      insert(_el$76, () => tr$1(props.locale(), "世界状态", "World Status"));
+      addEventListener(_el$77, "click", props.onToggleMaximized);
+      insert(_el$77, (() => {
+        var _c$3 = memo(() => !!props.maximized());
+        return () => _c$3() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
       })());
       createRenderEffect((_p$) => {
-        var _v$52 = surface().blocker.label ? "true" : "false", _v$53 = surface().blocker.label ? "critical" : "clear", _v$54 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
-        _v$52 !== _p$.e && setAttribute(_el$71, "data-blocker-present", _p$.e = _v$52);
-        _v$53 !== _p$.t && setAttribute(_el$71, "data-hud-priority", _p$.t = _v$53);
-        _v$54 !== _p$.a && setAttribute(_el$74, "aria-label", _p$.a = _v$54);
+        var _v$51 = surface().blocker.label ? "true" : "false", _v$52 = surface().blocker.label ? "critical" : "clear", _v$53 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
+        _v$51 !== _p$.e && setAttribute(_el$68, "data-blocker-present", _p$.e = _v$51);
+        _v$52 !== _p$.t && setAttribute(_el$68, "data-hud-priority", _p$.t = _v$52);
+        _v$53 !== _p$.a && setAttribute(_el$71, "aria-label", _p$.a = _v$53);
         return _p$;
       }, {
         e: void 0,
         t: void 0,
         a: void 0
       });
-      return _el$55;
+      return _el$52;
     }
   });
 }
@@ -11420,22 +11564,22 @@ function PixelWorldFocusCinematicBanner(props) {
       return surface();
     },
     get children() {
-      var _el$81 = _tmpl$27$1(), _el$82 = _el$81.firstChild, _el$83 = _el$82.nextSibling, _el$84 = _el$83.nextSibling, _el$85 = _el$84.nextSibling, _el$86 = _el$85.firstChild;
-      insert(_el$82, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
-      insert(_el$83, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
-      insert(_el$84, () => surface().objective.detail);
-      insert(_el$86, () => surface().objective.title);
-      insert(_el$85, createComponent(Show, {
+      var _el$78 = _tmpl$25$1(), _el$79 = _el$78.firstChild, _el$80 = _el$79.nextSibling, _el$81 = _el$80.nextSibling, _el$82 = _el$81.nextSibling, _el$83 = _el$82.firstChild;
+      insert(_el$79, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
+      insert(_el$80, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
+      insert(_el$81, () => surface().objective.detail);
+      insert(_el$83, () => surface().objective.title);
+      insert(_el$82, createComponent(Show, {
         get when() {
           return surface().blocker.label;
         },
         get children() {
-          var _el$87 = _tmpl$26$1();
-          insert(_el$87, () => surface().blocker.label);
-          return _el$87;
+          var _el$84 = _tmpl$24$1();
+          insert(_el$84, () => surface().blocker.label);
+          return _el$84;
         }
       }), null);
-      return _el$81;
+      return _el$78;
     }
   });
 }
@@ -11461,53 +11605,53 @@ function PixelWorldFocusRail(props) {
       return memo(() => !!surface())() && hasFocusItems();
     },
     get children() {
-      var _el$88 = _tmpl$30$1(), _el$89 = _el$88.firstChild;
-      insert(_el$89, () => tr$1(props.locale(), "焦点", "Focus"));
-      insert(_el$88, createComponent(Show, {
+      var _el$85 = _tmpl$28$1(), _el$86 = _el$85.firstChild;
+      insert(_el$86, () => tr$1(props.locale(), "焦点", "Focus"));
+      insert(_el$85, createComponent(Show, {
         get when() {
           return surface()?.blocker.label;
         },
         get children() {
-          var _el$90 = _tmpl$28$1(), _el$91 = _el$90.firstChild, _el$92 = _el$91.nextSibling;
-          insert(_el$91, () => tr$1(props.locale(), "阻塞", "Blocker"));
-          insert(_el$92, () => surface().blocker.label);
-          return _el$90;
+          var _el$87 = _tmpl$26$1(), _el$88 = _el$87.firstChild, _el$89 = _el$88.nextSibling;
+          insert(_el$88, () => tr$1(props.locale(), "阻塞", "Blocker"));
+          insert(_el$89, () => surface().blocker.label);
+          return _el$87;
         }
       }), null);
-      insert(_el$88, createComponent(Show, {
+      insert(_el$85, createComponent(Show, {
         get when() {
           return activeAgent();
         },
         get children() {
-          var _el$93 = _tmpl$29$1(), _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling;
-          insert(_el$94, () => tr$1(props.locale(), "Agent", "Agent"));
-          insert(_el$95, activeAgentName);
-          return _el$93;
+          var _el$90 = _tmpl$27$1(), _el$91 = _el$90.firstChild, _el$92 = _el$91.nextSibling;
+          insert(_el$91, () => tr$1(props.locale(), "Agent", "Agent"));
+          insert(_el$92, activeAgentName);
+          return _el$90;
         }
       }), null);
-      insert(_el$88, createComponent(Show, {
+      insert(_el$85, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$96 = _tmpl$29$1(), _el$97 = _el$96.firstChild, _el$98 = _el$97.nextSibling;
-          insert(_el$97, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$98, selectedName);
-          return _el$96;
+          var _el$93 = _tmpl$27$1(), _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling;
+          insert(_el$94, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$95, selectedName);
+          return _el$93;
         }
       }), null);
-      insert(_el$88, createComponent(Show, {
+      insert(_el$85, createComponent(Show, {
         get when() {
           return routeCount() > 0;
         },
         get children() {
-          var _el$99 = _tmpl$29$1(), _el$100 = _el$99.firstChild, _el$101 = _el$100.nextSibling;
-          insert(_el$100, () => tr$1(props.locale(), "路线", "Routes"));
-          insert(_el$101, routeCount);
-          return _el$99;
+          var _el$96 = _tmpl$27$1(), _el$97 = _el$96.firstChild, _el$98 = _el$97.nextSibling;
+          insert(_el$97, () => tr$1(props.locale(), "路线", "Routes"));
+          insert(_el$98, routeCount);
+          return _el$96;
         }
       }), null);
-      return _el$88;
+      return _el$85;
     }
   });
 }
@@ -11524,50 +11668,50 @@ function PixelWorldFocusMinimapCard(props) {
       return surface();
     },
     get children() {
-      var _el$102 = _tmpl$33$1(), _el$103 = _el$102.firstChild, _el$105 = _el$103.nextSibling, _el$106 = _el$105.nextSibling, _el$107 = _el$106.nextSibling, _el$108 = _el$107.firstChild, _el$109 = _el$108.nextSibling, _el$110 = _el$107.nextSibling, _el$111 = _el$110.firstChild, _el$112 = _el$111.nextSibling, _el$116 = _el$110.nextSibling, _el$117 = _el$116.firstChild, _el$118 = _el$117.nextSibling, _el$119 = _el$118.nextSibling, _el$120 = _el$119.nextSibling;
-      insert(_el$103, () => tr$1(props.locale(), "任务地图", "Mission Map"));
-      insert(_el$102, createComponent(Show, {
+      var _el$99 = _tmpl$31$1(), _el$100 = _el$99.firstChild, _el$102 = _el$100.nextSibling, _el$103 = _el$102.nextSibling, _el$104 = _el$103.nextSibling, _el$105 = _el$104.firstChild, _el$106 = _el$105.nextSibling, _el$107 = _el$104.nextSibling, _el$108 = _el$107.firstChild, _el$109 = _el$108.nextSibling, _el$113 = _el$107.nextSibling, _el$114 = _el$113.firstChild, _el$115 = _el$114.nextSibling, _el$116 = _el$115.nextSibling, _el$117 = _el$116.nextSibling;
+      insert(_el$100, () => tr$1(props.locale(), "任务地图", "Mission Map"));
+      insert(_el$99, createComponent(Show, {
         get when() {
           return primaryLocation();
         },
         get children() {
-          var _el$104 = _tmpl$31$1();
-          insert(_el$104, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
-          return _el$104;
+          var _el$101 = _tmpl$29$1();
+          insert(_el$101, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
+          return _el$101;
         }
-      }), _el$105);
-      insert(_el$108, () => tr$1(props.locale(), "目标", "Target"));
-      insert(_el$109, () => surface().next_action.label);
-      insert(_el$111, () => tr$1(props.locale(), "Agent", "Agent"));
-      insert(_el$112, (() => {
-        var _c$5 = memo(() => !!activeAgent());
-        return () => _c$5() ? activeAgentName() : tr$1(props.locale(), "待分配", "Unassigned");
+      }), _el$102);
+      insert(_el$105, () => tr$1(props.locale(), "目标", "Target"));
+      insert(_el$106, () => surface().next_action.label);
+      insert(_el$108, () => tr$1(props.locale(), "Agent", "Agent"));
+      insert(_el$109, (() => {
+        var _c$4 = memo(() => !!activeAgent());
+        return () => _c$4() ? activeAgentName() : tr$1(props.locale(), "待分配", "Unassigned");
       })());
-      insert(_el$102, createComponent(Show, {
+      insert(_el$99, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$113 = _tmpl$32$1(), _el$114 = _el$113.firstChild, _el$115 = _el$114.nextSibling;
-          insert(_el$114, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$115, selectedName);
-          return _el$113;
+          var _el$110 = _tmpl$30$1(), _el$111 = _el$110.firstChild, _el$112 = _el$111.nextSibling;
+          insert(_el$111, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$112, selectedName);
+          return _el$110;
         }
-      }), _el$116);
-      insert(_el$117, () => `agents=${props.renderState().agents.length}`);
-      insert(_el$118, () => `targets=${props.renderState().locations.length}`);
-      insert(_el$119, () => `routes=${props.renderState().links.length}`);
-      insert(_el$120, () => `fragments=${props.renderState().fragment_terrain.length}`);
+      }), _el$113);
+      insert(_el$114, () => `agents=${props.renderState().agents.length}`);
+      insert(_el$115, () => `targets=${props.renderState().locations.length}`);
+      insert(_el$116, () => `routes=${props.renderState().links.length}`);
+      insert(_el$117, () => `fragments=${props.renderState().fragment_terrain.length}`);
       createRenderEffect((_p$) => {
-        var _v$55 = props.renderState().links.length, _v$56 = tr$1(props.locale(), "世界摘要", "World summary");
-        _v$55 !== _p$.e && setAttribute(_el$106, "data-routes", _p$.e = _v$55);
-        _v$56 !== _p$.t && setAttribute(_el$116, "aria-label", _p$.t = _v$56);
+        var _v$54 = props.renderState().links.length, _v$55 = tr$1(props.locale(), "世界摘要", "World summary");
+        _v$54 !== _p$.e && setAttribute(_el$103, "data-routes", _p$.e = _v$54);
+        _v$55 !== _p$.t && setAttribute(_el$113, "aria-label", _p$.t = _v$55);
         return _p$;
       }, {
         e: void 0,
         t: void 0
       });
-      return _el$102;
+      return _el$99;
     }
   });
 }
@@ -11599,20 +11743,20 @@ function PixelRawDiagnostics(props) {
   const [open, setOpen] = createSignal(false);
   const value2 = () => typeof props.value === "function" ? props.value() : props.value;
   return (() => {
-    var _el$121 = _tmpl$35$1(), _el$122 = _el$121.firstChild;
-    _el$121.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
-    insert(_el$122, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
-    insert(_el$121, createComponent(Show, {
+    var _el$118 = _tmpl$33$1(), _el$119 = _el$118.firstChild;
+    _el$118.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
+    insert(_el$119, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
+    insert(_el$118, createComponent(Show, {
       get when() {
         return open();
       },
       get children() {
-        var _el$123 = _tmpl$34$1();
-        insert(_el$123, () => JSON.stringify(value2(), null, 2));
-        return _el$123;
+        var _el$120 = _tmpl$32$1();
+        insert(_el$120, () => JSON.stringify(value2(), null, 2));
+        return _el$120;
       }
     }), null);
-    return _el$121;
+    return _el$118;
   })();
 }
 function PixelWorldFocusCommandSurface(props) {
@@ -11634,136 +11778,136 @@ function PixelWorldFocusCommandSurface(props) {
   const receiptLabel = () => gameplaySummary()?.executionStateLabel || gameplaySummary()?.recentFeedback?.stage || tr$1(locale(), "等待回执", "Waiting");
   const chatHistory = () => state.chatHistory.filter((entry) => entry.agentId === agentId() || entry.targetAgentId === agentId()).slice(0, 12);
   return (() => {
-    var _el$124 = _tmpl$41$1();
-    insert(_el$124, createComponent(Show, {
+    var _el$121 = _tmpl$39$1();
+    insert(_el$121, createComponent(Show, {
       get when() {
         return agentId();
       },
       get fallback() {
         return (() => {
-          var _el$158 = _tmpl$39$1();
-          insert(_el$158, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
-          return _el$158;
+          var _el$155 = _tmpl$37$1();
+          insert(_el$155, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
+          return _el$155;
         })();
       },
       get children() {
         return [(() => {
-          var _el$125 = _tmpl$37$1(), _el$126 = _el$125.firstChild, _el$127 = _el$126.nextSibling, _el$129 = _el$127.nextSibling;
-          insert(_el$126, () => tr$1(locale(), "当前交互目标", "Current Target"));
-          insert(_el$127, agentName);
-          insert(_el$125, createComponent(Show, {
+          var _el$122 = _tmpl$35$1(), _el$123 = _el$122.firstChild, _el$124 = _el$123.nextSibling, _el$126 = _el$124.nextSibling;
+          insert(_el$123, () => tr$1(locale(), "当前交互目标", "Current Target"));
+          insert(_el$124, agentName);
+          insert(_el$122, createComponent(Show, {
             get when() {
               return binding()?.playerId;
             },
             get children() {
-              var _el$128 = _tmpl$36$1();
-              insert(_el$128, () => `boundPlayer=${binding().playerId}`);
-              return _el$128;
+              var _el$125 = _tmpl$34$1();
+              insert(_el$125, () => `boundPlayer=${binding().playerId}`);
+              return _el$125;
             }
-          }), _el$129);
-          insert(_el$129, (() => {
-            var _c$6 = memo(() => !!chatCapability().enabled);
-            return () => _c$6() ? tr$1(locale(), "聊天可用", "Chat Ready") : tr$1(locale(), "聊天受限", "Chat Limited");
+          }), _el$126);
+          insert(_el$126, (() => {
+            var _c$5 = memo(() => !!chatCapability().enabled);
+            return () => _c$5() ? tr$1(locale(), "聊天可用", "Chat Ready") : tr$1(locale(), "聊天受限", "Chat Limited");
           })());
-          createRenderEffect(() => className(_el$129, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
-          return _el$125;
+          createRenderEffect(() => className(_el$126, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
+          return _el$122;
         })(), (() => {
-          var _el$130 = _tmpl$38$1(), _el$131 = _el$130.firstChild, _el$132 = _el$131.firstChild, _el$133 = _el$132.nextSibling, _el$134 = _el$133.nextSibling, _el$135 = _el$131.nextSibling, _el$136 = _el$135.firstChild, _el$137 = _el$136.nextSibling, _el$138 = _el$135.nextSibling, _el$139 = _el$138.firstChild, _el$140 = _el$139.nextSibling, _el$141 = _el$138.nextSibling;
-          insert(_el$132, () => tr$1(locale(), "目标", "Target"));
-          insert(_el$133, agentName);
-          insert(_el$134, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
-          insert(_el$136, () => tr$1(locale(), "阻塞", "Blocker"));
-          insert(_el$137, blockerLabel);
-          insert(_el$139, () => tr$1(locale(), "回执", "Receipt"));
-          insert(_el$140, receiptLabel);
-          _el$141.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$141, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          var _el$127 = _tmpl$36$1(), _el$128 = _el$127.firstChild, _el$129 = _el$128.firstChild, _el$130 = _el$129.nextSibling, _el$131 = _el$130.nextSibling, _el$132 = _el$128.nextSibling, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling, _el$135 = _el$132.nextSibling, _el$136 = _el$135.firstChild, _el$137 = _el$136.nextSibling, _el$138 = _el$135.nextSibling;
+          insert(_el$129, () => tr$1(locale(), "目标", "Target"));
+          insert(_el$130, agentName);
+          insert(_el$131, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
+          insert(_el$133, () => tr$1(locale(), "阻塞", "Blocker"));
+          insert(_el$134, blockerLabel);
+          insert(_el$136, () => tr$1(locale(), "回执", "Receipt"));
+          insert(_el$137, receiptLabel);
+          _el$138.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$138, () => tr$1(locale(), "发送聊天", "Send Chat"));
           createRenderEffect((_p$) => {
-            var _v$57 = chatControlsEnabled() ? "true" : "false", _v$58 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$59 = !chatControlsEnabled();
-            _v$57 !== _p$.e && setAttribute(_el$130, "data-chat-ready", _p$.e = _v$57);
-            _v$58 !== _p$.t && setAttribute(_el$135, "data-blocker-present", _p$.t = _v$58);
-            _v$59 !== _p$.a && (_el$141.disabled = _p$.a = _v$59);
+            var _v$56 = chatControlsEnabled() ? "true" : "false", _v$57 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$58 = !chatControlsEnabled();
+            _v$56 !== _p$.e && setAttribute(_el$127, "data-chat-ready", _p$.e = _v$56);
+            _v$57 !== _p$.t && setAttribute(_el$132, "data-blocker-present", _p$.t = _v$57);
+            _v$58 !== _p$.a && (_el$138.disabled = _p$.a = _v$58);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          return _el$130;
+          return _el$127;
         })(), createComponent(Show, {
           get when() {
             return !chatCapability().enabled;
           },
           get children() {
-            var _el$142 = _tmpl$39$1();
-            insert(_el$142, () => chatCapability().reason);
-            return _el$142;
+            var _el$139 = _tmpl$37$1();
+            insert(_el$139, () => chatCapability().reason);
+            return _el$139;
           }
         }), (() => {
-          var _el$143 = _tmpl$40$1(), _el$144 = _el$143.firstChild, _el$145 = _el$144.firstChild, _el$146 = _el$145.firstChild, _el$147 = _el$146.nextSibling, _el$148 = _el$147.nextSibling, _el$149 = _el$144.nextSibling, _el$150 = _el$149.firstChild, _el$151 = _el$150.firstChild, _el$152 = _el$151.nextSibling, _el$153 = _el$150.nextSibling, _el$154 = _el$153.firstChild, _el$155 = _el$153.nextSibling, _el$156 = _el$155.firstChild, _el$157 = _el$156.nextSibling;
-          insert(_el$146, () => tr$1(locale(), "指挥面板", "Command Surface"));
-          insert(_el$147, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
-          insert(_el$148, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
-          insert(_el$151, () => tr$1(locale(), "消息", "Message"));
-          _el$152.$$input = (event) => {
+          var _el$140 = _tmpl$38$1(), _el$141 = _el$140.firstChild, _el$142 = _el$141.firstChild, _el$143 = _el$142.firstChild, _el$144 = _el$143.nextSibling, _el$145 = _el$144.nextSibling, _el$146 = _el$141.nextSibling, _el$147 = _el$146.firstChild, _el$148 = _el$147.firstChild, _el$149 = _el$148.nextSibling, _el$150 = _el$147.nextSibling, _el$151 = _el$150.firstChild, _el$152 = _el$150.nextSibling, _el$153 = _el$152.firstChild, _el$154 = _el$153.nextSibling;
+          insert(_el$143, () => tr$1(locale(), "指挥面板", "Command Surface"));
+          insert(_el$144, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
+          insert(_el$145, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
+          insert(_el$148, () => tr$1(locale(), "消息", "Message"));
+          _el$149.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
-          _el$154.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$154, () => tr$1(locale(), "发送聊天", "Send Chat"));
-          insert(_el$149, createComponent(Show, {
+          _el$151.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$151, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          insert(_el$146, createComponent(Show, {
             get when() {
               return chatFeedback();
             },
             get fallback() {
               return (() => {
-                var _el$159 = _tmpl$39$1();
-                insert(_el$159, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
-                return _el$159;
+                var _el$156 = _tmpl$37$1();
+                insert(_el$156, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
+                return _el$156;
               })();
             },
             children: (feedback) => (() => {
-              var _el$160 = _tmpl$43$1(), _el$161 = _el$160.firstChild, _el$162 = _el$161.firstChild, _el$164 = _el$161.nextSibling;
-              insert(_el$162, () => chatFeedbackDisplay().label);
-              insert(_el$161, createComponent(Show, {
+              var _el$157 = _tmpl$41$1(), _el$158 = _el$157.firstChild, _el$159 = _el$158.firstChild, _el$161 = _el$158.nextSibling;
+              insert(_el$159, () => chatFeedbackDisplay().label);
+              insert(_el$158, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().code;
                 },
                 get children() {
-                  var _el$163 = _tmpl$36$1();
-                  insert(_el$163, () => `code=${chatFeedbackDisplay().code}`);
-                  return _el$163;
+                  var _el$160 = _tmpl$34$1();
+                  insert(_el$160, () => `code=${chatFeedbackDisplay().code}`);
+                  return _el$160;
                 }
               }), null);
-              insert(_el$164, () => chatFeedbackDisplay().summary);
-              insert(_el$160, createComponent(Show, {
+              insert(_el$161, () => chatFeedbackDisplay().summary);
+              insert(_el$157, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().detail;
                 },
                 get children() {
-                  var _el$165 = _tmpl$42$1();
-                  insert(_el$165, () => chatFeedbackDisplay().detail);
-                  return _el$165;
+                  var _el$162 = _tmpl$40$1();
+                  insert(_el$162, () => chatFeedbackDisplay().detail);
+                  return _el$162;
                 }
               }), null);
-              insert(_el$160, createComponent(PixelRawDiagnostics, {
+              insert(_el$157, createComponent(PixelRawDiagnostics, {
                 locale,
                 value: feedback
               }), null);
-              createRenderEffect(() => className(_el$162, chatFeedbackDisplay().badgeClass));
-              return _el$160;
+              createRenderEffect(() => className(_el$159, chatFeedbackDisplay().badgeClass));
+              return _el$157;
             })()
-          }), _el$155);
-          insert(_el$156, () => tr$1(locale(), "消息流", "Message Flow"));
-          insert(_el$157, createComponent(Show, {
+          }), _el$152);
+          insert(_el$153, () => tr$1(locale(), "消息流", "Message Flow"));
+          insert(_el$154, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
             get fallback() {
               return (() => {
-                var _el$166 = _tmpl$39$1();
-                insert(_el$166, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
-                return _el$166;
+                var _el$163 = _tmpl$37$1();
+                insert(_el$163, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
+                return _el$163;
               })();
             },
             get children() {
@@ -11772,37 +11916,37 @@ function PixelWorldFocusCommandSurface(props) {
                   return chatHistory();
                 },
                 children: (entry) => (() => {
-                  var _el$167 = _tmpl$44$1(), _el$168 = _el$167.firstChild, _el$169 = _el$168.firstChild, _el$170 = _el$168.nextSibling, _el$171 = _el$170.nextSibling;
-                  insert(_el$169, () => chatEntryTitle$1(entry, locale()));
-                  insert(_el$170, () => chatEntryMeta$1(entry, locale()));
-                  insert(_el$171, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
-                  insert(_el$167, createComponent(PixelRawDiagnostics, {
+                  var _el$164 = _tmpl$42$1(), _el$165 = _el$164.firstChild, _el$166 = _el$165.firstChild, _el$167 = _el$165.nextSibling, _el$168 = _el$167.nextSibling;
+                  insert(_el$166, () => chatEntryTitle$1(entry, locale()));
+                  insert(_el$167, () => chatEntryMeta$1(entry, locale()));
+                  insert(_el$168, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
+                  insert(_el$164, createComponent(PixelRawDiagnostics, {
                     locale,
                     value: entry
                   }), null);
-                  createRenderEffect(() => className(_el$167, chatEntryCardClass$1(entry)));
-                  return _el$167;
+                  createRenderEffect(() => className(_el$164, chatEntryCardClass$1(entry)));
+                  return _el$164;
                 })()
               });
             }
           }));
           createRenderEffect((_p$) => {
-            var _v$60 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$61 = !chatControlsEnabled(), _v$62 = !chatControlsEnabled();
-            _v$60 !== _p$.e && setAttribute(_el$152, "placeholder", _p$.e = _v$60);
-            _v$61 !== _p$.t && (_el$152.disabled = _p$.t = _v$61);
-            _v$62 !== _p$.a && (_el$154.disabled = _p$.a = _v$62);
+            var _v$59 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$60 = !chatControlsEnabled(), _v$61 = !chatControlsEnabled();
+            _v$59 !== _p$.e && setAttribute(_el$149, "placeholder", _p$.e = _v$59);
+            _v$60 !== _p$.t && (_el$149.disabled = _p$.t = _v$60);
+            _v$61 !== _p$.a && (_el$151.disabled = _p$.a = _v$61);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          createRenderEffect(() => _el$152.value = state.chatDraft.message);
-          return _el$143;
+          createRenderEffect(() => _el$149.value = state.chatDraft.message);
+          return _el$140;
         })()];
       }
     }));
-    return _el$124;
+    return _el$121;
   })();
 }
 function PixelWorldHost(props) {
@@ -12051,26 +12195,26 @@ function PixelWorldHost(props) {
     });
   });
   return (() => {
-    var _el$172 = _tmpl$53$1(), _el$177 = _el$172.firstChild, _el$178 = _el$177.firstChild, _el$179 = _el$178.nextSibling, _el$216 = _el$177.nextSibling, _el$217 = _el$216.firstChild;
-    setAttribute(_el$172, "data-visual-fixture", visualFixtureName || "");
-    insert(_el$172, createComponent(Show, {
+    var _el$169 = _tmpl$51$1(), _el$174 = _el$169.firstChild, _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling, _el$213 = _el$174.nextSibling, _el$214 = _el$213.firstChild;
+    setAttribute(_el$169, "data-visual-fixture", visualFixtureName || "");
+    insert(_el$169, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$173 = _tmpl$45$1(), _el$174 = _el$173.firstChild, _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling;
-        insert(_el$175, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
-        insert(_el$176, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
-        return _el$173;
+        var _el$170 = _tmpl$43$1(), _el$171 = _el$170.firstChild, _el$172 = _el$171.firstChild, _el$173 = _el$172.nextSibling;
+        insert(_el$172, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
+        insert(_el$173, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
+        return _el$170;
       }
-    }), _el$177);
-    insert(_el$178, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
-    addEventListener(_el$179, "click", focusController.enterFocusMode);
-    insert(_el$179, (() => {
-      var _c$7 = memo(() => rendererStatus() === "unavailable");
-      return () => _c$7() ? tr$1(locale(), "电影视图（当前不可用）", "Cinematic View (unavailable)") : tr$1(locale(), "电影视图", "Cinematic View");
+    }), _el$174);
+    insert(_el$175, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
+    addEventListener(_el$176, "click", focusController.enterFocusMode);
+    insert(_el$176, (() => {
+      var _c$6 = memo(() => rendererStatus() === "unavailable");
+      return () => _c$6() ? tr$1(locale(), "电影视图（当前不可用）", "Cinematic View (unavailable)") : tr$1(locale(), "电影视图", "Cinematic View");
     })());
-    insert(_el$172, createComponent(Show, {
+    insert(_el$169, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
@@ -12115,8 +12259,8 @@ function PixelWorldHost(props) {
           }
         })];
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return renderState();
       },
@@ -12127,8 +12271,8 @@ function PixelWorldHost(props) {
           focusMode
         });
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return memo(() => rendererStatus() !== "fallback")() && rendererStatus() !== "unavailable";
       },
@@ -12158,59 +12302,59 @@ function PixelWorldHost(props) {
           }
         });
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return !renderState();
       },
       get children() {
-        var _el$180 = _tmpl$46$1();
-        insert(_el$180, (() => {
-          var _c$8 = memo(() => rendererStatus() === "unavailable");
-          return () => _c$8() ? [(() => {
-            var _el$220 = _tmpl$54$1();
-            insert(_el$220, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
-            return _el$220;
+        var _el$177 = _tmpl$44$1();
+        insert(_el$177, (() => {
+          var _c$7 = memo(() => rendererStatus() === "unavailable");
+          return () => _c$7() ? [(() => {
+            var _el$217 = _tmpl$52$1();
+            insert(_el$217, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
+            return _el$217;
           })(), (() => {
-            var _el$221 = _tmpl$55$1();
-            _el$221.$$click = requestReadyMode;
-            insert(_el$221, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
-            return _el$221;
+            var _el$218 = _tmpl$53$1();
+            _el$218.$$click = requestReadyMode;
+            insert(_el$218, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
+            return _el$218;
           })()] : tr$1(locale(), "Rust bridge 正在生成世界显示状态。", "Rust bridge is deriving the world display state.");
         })());
         createRenderEffect((_p$) => {
-          var _v$63 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$64 = rendererStatus();
-          _v$63 !== _p$.e && setAttribute(_el$180, "id", _p$.e = _v$63);
-          _v$64 !== _p$.t && setAttribute(_el$180, "data-renderer-state", _p$.t = _v$64);
+          var _v$62 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$63 = rendererStatus();
+          _v$62 !== _p$.e && setAttribute(_el$177, "id", _p$.e = _v$62);
+          _v$63 !== _p$.t && setAttribute(_el$177, "data-renderer-state", _p$.t = _v$63);
           return _p$;
         }, {
           e: void 0,
           t: void 0
         });
-        return _el$180;
+        return _el$177;
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState()?.commercial_surface;
       },
       get children() {
-        var _el$181 = _tmpl$47$1();
-        insert(_el$181, createComponent(PixelWorldActionReceipt, {
+        var _el$178 = _tmpl$45$1();
+        insert(_el$178, createComponent(PixelWorldActionReceipt, {
           "class": "pixel-world-action-receipt--focus-compact",
           locale,
           surface: () => renderState().commercial_surface
         }));
-        return _el$181;
+        return _el$178;
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return focusMode();
       },
       get children() {
-        var _el$182 = _tmpl$48$1(), _el$183 = _el$182.firstChild, _el$184 = _el$183.nextSibling;
-        _el$182.addEventListener("toggle", (event) => {
+        var _el$179 = _tmpl$46$1(), _el$180 = _el$179.firstChild, _el$181 = _el$180.nextSibling;
+        _el$179.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentCommandDrawerOpen(true);
@@ -12220,97 +12364,97 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$183, () => tr$1(locale(), "命令与目标", "Command and Target"));
-        insert(_el$184, createComponent(PixelWorldFocusCommandSurface, {
+        insert(_el$180, () => tr$1(locale(), "命令与目标", "Command and Target"));
+        insert(_el$181, createComponent(PixelWorldFocusCommandSurface, {
           locale
         }));
-        createRenderEffect(() => _el$182.open = commandDrawerOpen());
-        return _el$182;
+        createRenderEffect(() => _el$179.open = commandDrawerOpen());
+        return _el$179;
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$185 = _tmpl$50$1(), _el$186 = _el$185.firstChild, _el$187 = _el$186.nextSibling, _el$188 = _el$187.firstChild, _el$189 = _el$188.nextSibling, _el$190 = _el$189.nextSibling, _el$192 = _el$190.nextSibling, _el$193 = _el$192.nextSibling, _el$194 = _el$193.nextSibling, _el$195 = _el$194.nextSibling, _el$196 = _el$195.nextSibling, _el$197 = _el$196.nextSibling, _el$201 = _el$197.nextSibling, _el$202 = _el$201.nextSibling, _el$203 = _el$202.nextSibling;
-        insert(_el$186, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
-        insert(_el$188, () => `locations=${visualState().locations.length}`);
-        insert(_el$189, () => `fragments=${visualState().fragmentTerrain.length}`);
-        insert(_el$190, () => `agents=${visualState().agents.length}`);
-        insert(_el$187, createComponent(Show, {
+        var _el$182 = _tmpl$48$1(), _el$183 = _el$182.firstChild, _el$184 = _el$183.nextSibling, _el$185 = _el$184.firstChild, _el$186 = _el$185.nextSibling, _el$187 = _el$186.nextSibling, _el$189 = _el$187.nextSibling, _el$190 = _el$189.nextSibling, _el$191 = _el$190.nextSibling, _el$192 = _el$191.nextSibling, _el$193 = _el$192.nextSibling, _el$194 = _el$193.nextSibling, _el$198 = _el$194.nextSibling, _el$199 = _el$198.nextSibling, _el$200 = _el$199.nextSibling;
+        insert(_el$183, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
+        insert(_el$185, () => `locations=${visualState().locations.length}`);
+        insert(_el$186, () => `fragments=${visualState().fragmentTerrain.length}`);
+        insert(_el$187, () => `agents=${visualState().agents.length}`);
+        insert(_el$184, createComponent(Show, {
           get when() {
             return memo(() => renderState()?.world_tick !== null)() && renderState()?.world_tick !== void 0;
           },
           get children() {
-            var _el$191 = _tmpl$22$1();
-            insert(_el$191, () => `tick=${renderState()?.world_tick}`);
-            createRenderEffect(() => setAttribute(_el$191, "data-world-tick", String(renderState()?.world_tick)));
-            return _el$191;
+            var _el$188 = _tmpl$20$1();
+            insert(_el$188, () => `tick=${renderState()?.world_tick}`);
+            createRenderEffect(() => setAttribute(_el$188, "data-world-tick", String(renderState()?.world_tick)));
+            return _el$188;
           }
-        }), _el$192);
-        insert(_el$192, () => `links=${visualState().links.length}`);
-        insert(_el$193, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
-        insert(_el$194, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$195, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
-        insert(_el$196, () => `renderer=${rendererStatus()}`);
-        insert(_el$197, () => `runtime=${runtimeSource()}`);
-        insert(_el$187, createComponent(Show, {
+        }), _el$189);
+        insert(_el$189, () => `links=${visualState().links.length}`);
+        insert(_el$190, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
+        insert(_el$191, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$192, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
+        insert(_el$193, () => `renderer=${rendererStatus()}`);
+        insert(_el$194, () => `runtime=${runtimeSource()}`);
+        insert(_el$184, createComponent(Show, {
           get when() {
             return cameraState();
           },
           get children() {
-            var _el$198 = _tmpl$36$1();
-            insert(_el$198, () => `zoom=${cameraState().zoom.toFixed(2)}`);
-            return _el$198;
+            var _el$195 = _tmpl$34$1();
+            insert(_el$195, () => `zoom=${cameraState().zoom.toFixed(2)}`);
+            return _el$195;
           }
-        }), _el$201);
-        insert(_el$187, createComponent(Show, {
+        }), _el$198);
+        insert(_el$184, createComponent(Show, {
           get when() {
             return cameraState();
           },
           get children() {
-            var _el$199 = _tmpl$36$1();
-            insert(_el$199, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
-            return _el$199;
+            var _el$196 = _tmpl$34$1();
+            insert(_el$196, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
+            return _el$196;
           }
-        }), _el$201);
-        insert(_el$187, createComponent(Show, {
+        }), _el$198);
+        insert(_el$184, createComponent(Show, {
           get when() {
             return hoverSelection();
           },
           get children() {
-            var _el$200 = _tmpl$36$1();
-            insert(_el$200, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
-            return _el$200;
+            var _el$197 = _tmpl$34$1();
+            insert(_el$197, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
+            return _el$197;
           }
-        }), _el$201);
-        _el$201.$$click = requestReadyMode;
-        insert(_el$201, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        _el$202.$$click = simulateFatal;
-        insert(_el$202, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
-        insert(_el$203, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
-        insert(_el$187, createComponent(Show, {
+        }), _el$198);
+        _el$198.$$click = requestReadyMode;
+        insert(_el$198, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        _el$199.$$click = simulateFatal;
+        insert(_el$199, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
+        insert(_el$200, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
+        insert(_el$184, createComponent(Show, {
           get when() {
             return memo(() => rendererStatus() === "unavailable")() && rendererFatal();
           },
           get children() {
-            var _el$204 = _tmpl$49$1();
-            insert(_el$204, () => `${rendererFatal().code}: ${rendererFatal().message}`);
-            return _el$204;
+            var _el$201 = _tmpl$47$1();
+            insert(_el$201, () => `${rendererFatal().code}: ${rendererFatal().message}`);
+            return _el$201;
           }
         }), null);
-        createRenderEffect(() => setAttribute(_el$185, "data-renderer-state", rendererStatus()));
-        return _el$185;
+        createRenderEffect(() => setAttribute(_el$182, "data-renderer-state", rendererStatus()));
+        return _el$182;
       }
-    }), _el$216);
-    insert(_el$172, createComponent(Show, {
+    }), _el$213);
+    insert(_el$169, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
       get children() {
-        var _el$205 = _tmpl$51$1(), _el$206 = _el$205.firstChild, _el$207 = _el$206.nextSibling, _el$208 = _el$207.firstChild, _el$210 = _el$208.firstChild, _el$211 = _el$210.nextSibling, _el$212 = _el$211.nextSibling, _el$214 = _el$208.nextSibling, _el$215 = _el$214.firstChild;
-        _el$205.addEventListener("toggle", (event) => {
+        var _el$202 = _tmpl$49$1(), _el$203 = _el$202.firstChild, _el$204 = _el$203.nextSibling, _el$205 = _el$204.firstChild, _el$207 = _el$205.firstChild, _el$208 = _el$207.nextSibling, _el$209 = _el$208.nextSibling, _el$211 = _el$205.nextSibling, _el$212 = _el$211.firstChild;
+        _el$202.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentDiagnosticsDrawerOpen(true);
@@ -12320,58 +12464,58 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$206, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
-        insert(_el$208, createComponent(Show, {
+        insert(_el$203, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
+        insert(_el$205, createComponent(Show, {
           get when() {
             return memo(() => renderState().world_tick !== null)() && renderState().world_tick !== void 0;
           },
           get children() {
-            var _el$209 = _tmpl$22$1();
-            insert(_el$209, () => `tick=${renderState().world_tick}`);
-            createRenderEffect(() => setAttribute(_el$209, "data-world-tick", String(renderState().world_tick)));
-            return _el$209;
+            var _el$206 = _tmpl$20$1();
+            insert(_el$206, () => `tick=${renderState().world_tick}`);
+            createRenderEffect(() => setAttribute(_el$206, "data-world-tick", String(renderState().world_tick)));
+            return _el$206;
           }
-        }), _el$210);
-        insert(_el$210, () => `renderer=${rendererStatus()}`);
-        insert(_el$211, () => `runtime=${runtimeSource()}`);
-        insert(_el$212, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$208, createComponent(Show, {
+        }), _el$207);
+        insert(_el$207, () => `renderer=${rendererStatus()}`);
+        insert(_el$208, () => `runtime=${runtimeSource()}`);
+        insert(_el$209, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$205, createComponent(Show, {
           get when() {
             return rendererFatal();
           },
           get children() {
-            var _el$213 = _tmpl$26$1();
-            insert(_el$213, () => rendererFatal().code);
-            return _el$213;
+            var _el$210 = _tmpl$24$1();
+            insert(_el$210, () => rendererFatal().code);
+            return _el$210;
           }
         }), null);
-        _el$215.$$click = requestReadyMode;
-        insert(_el$215, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        createRenderEffect(() => _el$205.open = diagnosticsDrawerOpen());
-        return _el$205;
+        _el$212.$$click = requestReadyMode;
+        insert(_el$212, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        createRenderEffect(() => _el$202.open = diagnosticsDrawerOpen());
+        return _el$202;
       }
-    }), _el$216);
-    _el$216.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
-    insert(_el$217, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
-    insert(_el$216, createComponent(Show, {
+    }), _el$213);
+    _el$213.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
+    insert(_el$214, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
+    insert(_el$213, createComponent(Show, {
       get when() {
         return renderDtoOpen();
       },
       get children() {
-        var _el$218 = _tmpl$52$1(), _el$219 = _el$218.firstChild;
-        insert(_el$219, () => JSON.stringify(renderState(), null, 2));
-        return _el$218;
+        var _el$215 = _tmpl$50$1(), _el$216 = _el$215.firstChild;
+        insert(_el$216, () => JSON.stringify(renderState(), null, 2));
+        return _el$215;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$65 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$66 = focusMode() ? "true" : "false", _v$67 = focusMode() && maximized() ? "true" : "false", _v$68 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$69 = focusMode(), _v$70 = !renderState(), _v$71 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
-      _v$65 !== _p$.e && className(_el$172, _p$.e = _v$65);
-      _v$66 !== _p$.t && setAttribute(_el$172, "data-world-focus", _p$.t = _v$66);
-      _v$67 !== _p$.a && setAttribute(_el$172, "data-world-focus-maximized", _p$.a = _v$67);
-      _v$68 !== _p$.o && setAttribute(_el$172, "data-focus-comparable", _p$.o = _v$68);
-      _v$69 !== _p$.i && (_el$177.hidden = _p$.i = _v$69);
-      _v$70 !== _p$.n && (_el$179.disabled = _p$.n = _v$70);
-      _v$71 !== _p$.s && setAttribute(_el$179, "aria-describedby", _p$.s = _v$71);
+      var _v$64 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$65 = focusMode() ? "true" : "false", _v$66 = focusMode() && maximized() ? "true" : "false", _v$67 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$68 = focusMode(), _v$69 = !renderState(), _v$70 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
+      _v$64 !== _p$.e && className(_el$169, _p$.e = _v$64);
+      _v$65 !== _p$.t && setAttribute(_el$169, "data-world-focus", _p$.t = _v$65);
+      _v$66 !== _p$.a && setAttribute(_el$169, "data-world-focus-maximized", _p$.a = _v$66);
+      _v$67 !== _p$.o && setAttribute(_el$169, "data-focus-comparable", _p$.o = _v$67);
+      _v$68 !== _p$.i && (_el$174.hidden = _p$.i = _v$68);
+      _v$69 !== _p$.n && (_el$176.disabled = _p$.n = _v$69);
+      _v$70 !== _p$.s && setAttribute(_el$176, "aria-describedby", _p$.s = _v$70);
       return _p$;
     }, {
       e: void 0,
@@ -12382,11 +12526,11 @@ function PixelWorldHost(props) {
       n: void 0,
       s: void 0
     });
-    return _el$172;
+    return _el$169;
   })();
 }
 delegateEvents(["click", "input"]);
-var _tmpl$$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$2$o = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$6$b = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$7$7 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class=feedback-detail role=status aria-live=polite>`), _tmpl$9$3 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$0$3 = /* @__PURE__ */ template(`<article class="event-card world-feed__event"><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
+var _tmpl$$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$2$o = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$6$b = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=world-feed__summary-line><div class=panel__title></div><span></span></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$7$7 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class=feedback-detail role=status aria-live=polite>`), _tmpl$9$3 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$0$3 = /* @__PURE__ */ template(`<article class="event-card world-feed__event"><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
 function readFeed(props) {
   return typeof props.feed === "function" ? props.feed() : props.feed || {};
 }
@@ -12401,11 +12545,23 @@ function statusCopy(locale, tr2, status) {
   }[status] || ["世界动态不可用", "World activity unavailable"];
   return tr2(locale, copy2[0], copy2[1]);
 }
+function statusBadgeLabel(locale, tr2, status) {
+  const copy2 = {
+    loading: ["同步中", "SYNCING"],
+    ready: ["实时", "LIVE"],
+    empty: ["暂无动态", "NO EVENTS"],
+    replay: ["回放", "REPLAY"],
+    gap: ["断档", "GAP"],
+    unavailable: ["不可用", "UNAVAILABLE"]
+  }[status] || ["不可用", "UNAVAILABLE"];
+  return tr2(locale, copy2[0], copy2[1]);
+}
 function statusBadgeClass(status) {
-  if (status === "ready") return "badge badge--accent";
-  if (status === "replay") return "badge badge--accent";
-  if (status === "gap" || status === "unavailable") return "badge badge--warn";
-  return "badge";
+  const stateClass = `world-feed__status-badge world-feed__status-badge--${status || "unknown"}`;
+  if (status === "ready") return `badge badge--accent ${stateClass}`;
+  if (status === "replay") return `badge badge--accent ${stateClass}`;
+  if (status === "gap" || status === "unavailable") return `badge badge--warn ${stateClass}`;
+  return `badge ${stateClass}`;
 }
 function reasonCopy(locale, tr2, feed) {
   if (feed.status === "gap") {
@@ -12458,118 +12614,120 @@ function WorldFeedPanel(props) {
   const presentationEvents = () => [...feed().events || []].sort((left, right) => compareUnsignedDecimal(left?.event_seq, right?.event_seq));
   const status = () => String(feed().status || "unavailable");
   const statusLabel2 = () => statusCopy(locale(), tr2, status());
+  const summaryStatusLabel = () => statusBadgeLabel(locale(), tr2, status());
   const shouldReload = () => status() !== "unavailable" && Boolean(feed().snapshotReloadRequired || status() === "gap");
   return (() => {
-    var _el$ = _tmpl$6$b(), _el$2 = _el$.firstChild, _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling, _el$5 = _el$4.nextSibling, _el$6 = _el$2.nextSibling, _el$7 = _el$6.firstChild, _el$8 = _el$7.firstChild;
+    var _el$ = _tmpl$6$b(), _el$2 = _el$.firstChild, _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling, _el$5 = _el$4.firstChild, _el$6 = _el$5.nextSibling, _el$7 = _el$4.nextSibling, _el$8 = _el$2.nextSibling, _el$9 = _el$8.firstChild, _el$0 = _el$9.firstChild;
     insert(_el$3, () => tr2(locale(), "环境上下文", "Ambient Context"));
-    insert(_el$4, () => tr2(locale(), "World Feed", "World Feed"));
-    insert(_el$5, () => tr2(locale(), "只读的运行时环境投影；不会替代 Action Receipt，也不会证明玩家动作成功。", "Read-only runtime context; it never replaces Action Receipt or proves a player action succeeded."));
-    insert(_el$8, statusLabel2);
-    insert(_el$7, createComponent(Show, {
+    insert(_el$5, () => tr2(locale(), "World Feed", "World Feed"));
+    insert(_el$6, summaryStatusLabel);
+    insert(_el$7, () => tr2(locale(), "只读的运行时环境投影；不会替代 Action Receipt，也不会证明玩家动作成功。", "Read-only runtime context; it never replaces Action Receipt or proves a player action succeeded."));
+    insert(_el$0, statusLabel2);
+    insert(_el$9, createComponent(Show, {
       get when() {
         return feed().worldId;
       },
       get children() {
-        var _el$9 = _tmpl$$o();
-        insert(_el$9, () => `world=${feed().worldId}`);
-        return _el$9;
+        var _el$1 = _tmpl$$o();
+        insert(_el$1, () => `world=${feed().worldId}`);
+        return _el$1;
       }
     }), null);
-    insert(_el$7, createComponent(Show, {
+    insert(_el$9, createComponent(Show, {
       get when() {
         return feed().reorgEpoch != null;
       },
       get children() {
-        var _el$0 = _tmpl$$o();
-        insert(_el$0, () => `epoch=${feed().reorgEpoch}`);
-        return _el$0;
+        var _el$10 = _tmpl$$o();
+        insert(_el$10, () => `epoch=${feed().reorgEpoch}`);
+        return _el$10;
       }
     }), null);
-    insert(_el$6, createComponent(Show, {
+    insert(_el$8, createComponent(Show, {
       get when() {
         return reasonCopy(locale(), tr2, feed());
       },
       get children() {
-        var _el$1 = _tmpl$2$o();
-        insert(_el$1, () => reasonCopy(locale(), tr2, feed()));
-        return _el$1;
+        var _el$11 = _tmpl$2$o();
+        insert(_el$11, () => reasonCopy(locale(), tr2, feed()));
+        return _el$11;
       }
     }), null);
-    insert(_el$6, createComponent(Show, {
+    insert(_el$8, createComponent(Show, {
       get when() {
         return shouldReload();
       },
       get children() {
-        var _el$10 = _tmpl$3$l(), _el$11 = _el$10.firstChild;
-        _el$11.$$click = () => props.onReloadSnapshot?.();
-        insert(_el$11, () => tr2(locale(), "重新加载权威快照", "Reload authoritative snapshot"));
-        return _el$10;
+        var _el$12 = _tmpl$3$l(), _el$13 = _el$12.firstChild;
+        _el$13.$$click = () => props.onReloadSnapshot?.();
+        insert(_el$13, () => tr2(locale(), "重新加载权威快照", "Reload authoritative snapshot"));
+        return _el$12;
       }
     }), null);
-    insert(_el$6, createComponent(Show, {
+    insert(_el$8, createComponent(Show, {
       get when() {
         return status() === "unavailable";
       },
       get children() {
-        var _el$12 = _tmpl$4$i(), _el$13 = _el$12.firstChild;
-        _el$13.$$click = () => props.onRetryFeed?.();
-        insert(_el$13, () => tr2(locale(), "重试 World Feed", "Retry World Feed"));
-        return _el$12;
+        var _el$14 = _tmpl$4$i(), _el$15 = _el$14.firstChild;
+        _el$15.$$click = () => props.onRetryFeed?.();
+        insert(_el$15, () => tr2(locale(), "重试 World Feed", "Retry World Feed"));
+        return _el$14;
       }
     }), null);
-    insert(_el$6, createComponent(Show, {
+    insert(_el$8, createComponent(Show, {
       get when() {
         return presentationEvents().length > 0;
       },
       get fallback() {
         return (() => {
-          var _el$15 = _tmpl$7$7();
-          insert(_el$15, (() => {
+          var _el$17 = _tmpl$7$7();
+          insert(_el$17, (() => {
             var _c$ = memo(() => status() === "loading");
             return () => _c$() ? tr2(locale(), "正在等待 world_feed/v1 响应…", "Waiting for a world_feed/v1 response…") : memo(() => status() === "empty")() ? tr2(locale(), "权威运行时尚未发布世界更新中的事件。此动态仅作上下文；请继续当前玩家目标，下一次权威世界更新后动态会刷新。", "No authoritative world update has published events yet. This feed is context only—continue your Player goal; the feed will update after the next authoritative world update.") : memo(() => status() === "unavailable")() ? tr2(locale(), "重试 World Feed 以检查最新环境动态。", "Retry World Feed to check for the latest ambient activity.") : tr2(locale(), "没有可显示的环境事件。", "No ambient events are available to display.");
           })());
-          return _el$15;
+          return _el$17;
         })();
       },
       get children() {
-        var _el$14 = _tmpl$5$h();
-        insert(_el$14, createComponent(For, {
+        var _el$16 = _tmpl$5$h();
+        insert(_el$16, createComponent(For, {
           get each() {
             return presentationEvents();
           },
           children: (event) => (() => {
-            var _el$16 = _tmpl$0$3(), _el$17 = _el$16.firstChild, _el$18 = _el$17.firstChild, _el$19 = _el$18.nextSibling, _el$20 = _el$17.nextSibling;
-            insert(_el$18, () => event.summary);
-            insert(_el$19, () => `#${event.event_seq}`);
-            insert(_el$20, () => eventKindLabel(event, locale(), tr2));
-            insert(_el$16, createComponent(Show, {
+            var _el$18 = _tmpl$0$3(), _el$19 = _el$18.firstChild, _el$20 = _el$19.firstChild, _el$21 = _el$20.nextSibling, _el$22 = _el$19.nextSibling;
+            insert(_el$20, () => event.summary);
+            insert(_el$21, () => `#${event.event_seq}`);
+            insert(_el$22, () => eventKindLabel(event, locale(), tr2));
+            insert(_el$18, createComponent(Show, {
               get when() {
                 return memo(() => event.major_event?.freshness === "current")() && status() === "ready";
               },
               get children() {
-                var _el$21 = _tmpl$8$4();
-                insert(_el$21, () => majorEventStatusCopy(event, locale(), tr2));
-                return _el$21;
+                var _el$23 = _tmpl$8$4();
+                insert(_el$23, () => majorEventStatusCopy(event, locale(), tr2));
+                return _el$23;
               }
             }), null);
-            insert(_el$16, createComponent(Show, {
+            insert(_el$18, createComponent(Show, {
               get when() {
                 return event.receipt_ref != null;
               },
               get children() {
-                var _el$22 = _tmpl$9$3();
-                insert(_el$22, () => tr2(locale(), `查看明确回执 ${event.receipt_ref}`, `View explicit receipt ${event.receipt_ref}`));
-                createRenderEffect(() => setAttribute(_el$22, "data-world-feed-receipt-ref", event.receipt_ref));
-                return _el$22;
+                var _el$24 = _tmpl$9$3();
+                insert(_el$24, () => tr2(locale(), `查看明确回执 ${event.receipt_ref}`, `View explicit receipt ${event.receipt_ref}`));
+                createRenderEffect(() => setAttribute(_el$24, "data-world-feed-receipt-ref", event.receipt_ref));
+                return _el$24;
               }
             }), null);
             createRenderEffect((_p$) => {
-              var _v$3 = event.event_seq, _v$4 = event.major_event ? event.event_seq : void 0, _v$5 = event.major_event?.category, _v$6 = event.major_event?.lifecycle, _v$7 = event.major_event?.severity;
-              _v$3 !== _p$.e && setAttribute(_el$16, "data-world-feed-event", _p$.e = _v$3);
-              _v$4 !== _p$.t && setAttribute(_el$16, "data-world-feed-major-event", _p$.t = _v$4);
-              _v$5 !== _p$.a && setAttribute(_el$16, "data-major-event-category", _p$.a = _v$5);
-              _v$6 !== _p$.o && setAttribute(_el$16, "data-major-event-lifecycle", _p$.o = _v$6);
-              _v$7 !== _p$.i && setAttribute(_el$16, "data-major-event-severity", _p$.i = _v$7);
+              var _v$5 = event.event_seq, _v$6 = event.major_event ? event.event_seq : void 0, _v$7 = event.major_event?.category, _v$8 = event.major_event?.lifecycle, _v$9 = event.major_event?.severity;
+              _v$5 !== _p$.e && setAttribute(_el$18, "data-world-feed-event", _p$.e = _v$5);
+              _v$6 !== _p$.t && setAttribute(_el$18, "data-world-feed-major-event", _p$.t = _v$6);
+              _v$7 !== _p$.a && setAttribute(_el$18, "data-major-event-category", _p$.a = _v$7);
+              _v$8 !== _p$.o && setAttribute(_el$18, "data-major-event-lifecycle", _p$.o = _v$8);
+              _v$9 !== _p$.i && setAttribute(_el$18, "data-major-event-severity", _p$.i = _v$9);
               return _p$;
             }, {
               e: void 0,
@@ -12578,20 +12736,24 @@ function WorldFeedPanel(props) {
               o: void 0,
               i: void 0
             });
-            return _el$16;
+            return _el$18;
           })()
         }));
-        return _el$14;
+        return _el$16;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$ = status(), _v$2 = statusBadgeClass(status());
+      var _v$ = status(), _v$2 = statusBadgeClass(status()), _v$3 = status(), _v$4 = statusBadgeClass(status());
       _v$ !== _p$.e && setAttribute(_el$, "data-world-feed-status", _p$.e = _v$);
-      _v$2 !== _p$.t && className(_el$8, _p$.t = _v$2);
+      _v$2 !== _p$.t && className(_el$6, _p$.t = _v$2);
+      _v$3 !== _p$.a && setAttribute(_el$6, "data-world-feed-summary-status", _p$.a = _v$3);
+      _v$4 !== _p$.o && className(_el$0, _p$.o = _v$4);
       return _p$;
     }, {
       e: void 0,
-      t: void 0
+      t: void 0,
+      a: void 0,
+      o: void 0
     });
     return _el$;
   })();

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -436,6 +436,24 @@ body {
   list-style: none;
 }
 
+.world-feed__summary-line {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.world-feed__summary-line .panel__title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.world-feed__summary-line .world-feed__status-badge {
+  flex: 0 0 auto;
+}
+
 .world-feed__summary::-webkit-details-marker {
   display: none;
 }
@@ -464,6 +482,39 @@ body {
   align-items: center;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.world-feed__status-badge::before,
+.pixel-world-readout__status::before {
+  display: inline-block;
+  margin-right: 5px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.world-feed__status-badge--ready::before,
+.pixel-world-readout__status--ready::before {
+  content: "•";
+}
+
+.world-feed__status-badge--replay::before,
+.pixel-world-readout__status--replay::before {
+  content: "↺";
+}
+
+.world-feed__status-badge--empty::before,
+.pixel-world-readout__status--empty::before {
+  content: "—";
+}
+
+.world-feed__status-badge--gap::before,
+.pixel-world-readout__status--gap::before {
+  content: "!";
+}
+
+.world-feed__status-badge--unavailable::before,
+.pixel-world-readout__status--unavailable::before {
+  content: "×";
 }
 
 .world-feed__notice,
@@ -774,6 +825,31 @@ body {
     max-height: min(62dvh, 520px);
   }
 
+  [data-viewer-overlay="feed"][open] {
+    position: fixed;
+    top: 160px;
+    bottom: 300px;
+    max-height: none;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .pixel-world-canvas__hotspot-tooltip {
+    top: 112px;
+    right: 10px;
+    width: min(420px, calc(100% - 20px));
+    max-width: calc(100% - 20px);
+  }
+
+  .pixel-world-host:has(+ [data-viewer-overlay="feed"]:not([open])) .pixel-world-canvas__selection {
+    top: 160px;
+  }
+
+  .stack:has(> [data-viewer-overlay="feed"]:not([open])) > [data-viewer-overlay="world-hud"] .pixel-world-canvas__selection {
+    top: 160px;
+  }
+
   [data-viewer-overlay="world-summary"]:has(#viewer-gameplay-details[open]) {
     inset: 82px 12px 72px;
     width: auto;
@@ -925,7 +1001,17 @@ body {
   }
 
   [data-viewer-overlay="world-hud"] .pixel-world-canvas__selection {
-    display: none;
+    display: flex;
+    top: 104px;
+    right: auto;
+    left: 10px;
+    width: fit-content;
+    max-width: calc(100vw - 20px);
+    max-height: 48px;
+    min-width: 0;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   [data-viewer-shell="player-fullscreen"] .pixel-world-readout {
@@ -937,6 +1023,20 @@ body {
     top: 104px;
   }
 
+  [data-viewer-overlay="feed"][open] {
+    top: 160px;
+    bottom: calc(144px + min(38dvh, 280px) + 8px);
+  }
+
+  .pixel-world-canvas__hotspot-tooltip {
+    top: auto;
+    right: 10px;
+    bottom: calc(144px + min(38dvh, 280px) + 8px);
+    left: 10px;
+    width: auto;
+    max-width: none;
+  }
+
   [data-viewer-overlay="next-move"] {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     width: calc(100vw - 20px);
@@ -945,6 +1045,28 @@ body {
     bottom: calc(96px + 48px);
     max-height: min(38dvh, 280px);
     overflow-y: auto;
+  }
+
+  .pixel-world-command-cell--next .pixel-world-command-cell__value {
+    display: block;
+    min-width: 0;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    -webkit-line-clamp: unset;
+  }
+
+  .pixel-world-command-cell--next .pixel-world-command-cell__detail {
+    display: block;
+    max-height: min(20dvh, 120px);
+    min-width: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overflow-wrap: anywhere;
+  }
+
+  .pixel-world-command-cell--next .pixel-world-command-cell__blocker-chip {
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   [data-viewer-overlay="next-move"] .pixel-world-command-cell--next {

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -313,6 +313,10 @@ body {
 
 .pixel-world-canvas__hotspot-tooltip {
   position: fixed;
+  padding: 5px 9px;
+  min-height: 56px;
+  max-height: var(--hotspot-tooltip-max-height, calc(100dvh - 20px));
+  overflow: hidden;
   z-index: 70;
   top: 52px;
   right: 10px;

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -1211,3 +1211,39 @@ body {
     display: none;
   }
 }
+
+/* On short landscape screens, the normal portrait-safe offsets leave no Feed
+ * viewport. Compress the secondary bands and keep an explicit scroll region
+ * between the top chrome and those bands. */
+@media (max-width: 1240px) and (max-height: 640px) {
+  [data-viewer-overlay="receipt"] {
+    max-height: min(12dvh, 48px);
+  }
+
+  [data-viewer-overlay="next-move"] {
+    bottom: calc(48px + 16px);
+    /* Keep a 64px Feed summary plus a 32px scroll body at 844x390 and
+     * 640x360; Next Move remains the largest band that fits that budget. */
+    height: min(42dvh, calc(100dvh - 72px - min(12dvh, 48px) - 16px - 8px - 96px));
+    max-height: none;
+    overflow-y: auto;
+  }
+
+  [data-viewer-overlay="next-move"] [data-shell-region="next-move-primary"],
+  [data-viewer-overlay="next-move"] [data-shell-region="supporting-context"] {
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  [data-viewer-overlay="feed"][open] .panel__eyebrow,
+  [data-viewer-overlay="feed"][open] .panel__meta-copy {
+    display: none;
+  }
+
+  [data-viewer-overlay="feed"][open] {
+    top: 72px;
+    bottom: calc(48px + 16px + min(42dvh, calc(100dvh - 72px - min(12dvh, 48px) - 16px - 8px - 96px)) + 8px);
+    max-height: calc(100dvh - 72px - 48px - 16px - min(42dvh, calc(100dvh - 72px - min(12dvh, 48px) - 16px - 8px - 96px)) - 8px);
+  }
+}

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -304,6 +304,22 @@ body {
   pointer-events: auto;
 }
 
+/* Hotspot explanations are portaled to document.body so the expanded Feed
+ * stacking context cannot cover the read-only inspection surface. */
+.pixel-world-hotspot:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.pixel-world-canvas__hotspot-tooltip {
+  position: fixed;
+  z-index: 70;
+  top: 52px;
+  right: 10px;
+  width: min(42vw, 320px);
+  max-width: calc(100vw - 20px);
+}
+
 [data-viewer-overlay="navigation"] {
   position: fixed;
   display: flex;
@@ -836,6 +852,7 @@ body {
   }
 
   .pixel-world-canvas__hotspot-tooltip {
+    position: fixed;
     top: 112px;
     right: 10px;
     width: min(420px, calc(100% - 20px));
@@ -1029,6 +1046,7 @@ body {
   }
 
   .pixel-world-canvas__hotspot-tooltip {
+    position: fixed;
     top: auto;
     right: 10px;
     bottom: calc(144px + min(38dvh, 280px) + 8px);

--- a/doc/world-simulator/viewer/viewer-pixel-world-player-readable-rendering.design.md
+++ b/doc/world-simulator/viewer/viewer-pixel-world-player-readable-rendering.design.md
@@ -100,6 +100,21 @@ JavaScript `Number`.
 | `gap`/reorg | warning state | reload cursor/snapshot; never splice unknown events |
 | `unavailable` | honest unavailable state | explain next recovery action |
 
+### Player visual feedback invariants (2026-09)
+
+- The mobile board keeps a wrapped `Selected` chip in the upper safe area so a
+  touch or keyboard selection remains tied to the visible entity.
+- The compact world readout uses `LIVE` only for a connected `ready` feed;
+  `REPLAY`, `NO EVENTS`, `GAP`, and `UNAVAILABLE` retain their own labels and
+  status marks. None of these ambient states is a player action receipt.
+- An expanded World Feed remains a bounded, scrollable context panel above the
+  Next Move and Action Receipt safe area at tablet and mobile widths.
+- Hotspots are read-only inspection controls. They expose their kind and label
+  to keyboard and touch users, keep a short explanation open until Escape or
+  an explicit close, and never submit or select a gameplay action.
+- Long Next Move, blocker, and recovery copy wraps within the mobile command
+  surface; secondary detail scrolls inside the reserved command area.
+
 Current Recent Events/Feedback retain their names; they are not silently renamed by
 the new projection. `#viewer-world-feed` is a source and generated-output anchor.
 Runtime currently emits `receipt_ref=null`; a receipt link is rendered only for an


### PR DESCRIPTION
Improve player visual feedback across mobile, tablet, and desktop: keep the selected object visible, distinguish live/replay/empty Feed states in the collapsed summary, reserve space for actions and receipts, make hotspots inspectable by touch and keyboard, and wrap long next-action text.

Add focused regressions and a headed browser fixture harness covering the five behaviors, including status-dependent Feed height, actual AppShell layout, hotspot inspection without gameplay submission, and narrow-screen overflow. Update the rendering design and regenerate the Viewer bundle.

Validation: focused component/layout regressions, frontend structure and feedback contracts, generated-output freshness, and external headed Chromium screenshots/interactions. Browser evidence uses deterministic bridge/feed fixtures and does not establish live WASM/WebGPU gameplay health. Final detailed QA and visual evidence is recorded in the task issue.

Refs #3622

Task: task_872ecd04e2824c02a685e1fd6df63d03
