### PR TITLE
fix: discover bundled Python on Unix hosts

### DIFF
--- a/scripts/pm/find-python-with-module.sh
+++ b/scripts/pm/find-python-with-module.sh
@@ -39,10 +39,15 @@ for generic_name in python python3; do
   fi
 done
 
-codex_runtime_python="$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/python.exe"
-if [[ -x "$codex_runtime_python" ]]; then
-  emit_if_supported "$codex_runtime_python"
-fi
+codex_runtime_root="$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/python"
+for codex_runtime_python in \
+  "$codex_runtime_root/python.exe" \
+  "$codex_runtime_root/bin/python3" \
+  "$codex_runtime_root/bin/python"; do
+  if [[ -x "$codex_runtime_python" ]]; then
+    emit_if_supported "$codex_runtime_python"
+  fi
+done
 
 while IFS= read -r path_dir; do
   [[ -n "$path_dir" ]] || path_dir="."

--- a/scripts/pm/find-python-with-module.test.sh
+++ b/scripts/pm/find-python-with-module.test.sh
@@ -7,6 +7,18 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
+write_forwarding_wrapper() {
+  local wrapper="$1"
+  local target="$2"
+  local quoted_target
+  printf -v quoted_target '%q' "$target"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'exec %s "$@"\n' "$quoted_target"
+  } >"$wrapper"
+  chmod +x "$wrapper"
+}
+
 if [[ -n "${OASIS7_TEST_PYTHON:-}" ]]; then
   REAL_PYTHON="$OASIS7_TEST_PYTHON"
 else
@@ -30,7 +42,7 @@ done
 for utility in bash tr dirname basename; do
   ln -s "$(command -v "$utility")" "$TMPDIR/broken-bin/$utility"
 done
-ln -s "$REAL_PYTHON" "$TMPDIR/working-bin/python42"
+write_forwarding_wrapper "$TMPDIR/working-bin/python42" "$REAL_PYTHON"
 generic_home="$TMPDIR/no-bundled-home"
 mkdir -p "$generic_home"
 
@@ -51,7 +63,7 @@ fi
 bundled_home="$TMPDIR/bundled-home"
 bundled_python_dir="$bundled_home/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin"
 mkdir -p "$bundled_python_dir"
-ln -s "$REAL_PYTHON" "$bundled_python_dir/python3"
+write_forwarding_wrapper "$bundled_python_dir/python3" "$REAL_PYTHON"
 bundled_selected="$(HOME="$bundled_home" PATH="$TMPDIR/broken-bin" \
   "$ROOT_DIR/scripts/pm/find-python-with-module.sh" ast)"
 if [[ "$bundled_selected" != "$bundled_python_dir/python3" ]]; then

--- a/scripts/pm/find-python-with-module.test.sh
+++ b/scripts/pm/find-python-with-module.test.sh
@@ -27,16 +27,35 @@ exit 0
 SH
   chmod +x "$TMPDIR/broken-bin/$name"
 done
+for utility in bash tr dirname basename; do
+  ln -s "$(command -v "$utility")" "$TMPDIR/broken-bin/$utility"
+done
 ln -s "$REAL_PYTHON" "$TMPDIR/working-bin/python42"
+generic_home="$TMPDIR/no-bundled-home"
+mkdir -p "$generic_home"
 
-selected="$(PATH="$TMPDIR/broken-bin:$TMPDIR/working-bin:$PATH" \
+selected="$(HOME="$generic_home" PATH="$TMPDIR/broken-bin:$TMPDIR/working-bin:$PATH" \
   "$ROOT_DIR/scripts/pm/find-python-with-module.sh" ast)"
-if [[ "$selected" == "$TMPDIR/broken-bin/"* ]]; then
-  echo "find-python-with-module.test: accepted a non-executing interpreter: $selected" >&2
+if [[ "$selected" != "$TMPDIR/working-bin/python42" ]]; then
+  echo "find-python-with-module.test: generic discovery did not select python42: $selected" >&2
   exit 1
 fi
 if ! "$selected" -c 'import ast; print("selected")' | grep -Fxq selected; then
   echo "find-python-with-module.test: selected interpreter cannot execute Python" >&2
+  exit 1
+fi
+
+# The Codex bundled runtime uses a Unix bin/python3 layout.  Isolate HOME and
+# PATH so this contract exercises the bundled candidate rather than a host
+# installation or the generic future-python shim above.
+bundled_home="$TMPDIR/bundled-home"
+bundled_python_dir="$bundled_home/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin"
+mkdir -p "$bundled_python_dir"
+ln -s "$REAL_PYTHON" "$bundled_python_dir/python3"
+bundled_selected="$(HOME="$bundled_home" PATH="$TMPDIR/broken-bin" \
+  "$ROOT_DIR/scripts/pm/find-python-with-module.sh" ast)"
+if [[ "$bundled_selected" != "$bundled_python_dir/python3" ]]; then
+  echo "find-python-with-module.test: did not select Unix bundled runtime: $bundled_selected" >&2
   exit 1
 fi
 

--- a/scripts/pm/find-python-with-module.test.sh
+++ b/scripts/pm/find-python-with-module.test.sh
@@ -19,6 +19,19 @@ write_forwarding_wrapper() {
   chmod +x "$wrapper"
 }
 
+write_helper_launcher() {
+  local wrapper="$1"
+  local target="$2"
+  local quoted_target
+  printf -v quoted_target '%q' "$target"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'command -v grep >/dev/null 2>&1 || exit 127'
+    printf 'exec %s "$@"\n' "$quoted_target"
+  } >"$wrapper"
+  chmod +x "$wrapper"
+}
+
 if [[ -n "${OASIS7_TEST_PYTHON:-}" ]]; then
   REAL_PYTHON="$OASIS7_TEST_PYTHON"
 else
@@ -27,6 +40,29 @@ fi
 
 if [[ ! -x "$REAL_PYTHON" ]] || ! "$REAL_PYTHON" -c 'import ast; print("ready")' | grep -Fxq ready; then
   echo "find-python-with-module.test: OASIS7_TEST_PYTHON or PATH discovery must provide a functional Python interpreter" >&2
+  exit 1
+fi
+
+# Keep a persistent regression for launchers that need helper commands while
+# PATH is unrestricted, then fail if the child test reuses that launcher after
+# its fixtures intentionally reduce PATH.  The guard permits one child run.
+if [[ -z "${OASIS7_TEST_HELPER_LAUNCHER:-}" ]]; then
+  helper_launcher="$TMPDIR/helper-python"
+  write_helper_launcher "$helper_launcher" "$REAL_PYTHON"
+  if ! OASIS7_TEST_PYTHON="$helper_launcher" \
+    OASIS7_TEST_HELPER_LAUNCHER=1 \
+    bash "$SCRIPT_DIR/find-python-with-module.test.sh"; then
+    echo "find-python-with-module.test: helper-dependent launcher regression failed" >&2
+    exit 1
+  fi
+fi
+
+# Resolve launchers (for example pyenv shims) before later fixtures reduce
+# PATH.  The resolved interpreter must not depend on helper commands supplied
+# by the launcher environment.
+REAL_PYTHON="$("$REAL_PYTHON" -c 'import sys; print(sys.executable)')"
+if [[ ! -x "$REAL_PYTHON" ]]; then
+  echo "find-python-with-module.test: launcher did not expose an executable sys.executable: $REAL_PYTHON" >&2
   exit 1
 fi
 

--- a/scripts/pm/validate-codex-agent-config.test.sh
+++ b/scripts/pm/validate-codex-agent-config.test.sh
@@ -20,7 +20,9 @@ SH
   chmod +x "$TMP_DIR/broken-python-bin/$name"
 done
 ln -s "$TOML_PYTHON" "$TMP_DIR/future-python-bin/python42"
-future_python="$(PATH="$TMP_DIR/broken-python-bin:$TMP_DIR/future-python-bin:/usr/bin:/bin" \
+generic_home="$TMP_DIR/no-bundled-home"
+mkdir -p "$generic_home"
+future_python="$(HOME="$generic_home" PATH="$TMP_DIR/broken-python-bin:$TMP_DIR/future-python-bin:/usr/bin:/bin" \
   "$ROOT_DIR/scripts/pm/find-python-with-module.sh" tomllib)"
 if [[ "$(basename "$future_python")" != "python42" ]]; then
   echo "validate-codex-agent-config.test: generic future Python discovery failed: $future_python" >&2
@@ -83,7 +85,7 @@ printf 'positive case passed: baseline\n'
 # repository's generic interpreter finder can discover a compatible runtime.
 # Hosts whose conventional Python already provides tomllib need not re-exec;
 # the controlled broken-python-bin above separately proves fallback discovery.
-if ! PATH="/usr/bin:/bin:$TMP_DIR/future-python-bin" \
+if ! HOME="$generic_home" PATH="/usr/bin:/bin:$TMP_DIR/future-python-bin" \
   "$ROOT_DIR/scripts/pm/validate-codex-agent-config.py" \
     --root "$fixture" --skip-native-probe >"$TMP_DIR/direct-entrypoint.out" \
     2>"$TMP_DIR/direct-entrypoint.err"; then


### PR DESCRIPTION
When a task shell omits the bundled Python directory from PATH, interpreter discovery now checks the Unix `bin/python3` and `bin/python` layouts as well as the existing Windows `python.exe` layout. This lets TOML-based configuration validation use the installed runtime without changing PATH discovery precedence.

Regression tests isolate HOME so host runtimes cannot intercept the intended fixture, and verify both Unix bundle discovery and future-version PATH discovery.

Validation: finder regression and full Codex configuration validation pass; the Unix bundle regression was observed failing before the fix.

Refs #3636
Task: task_63f4264cdb094ba7866709c3b2e0fe91
