### PR TITLE
Improve Bevy world rendering and viewer interaction clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -7326,7 +7326,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar_tests.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar_tests.rs
@@ -418,17 +418,21 @@ fn runtime_provider_continuation_recovery_fence_blocks_retained_context_after_re
         "fenced agent A must not append a Runtime lifecycle prefix: {dispatched_events:?}"
     );
 
-    let sibling_b_dispatched = (0..1_000).any(|_| {
+    let dispatch_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let sibling_b_dispatched = loop {
         let state = provider_states[1].lock().expect("provider B state lock");
         let dispatched = !state.recorded_requests.is_empty()
             && !state.recorded_turn_contexts.is_empty()
             && !state.recorded_request_contexts.is_empty();
         drop(state);
-        if !dispatched {
-            std::thread::yield_now();
+        if dispatched {
+            break true;
         }
-        dispatched
-    });
+        if std::time::Instant::now() >= dispatch_deadline {
+            break false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    };
     assert!(
         sibling_b_dispatched,
         "serviceable sibling B must dispatch one provider request"

--- a/crates/oasis7_viewer/scripts/pixel-world-completion-evidence.mjs
+++ b/crates/oasis7_viewer/scripts/pixel-world-completion-evidence.mjs
@@ -1,0 +1,81 @@
+import { join } from 'node:path';
+
+export async function completionEvidence({name,url,outDir,evalJson,browserJson,runBrowser,writeJson,assert}) {
+  await browserJson(['open',url]);
+  await evalJson('new Promise(r=>setTimeout(()=>r(true),700))');
+  const rectScript=`(() => { const target=document.querySelector('[data-renderer-target="true"][data-agent-id="agent-0"]');const r=target.getBoundingClientRect();return {x:r.left+r.width/2,y:r.top+r.height/2,width:r.width,height:r.height,camera:window.__AW_TEST__.getState().pixelWorldCamera};})()`;
+  const before=await evalJson(rectScript);
+  await runBrowser(['mouse','move',String(Math.round(before.x)),String(Math.round(before.y))]);
+  await runBrowser(['mouse','down']);
+  await runBrowser(['mouse','move',String(Math.round(before.x+30)),String(Math.round(before.y+10))]);
+  await runBrowser(['mouse','up']);
+  await evalJson('new Promise(r=>setTimeout(()=>r(true),150))');
+  const after=await evalJson(rectScript);
+  assert(after.camera.pan_x_px !== before.camera.pan_x_px,'target-origin drag did not reach renderer',{before,after});
+  await evalJson(`(() => {window.__AW_TEST__.select({kind:'agent',id:'agent-1'});return true;})()`);
+  const keyboardBefore=await evalJson(`window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().selection`);
+  await evalJson(`(() => {const t=document.querySelector('[data-renderer-target="true"][data-agent-id="agent-0"]');t.focus();return true;})()`);
+  const focused=await evalJson(`({id:document.activeElement.dataset.agentId,focusVisible:document.activeElement.matches(':focus-visible')})`);
+  await runBrowser(['press','Enter']);
+  const keyboard=await evalJson(`({selection:window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().selection,focused:document.activeElement.dataset.agentId})`);
+  assert(focused.id === 'agent-0' && keyboard.selection.id === 'agent-0','keyboard target activation lost identity',{focused,keyboard});
+  await evalJson(`(() => {window.__AW_TEST__.select({kind:'agent',id:'agent-1'});return true;})()`);
+  const touchBefore=await evalJson(`window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().selection`);
+  const endpointResult=await browserJson(['get','cdp-url']);
+  const endpoint=JSON.stringify(endpointResult).match(/ws:\/\/[^"\\\s]+/)?.[0];
+  assert(endpoint,'browser did not expose touch emulation transport',endpointResult);
+  const socket=new WebSocket(endpoint);
+  await new Promise((resolve,reject)=>{socket.addEventListener('open',resolve,{once:true});socket.addEventListener('error',reject,{once:true});});
+  let id=0;const requests=new Map();
+  socket.addEventListener('message',event=>{const message=JSON.parse(event.data);const request=requests.get(message.id);if(request){requests.delete(message.id);message.error?request.reject(new Error(JSON.stringify(message.error))):request.resolve(message.result);}});
+  const cdp=(method,params={},sessionId)=>new Promise((resolve,reject)=>{const next=++id;requests.set(next,{resolve,reject});socket.send(JSON.stringify({id:next,method,params,sessionId}));});
+  try {
+    const {targetInfos}=await cdp('Target.getTargets');
+    const target=targetInfos.find(target=>target.type==='page' && target.url.includes('pixel_world_visual_fixture='));
+    const {sessionId}=await cdp('Target.attachToTarget',{targetId:target.targetId,flatten:true});
+    await cdp('Emulation.setTouchEmulationEnabled',{enabled:true,maxTouchPoints:1},sessionId);
+    await evalJson(`(() => {window.__completionPointers=[];document.addEventListener('pointerdown',e=>window.__completionPointers.push({type:e.pointerType,id:e.pointerId}),{capture:true});return true;})()`);
+    const touchPoint=await evalJson(rectScript);
+    await cdp('Input.dispatchTouchEvent',{type:'touchStart',touchPoints:[{x:touchPoint.x,y:touchPoint.y}]},sessionId);
+    await cdp('Input.dispatchTouchEvent',{type:'touchEnd',touchPoints:[]},sessionId);
+  } finally {socket.close();}
+  const touch=await evalJson(`({pointers:window.__completionPointers,selection:window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().selection})`);
+  assert(touch.pointers.some(pointer=>pointer.type==='touch') && touch.selection.id==='agent-0','touch activation did not reach selected entity',touch);
+  await runBrowser(['screenshot','--full',join(outDir,`${name}-completion-input.png`)]);
+  const feedStates=[];
+  for (const [status,seq] of [['ready',1],['ready',2],['replay',2],['gap',2],['unavailable',2]]) {
+    const feed={schema_version:'world_feed/v1',world_id:'completion-world',reorg_epoch:0,cursor:null,status,events:status==='gap'||status==='unavailable'?[]:[{event_seq:seq,kind:'resource_change',summary:`Published resource event ${seq}`,detail:'fixture journal entry',receipt_ref:null}],gap_reason:status==='gap'?'cursor_gap':null,unavailable_reason:status==='unavailable'?'source_unavailable':null,snapshot_reload_required:false};
+    const consumed=await evalJson(`window.__AW_TEST__.injectWorldFeedForTest(${JSON.stringify(feed)})`);
+    await evalJson('new Promise(r=>setTimeout(()=>r(true),150))');
+    const observed={feed:consumed,...await evalJson(`({text:document.querySelector('[data-viewer-overlay="feed"]').textContent})`)};
+    assert(observed.feed.status===status,'feed consumer status differs from published fixture',{status,observed});
+    await runBrowser(['screenshot','--full',join(outDir,`${name}-feed-${status}-${seq}.png`)]);
+    feedStates.push({status,seq,observed});
+  }
+  const result={before,after,focused,keyboardBefore,keyboard,touchBefore,touch,feedStates};
+  const pending=await evalJson(`(async()=>{
+    const snapshot=window.__OASIS7_PIXEL_WORLD_VISUAL_FIXTURES__.selected_blocker();
+    snapshot.model.agents={};
+    snapshot.player_gameplay={stage_id:'awaiting_agent_claim',stage_status:'ready',execution_state:'waiting_for_intent',available_actions:[{action_id:'claim_first_agent',label:'Claim First Agent',protocol_action:'gameplay_action.submit',target_agent_id:'agent-0',disabled_reason:null}],recent_feedback:null};
+    window.__AW_TEST__.injectSnapshot(snapshot);
+    await new Promise(r=>setTimeout(r,200));
+    const button=document.querySelector('[data-primary-action="true"]');button.focus();
+    button.click();
+    const next=document.querySelector('[data-primary-action="true"]');
+    return {feedback:window.__AW_TEST__.getState().lastGameplayActionFeedback,sameNode:button===next,focused:document.activeElement===next,busy:next.getAttribute('aria-busy'),text:next.textContent,receipt:document.querySelector('[data-viewer-overlay="receipt"]')?.textContent,render:window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().commercial_surface};
+  })()`);
+  assert(pending.sameNode && pending.focused && pending.busy==='true','pending transition lost in-place action',pending);
+  pending.detailsLayout=await evalJson(`(()=>{const panel=document.querySelector('[data-viewer-overlay="world-summary"]');const summary=panel.querySelector('summary');const r=summary.getBoundingClientRect();return {background:getComputedStyle(panel).backgroundColor,top:r.top,bottom:r.bottom,visible:panel.contains(document.elementFromPoint(r.left+20,r.top+20)),scrollable:getComputedStyle(panel).overflowY};})()`);
+  assert(pending.detailsLayout.visible && pending.detailsLayout.background==='rgb(20, 29, 25)','details introduction is obscured',pending.detailsLayout);
+  await runBrowser(['screenshot','--full',join(outDir,`${name}-pending-action.png`)]);
+  result.pending=pending;
+  await browserJson(['open',`${url}&pixel_world_renderer=defer`]);
+  await evalJson('new Promise(r=>setTimeout(()=>r(true),700))');
+  result.fallback=await evalJson(`({status:window.__AW_TEST__.getState().pixelWorldRuntimeStatus,source:window.__AW_TEST__.getState().pixelWorldRuntimeSource,text:document.body.textContent})`);
+  assert(result.fallback.status==='unavailable','explicit deferred renderer did not expose fallback',result.fallback);
+  result.fallback.layout=await evalJson(`(()=>{const card=document.querySelector('[data-viewer-overlay="renderer-unavailable"]');const button=card.querySelector('button');const r=button.getBoundingClientRect();const feed=document.querySelector('[data-viewer-overlay="feed"]').getBoundingClientRect();return {card:card.getBoundingClientRect().toJSON(),feed:feed.toJSON(),retry:r.toJSON(),retryVisible:button.contains(document.elementFromPoint(r.left+r.width/2,r.top+r.height/2))};})()`);
+  assert(result.fallback.layout.retryVisible && result.fallback.layout.retry.height>=44,'renderer recovery action is obscured',result.fallback.layout);
+  await runBrowser(['screenshot','--full',join(outDir,`${name}-renderer-unavailable.png`)]);
+  writeJson(`${name}-completion-evidence.json`,result);
+  return result;
+}

--- a/crates/oasis7_viewer/scripts/pixel-world-hotspot-visual-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/pixel-world-hotspot-visual-smoke.mjs
@@ -4,6 +4,7 @@ import { dirname, extname, join, normalize, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { completionEvidence } from './pixel-world-completion-evidence.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const viewerRoot = resolve(scriptDir, "..");
@@ -12,7 +13,10 @@ const runId = new Date().toISOString().replace(/[:.]/g, "-");
 const outDir = resolve(repoRoot, "output/playwright/pixel-world-hotspot-visual", runId);
 const agentBrowserBin = process.env.AGENT_BROWSER_BIN || "agent-browser";
 const session = `pixel-world-hotspot-visual-${process.pid}`;
-const summary = { status: "running", fixtureName: "recent_event_glyphs", startedAt: new Date().toISOString(), viewports: {} };
+const routeMotionEvidence = process.argv.includes('--routes-and-motion');
+const completionRun = process.argv.includes('--completion');
+const fixtureName = routeMotionEvidence ? 'routes_and_events' : 'recent_event_glyphs';
+const summary = { status: "running", fixtureName, startedAt: new Date().toISOString(), viewports: {} };
 mkdirSync(outDir, { recursive: true });
 
 function fail(message, details) { throw new Error(`${message}${details ? `\n${JSON.stringify(details, null, 2)}` : ""}`); }
@@ -73,13 +77,18 @@ const server = createServer(serveFile);
 try {
   await new Promise((resolveServer) => server.listen(0, "127.0.0.1", resolveServer));
   const address = server.address();
-  const url = `http://127.0.0.1:${address.port}/viewer.html?test_api=1&connect=0&locale=en&pixel_world_visual_fixture=recent_event_glyphs`;
+  const url = `http://127.0.0.1:${address.port}/viewer.html?test_api=1&connect=0&locale=en&pixel_world_visual_fixture=${fixtureName}`;
   summary.url = url; closeBrowser(); await browserJson(["open", url], { timeout: 45_000 });
-  for (const [name, width, height] of [["desktop", 1440, 900], ["narrow", 390, 844]]) {
+  for (const [name, width, height] of [["desktop", 1440, 1000], ["narrow", 390, 844], ...((completionRun || routeMotionEvidence) ? [['compact',320,568]] : [])]) {
     await browserJson(["set", "viewport", String(width), String(height)]);
     if (name !== 'desktop') await browserJson(['open',url]);
-    const state = await evalJson(String.raw`(async()=>{const read=()=>(${pageStateScript()}); const deadline=Date.now()+15000; while(Date.now()<deadline){const s=read(); if(s.rendererReady && s.runtimeStatus==='ready') return JSON.stringify(s); await new Promise(r=>setTimeout(r,100));} throw new Error('renderer not ready');})()`);
-    assert(state.fixture === "recent_event_glyphs" && state.rendererReady && state.runtimeStatus === "ready" && !state.fatal, "fixture renderer did not become ready", state);
+    let state = await evalJson(String.raw`(async()=>{const read=()=>(${pageStateScript()}); const deadline=Date.now()+15000; while(Date.now()<deadline){const s=read(); if(s.rendererReady && s.runtimeStatus==='ready') return JSON.stringify(s); await new Promise(r=>setTimeout(r,100));} throw new Error('renderer not ready');})()`);
+    if (routeMotionEvidence || name === 'compact') {
+      await evalJson(`(async()=>{for(let n=0;n<${name === 'compact' && routeMotionEvidence ? 3 : 1};n++){document.querySelector('#pixel-world-embedded-runtime-canvas').dispatchEvent(new WheelEvent('wheel',{deltaY:300,bubbles:true,cancelable:true}));await new Promise(r=>setTimeout(r,80));}await new Promise(r=>setTimeout(r,250));return true;})()`);
+      state=await evalJson(pageStateScript());
+    }
+    assert(state.fixture === fixtureName && state.rendererReady && state.runtimeStatus === "ready" && !state.fatal, "fixture renderer did not become ready", state);
+    if (routeMotionEvidence) assert(state.renderDto.links.length === 2 && state.renderDto.links.every(link => link.kind === 'agent_assignment' && link.from && link.to && link.source_class === 'runtime_projection'), 'published assignment links missing from real Rust DTO',state.renderDto.links);
     assert(state.renderDto?.agents?.some((agent) => agent.id === "agent-0"), "fixture Render DTO omits agent-0", state.renderDto);
     assert(state.renderDto?.receipt_target?.agent_id === "agent-0" && state.renderDto?.receipt_target?.state === "blocked", "fixture Render DTO omits the blocked agent-0 receipt target", state.renderDto);
     const glyphKinds = Object.fromEntries((state.renderDto?.visual_hotspots || []).map((hotspot) => [hotspot.id, hotspot.kind]));
@@ -121,9 +130,9 @@ try {
     const initialProjection = await evalJson(selectionGeometryScript());
     await evalJson(`(() => { document.querySelector('#pixel-world-embedded-runtime-canvas').dispatchEvent(new WheelEvent('wheel', {deltaY:-100,bubbles:true,cancelable:true})); return true; })()`);
     const zoomProjection = await evalJson(selectionGeometryScript());
-    await runBrowser(['mouse','move',String(width > 640 ? 850 : 100),'400']);
+    await runBrowser(['mouse','move',String(width > 640 ? 850 : 100),String(width === 320 ? 240 : 400)]);
     await runBrowser(['mouse','down']);
-    await runBrowser(['mouse','move',String(width > 640 ? 890 : 140),'420']);
+    await runBrowser(['mouse','move',String(width > 640 ? 890 : 140),String(width === 320 ? 260 : 420)]);
     await runBrowser(['mouse','up']);
     const panProjection = await evalJson(selectionGeometryScript());
     for (const projection of [initialProjection,zoomProjection,panProjection]) assert(projection.count === 1 && projection.width >= 44 && projection.height >= 44 && projection.error < 1.1, 'renderer selection projection diverged', projection);
@@ -131,6 +140,62 @@ try {
     assert(panProjection.camera.pan_x_px !== zoomProjection.camera.pan_x_px, 'drag did not change renderer camera', {zoomProjection,panProjection});
     const projectionPath = writeJson(`${name}-selection-projection.json`, {initialProjection,zoomProjection,panProjection});
     summary.viewports[name].projectionPath = projectionPath;
+    if (routeMotionEvidence) {
+      // Reload before the animation comparison so pan/hover do not contaminate
+      // the frame comparison. Media emulation is observed from matchMedia.
+      await browserJson(['set','media','dark']);
+      await browserJson(['open',url]);
+      await evalJson(`new Promise(resolve => setTimeout(() => resolve(true),600))`);
+      await evalJson(`(async()=>{for(let n=0;n<${name === 'compact' && routeMotionEvidence ? 3 : 1};n++){document.querySelector('#pixel-world-embedded-runtime-canvas').dispatchEvent(new WheelEvent('wheel',{deltaY:300,bubbles:true,cancelable:true}));await new Promise(r=>setTimeout(r,80));}await new Promise(r=>setTimeout(r,250));return true;})()`);
+      const mediaBefore = await evalJson(`matchMedia('(prefers-reduced-motion: reduce)').matches`);
+      assert(mediaBefore === false,'normal-motion media preference not observed',mediaBefore);
+      const motionTargets = await evalJson(targetsScript());
+      const motionCanvas = await evalJson(bringCanvasIntoViewScript());
+      const frameFiles = {};
+      for (const mode of ['normal','reduced']) {
+        if (mode === 'reduced') await browserJson(['set','media','dark','reduced-motion']);
+        await evalJson(`new Promise(resolve => setTimeout(() => resolve(true),300))`);
+        for (const frame of [0,1]) {
+          const path=join(outDir,`${name}-${mode}-frame-${frame}.png`);
+          await runBrowser(['screenshot','--full',path]);
+          frameFiles[`${mode}${frame}`]=path;
+          await evalJson(`new Promise(resolve => setTimeout(() => resolve(true),350))`);
+        }
+      }
+      const mediaAfter=await evalJson(`matchMedia('(prefers-reduced-motion: reduce)').matches`);
+      assert(mediaAfter === true,'reduced-motion media preference not observed',mediaAfter);
+      const reducedInput=await evalJson(receiptScript('hover','recent:resource-transfer-fixture'));
+      assert(reducedInput.receipt.visible,'reduced preference froze input',reducedInput);
+      await evalJson(receiptScript('leave'));
+      const reducedSnapshot=await evalJson(`(async()=>{const before=window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().world_tick;const snapshot=window.__OASIS7_PIXEL_WORLD_VISUAL_FIXTURES__.routes_and_events();snapshot.time=13;window.__AW_TEST__.injectSnapshot(snapshot);window.__OASIS7_PIXEL_WORLD_VISUAL_FIXTURE_AUTH_ALIGNMENT__();await new Promise(r=>setTimeout(r,200));return {before,after:window.__OASIS7_PIXEL_WORLD_RENDER_DTO__().world_tick,reduced:matchMedia('(prefers-reduced-motion: reduce)').matches};})()`);
+      assert(reducedSnapshot.reduced && reducedSnapshot.after===13,'reduced preference froze snapshot updates',reducedSnapshot);
+      await browserJson(['set','media','dark']);
+      const mediaRestored=await evalJson(`matchMedia('(prefers-reduced-motion: reduce)').matches`);
+      assert(mediaRestored === false,'normal preference did not restore live',mediaRestored);
+      for (const frame of [0,1,2]) {
+        const path=join(outDir,`${name}-restored-frame-${frame}.png`);
+        await runBrowser(['screenshot','--full',path]);
+        frameFiles[`restored${frame}`]=path;
+        await evalJson(`new Promise(resolve=>setTimeout(()=>resolve(true),350))`);
+      }
+      const glyphDiffs={};
+      for (const id of ['recent:resource-transfer-fixture','recent:build-queue-fixture']) {
+        const hit=motionTargets.find(hit=>hit.id===id);
+        const center={x:motionCanvas.canvas.left+hit.canvas_x,y:motionCanvas.canvas.top+hit.canvas_y};
+        const files={};
+        for (const [key,path] of Object.entries(frameFiles)) {
+          files[key]=join(outDir,`${name}-${key}-${id.split(':')[1]}.png`);
+          cropGlyph(path,files[key],center);
+        }
+        glyphDiffs[id]={normal:screenshotDifference(files.normal0,files.normal1),reduced:screenshotDifference(files.reduced0,files.reduced1),restored:[screenshotDifference(files.restored0,files.restored1),screenshotDifference(files.restored0,files.restored2)].sort((a,b)=>b.changedPixelRatio-a.changedPixelRatio)[0]};
+        assert(glyphDiffs[id].reduced.changedPixelRatio === 0,'reduced-motion event pixels continue animating',glyphDiffs[id]);
+        assert(glyphDiffs[id].restored.changedPixelRatio > 0,'normal event motion did not resume',glyphDiffs[id]);
+      }
+      const motionPath=writeJson(`${name}-motion-evidence.json`,{mediaBefore,mediaAfter,mediaRestored,reducedInput,reducedSnapshot,frameFiles,glyphDiffs,routeCount:state.renderDto.links.length,links:state.renderDto.links});
+      summary.viewports[name].motionPath=motionPath;
+      await browserJson(['set','media','dark']);
+    }
+    if (completionRun) summary.viewports[name].completion=await completionEvidence({name,url:url.replace("routes_and_events","recent_event_glyphs"),outDir,evalJson,browserJson,runBrowser,writeJson,assert});
   }
   summary.status = "passed"; summary.completedAt = new Date().toISOString(); writeJson("summary.json", summary); console.log(`pixel-world hotspot visual smoke passed: ${join(outDir, "summary.json")}`);
 } catch (error) { summary.status = "failed"; summary.completedAt = new Date().toISOString(); summary.failure = { message: error instanceof Error ? error.message : String(error) }; writeJson("summary.json", summary); console.error(`pixel-world hotspot visual smoke failed: ${join(outDir, "summary.json")}`); throw error; }

--- a/crates/oasis7_viewer/scripts/pixel-world-hotspot-visual-smoke.mjs
+++ b/crates/oasis7_viewer/scripts/pixel-world-hotspot-visual-smoke.mjs
@@ -49,6 +49,24 @@ function pageStateScript() { return String.raw`(() => { const canvas = document.
 function bringCanvasIntoViewScript() { return String.raw`(async () => { const canvas = document.querySelector('#pixel-world-embedded-runtime-canvas'); const host = document.querySelector('.pixel-world-host'); if (!canvas || !host) throw new Error('canvas host unavailable'); canvas.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' }); await new Promise((resolve) => requestAnimationFrame(() => resolve())); const rect = canvas.getBoundingClientRect(); return JSON.stringify({ scrollY: window.scrollY, viewport: { width: window.innerWidth, height: window.innerHeight }, canvas: { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom, width: rect.width, height: rect.height } }); })()`; }
 function receiptScript(method, id) { return String.raw`(async () => { const probe = window.__OASIS7_PIXEL_WORLD_HOTSPOT_POINTER_PROBE__; if (!probe) throw new Error('test-only hotspot pointer probe unavailable'); const receipt = await probe.${method}(${id ? JSON.stringify(id) : ""}); const tooltip = document.querySelector('[data-hotspot-tooltip]'); const viewport = { width: window.innerWidth, height: window.innerHeight }; const rect = tooltip?.getBoundingClientRect(); return JSON.stringify({ receipt, viewport, tooltip: tooltip ? { text: tooltip.textContent.trim(), visible: getComputedStyle(tooltip).display !== 'none', rect: { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom, width: rect.width, height: rect.height } } : null }); })()`; }
 function targetsScript() { return String.raw`(() => { const probe = window.__OASIS7_PIXEL_WORLD_HOTSPOT_POINTER_PROBE__; if (!probe) throw new Error('test-only hotspot pointer probe unavailable'); return JSON.stringify(probe.targets()); })()`; }
+function selectionGeometryScript() { return String.raw`(async () => {
+  await new Promise(resolve => setTimeout(resolve, 150));
+  const canvas = document.querySelector('#pixel-world-embedded-runtime-canvas');
+  const rect = canvas.getBoundingClientRect();
+  const state = window.__AW_TEST__.getState();
+  const camera = state.pixelWorldCamera;
+  const dto = window.__OASIS7_PIXEL_WORLD_RENDER_DTO__();
+  const agent = dto.agents.find(agent => agent.id === 'agent-0');
+  const targets = [...document.querySelectorAll('[data-renderer-target="true"][data-agent-id="agent-0"]')];
+  const target = targets[0].getBoundingClientRect();
+  const bounds = dto.world_bounds;
+  const expected = {
+    x: rect.left + rect.width / 2 + (20 + agent.pos.x_cm / bounds.width_cm * (rect.width - 40) - rect.width / 2) * camera.zoom + camera.pan_x_px,
+    y: rect.top + rect.height / 2 + (20 + agent.pos.y_cm / bounds.depth_cm * (rect.height - 40) - rect.height / 2) * camera.zoom + camera.pan_y_px,
+  };
+  const actual = { x: target.left + target.width / 2, y: target.top + target.height / 2 };
+  return JSON.stringify({ camera, expected, actual, count: targets.length, width: target.width, height: target.height, error: Math.hypot(expected.x-actual.x,expected.y-actual.y), selection: dto.selection });
+})()`; }
 
 ensureBrowser();
 const server = createServer(serveFile);
@@ -59,6 +77,7 @@ try {
   summary.url = url; closeBrowser(); await browserJson(["open", url], { timeout: 45_000 });
   for (const [name, width, height] of [["desktop", 1440, 900], ["narrow", 390, 844]]) {
     await browserJson(["set", "viewport", String(width), String(height)]);
+    if (name !== 'desktop') await browserJson(['open',url]);
     const state = await evalJson(String.raw`(async()=>{const read=()=>(${pageStateScript()}); const deadline=Date.now()+15000; while(Date.now()<deadline){const s=read(); if(s.rendererReady && s.runtimeStatus==='ready') return JSON.stringify(s); await new Promise(r=>setTimeout(r,100));} throw new Error('renderer not ready');})()`);
     assert(state.fixture === "recent_event_glyphs" && state.rendererReady && state.runtimeStatus === "ready" && !state.fatal, "fixture renderer did not become ready", state);
     assert(state.renderDto?.agents?.some((agent) => agent.id === "agent-0"), "fixture Render DTO omits agent-0", state.renderDto);
@@ -73,16 +92,23 @@ try {
     const targets = await evalJson(targetsScript());
     const glyphTargets = Object.fromEntries(targets.filter((target) => ["recent:resource-transfer-fixture", "recent:build-queue-fixture"].includes(target.id)).map((target) => [target.id, target]));
     assert(glyphTargets["recent:resource-transfer-fixture"] && glyphTargets["recent:build-queue-fixture"], "real WASM hit-target readback omits one glyph", { targets });
+    const decisionClearance = await evalJson(`(() => { const panel=document.querySelector('.pixel-world-decision-area'); const r=panel.getBoundingClientRect(); return {left:r.left,top:r.top,right:r.right,bottom:r.bottom,height:r.height,scrollHeight:panel.scrollHeight,overflowY:getComputedStyle(panel).overflowY}; })()`);
+    for (const target of Object.values(glyphTargets)) {
+      const x=canvasViewport.canvas.left + Number(target.canvas_x), y=canvasViewport.canvas.top + Number(target.canvas_y);
+      assert(x+22 <= decisionClearance.left || x-22 >= decisionClearance.right || y+22+7 <= decisionClearance.top, 'decision panel obscures event glyph', {target,decisionClearance});
+    }
+    assert(decisionClearance.height >= 160 && decisionClearance.overflowY === 'auto', 'decision controls lost scroll access', decisionClearance);
+    writeJson(`${name}-decision-clearance.json`,decisionClearance);
     const unhoveredPng = join(outDir, `${name}-unhovered-full.png`); await runBrowser(["screenshot", "--full", unhoveredPng]);
     const toFullPageCenter = (target) => ({ x: canvasViewport.canvas.left + Number(target.canvas_x), y: canvasViewport.scrollY + canvasViewport.canvas.top + Number(target.canvas_y) });
     const transferCrop = cropGlyph(unhoveredPng, join(outDir, `${name}-resource-transfer-glyph.png`), toFullPageCenter(glyphTargets["recent:resource-transfer-fixture"]));
     const buildQueueCrop = cropGlyph(unhoveredPng, join(outDir, `${name}-build-queue-glyph.png`), toFullPageCenter(glyphTargets["recent:build-queue-fixture"]));
     const transfer = await evalJson(receiptScript("hover", "recent:resource-transfer-fixture"));
-    assert(transfer.receipt.dispatched && transfer.receipt.visible && transfer.tooltip?.visible && transfer.tooltip.text === "Resource transfer completed", "resource transfer pointermove did not produce its authoritative tooltip", transfer);
+    assert(transfer.receipt.dispatched && transfer.receipt.visible && transfer.tooltip?.visible && transfer.tooltip.text.includes("Resource transfer completed"), "resource transfer pointermove did not produce its authoritative tooltip", transfer);
     assert(transfer.tooltip.rect.left >= 0 && transfer.tooltip.rect.top >= 0 && transfer.tooltip.rect.right <= transfer.viewport.width && transfer.tooltip.rect.bottom <= transfer.viewport.height, "resource transfer tooltip is not fully inside the screenshot viewport", transfer);
     const transferPng = join(outDir, `${name}-resource-transfer-full.png`); await runBrowser(["screenshot", "--full", transferPng]); const transferStats = screenshotStats(transferPng); assert(transferStats.nonBlackRatio > 0.01 && transferStats.meanBrightness > 3, "resource transfer screenshot is black", transferStats);
     const buildQueue = await evalJson(receiptScript("hover", "recent:build-queue-fixture"));
-    assert(buildQueue.receipt.dispatched && buildQueue.receipt.visible && buildQueue.tooltip?.visible && buildQueue.tooltip.text === "Build queue updated", "build queue pointermove did not produce its authoritative tooltip", buildQueue);
+    assert(buildQueue.receipt.dispatched && buildQueue.receipt.visible && buildQueue.tooltip?.visible && buildQueue.tooltip.text.includes("Build queue updated"), "build queue pointermove did not produce its authoritative tooltip", buildQueue);
     const buildQueuePng = join(outDir, `${name}-build-queue-full.png`); await runBrowser(["screenshot", "--full", buildQueuePng]); const buildQueueStats = screenshotStats(buildQueuePng); assert(buildQueueStats.nonBlackRatio > 0.01 && buildQueueStats.meanBrightness > 3, "build queue screenshot is black", buildQueueStats);
     const cleared = await evalJson(receiptScript("leave"));
     assert(cleared.receipt.dispatched && cleared.receipt.cleared && cleared.tooltip === null, "canvas pointerleave did not clear tooltip", cleared);
@@ -92,6 +118,19 @@ try {
     assert(!/\b(?:fatal|CONTEXT_LOST_WEBGL|webgl.*error)\b/i.test(consoleOutput), "browser console reports WebGL fatal", { consolePath, consoleOutput });
     const pointerPath = writeJson(`${name}-pointer-receipt.json`, { resourceTransfer: transfer.receipt, buildQueue: buildQueue.receipt, cleared: cleared.receipt });
     summary.viewports[name] = { width, height, statePath, envPath, stateDigest, canvasViewport, pointerPath, consolePath, unhoveredPng, transferPng, buildQueuePng, clearedPng, transferCrop, buildQueueCrop, transferStats, buildQueueStats, clearedStats, screenshotDiff };
+    const initialProjection = await evalJson(selectionGeometryScript());
+    await evalJson(`(() => { document.querySelector('#pixel-world-embedded-runtime-canvas').dispatchEvent(new WheelEvent('wheel', {deltaY:-100,bubbles:true,cancelable:true})); return true; })()`);
+    const zoomProjection = await evalJson(selectionGeometryScript());
+    await runBrowser(['mouse','move',String(width > 640 ? 850 : 100),'400']);
+    await runBrowser(['mouse','down']);
+    await runBrowser(['mouse','move',String(width > 640 ? 890 : 140),'420']);
+    await runBrowser(['mouse','up']);
+    const panProjection = await evalJson(selectionGeometryScript());
+    for (const projection of [initialProjection,zoomProjection,panProjection]) assert(projection.count === 1 && projection.width >= 44 && projection.height >= 44 && projection.error < 1.1, 'renderer selection projection diverged', projection);
+    assert(zoomProjection.camera.zoom !== initialProjection.camera.zoom, 'wheel did not change renderer camera', {initialProjection,zoomProjection});
+    assert(panProjection.camera.pan_x_px !== zoomProjection.camera.pan_x_px, 'drag did not change renderer camera', {zoomProjection,panProjection});
+    const projectionPath = writeJson(`${name}-selection-projection.json`, {initialProjection,zoomProjection,panProjection});
+    summary.viewports[name].projectionPath = projectionPath;
   }
   summary.status = "passed"; summary.completedAt = new Date().toISOString(); writeJson("summary.json", summary); console.log(`pixel-world hotspot visual smoke passed: ${join(outDir, "summary.json")}`);
 } catch (error) { summary.status = "failed"; summary.completedAt = new Date().toISOString(); summary.failure = { message: error instanceof Error ? error.message : String(error) }; writeJson("summary.json", summary); console.error(`pixel-world hotspot visual smoke failed: ${join(outDir, "summary.json")}`); throw error; }

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -337,10 +337,11 @@ describe("fullscreen map shell contract", () => {
     const { terminalShellCss } = await readViewerHtml();
     const mobileBlock = terminalShellCss.match(/@media\s*\(max-width:\s*640px\)[\s\S]*$/i)?.[0] || "";
     const entryTop = Number(mobileBlock.match(/\[data-viewer-overlay=["']cinematic-entry["']\][^{]*\{[^}]*top:\s*(\d+)px/i)?.[1]);
-    const readoutTop = Number(mobileBlock.match(/\[data-viewer-shell=["']player-fullscreen["']\] \.pixel-world-readout[^{}]*\{[^}]*top:\s*(\d+)px/i)?.[1]);
+    const readoutRule = findRule(mobileBlock, /\[data-viewer-shell=["']player-fullscreen["']\]\s+\.pixel-world-readout/);
+    const readoutTop = Number(readoutRule?.declarations.match(/top\s*:\s*(\d+)px/i)?.[1]);
     expect(Number.isFinite(entryTop)).toBe(true);
-    expect(Number.isFinite(readoutTop)).toBe(true);
-    expect(readoutTop).toBeGreaterThanOrEqual(entryTop + 44);
+    expect(Number.isFinite(readoutTop) || hasDeclaration(readoutRule, "position", /static/)).toBe(true);
+    if (Number.isFinite(readoutTop)) expect(readoutTop).toBeGreaterThanOrEqual(entryTop + 44);
   });
 
   it("does not leave the low-priority mobile readout under the Feed overlay", async () => {
@@ -355,6 +356,7 @@ describe("fullscreen map shell contract", () => {
     expect(feedRule, "mobile Feed must have an explicit safe-area policy").not.toBeNull();
 
     const readoutIsHidden = hasDeclaration(readoutRule, "display", /none/);
+    const readoutIsStatic = hasDeclaration(readoutRule, "position", /static/);
     const readoutTop = Number(readoutRule?.declarations.match(/top\s*:\s*(\d+)px/i)?.[1]);
     const feedTop = Number(feedRule?.declarations.match(/top\s*:\s*(\d+)px/i)?.[1]);
     const bandsAreSeparated = Number.isFinite(readoutTop)
@@ -362,7 +364,7 @@ describe("fullscreen map shell contract", () => {
       && feedTop >= readoutTop + 44;
 
     expect(
-      readoutIsHidden || bandsAreSeparated,
+      readoutIsHidden || readoutIsStatic || bandsAreSeparated,
       "mobile Feed and the low-priority world readout must be hidden or occupy disjoint vertical bands",
     ).toBe(true);
   });
@@ -373,6 +375,28 @@ describe("fullscreen map shell contract", () => {
     const safeAreaSource = await readFile("software_safe_src/pixel_world_mobile_safe_area.js", "utf8");
     expect(safeAreaSource).toContain("commandTop - SAFE_AREA_GAP_PX - markerBottom");
     expect(safeAreaSource).toContain("feedBottom + SAFE_AREA_GAP_PX - markerTop");
+  });
+
+  it("keeps mobile selection, Feed, legend, and status surfaces in distinct presentation bands", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    const mobileBlock = terminalShellCss.match(/@media\s*\(max-width:\s*640px\)[\s\S]*$/i)?.[0] || "";
+    expect(mobileBlock).toMatch(
+      /\[data-viewer-overlay=["']world-hud["']\]\s+\.pixel-world-canvas__selection\s*\{[^}]*top:\s*264px/i,
+    );
+    expect(mobileBlock).toMatch(
+      /\.pixel-world-decision-area\s+\.pixel-world-canvas__legend\s*\{[^}]*margin:\s*0\s+0\s+0\s+auto/i,
+    );
+    expect(mobileBlock).toMatch(
+      /\[data-viewer-shell=["']player-fullscreen["']\]\s+\.pixel-world-readout\s*\{[^}]*position:\s*static[^}]*display:\s*flex/i,
+    );
+    expect(terminalShellCss).toMatch(/\.pixel-world-canvas__sparse-guidance\s*\{/i);
+  });
+
+  it("uses severity width and lifecycle line styles as truthful crisis shape cues", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(/\.world-feed__event--severity-4\s*\{[^}]*border-left-color/i);
+    expect(terminalShellCss).toMatch(/\.world-feed__event--lifecycle-resolved\s*\{[^}]*border-left-style:\s*dashed/i);
+    expect(terminalShellCss).toMatch(/\.world-feed__event--lifecycle-timed_out\s*\{[^}]*border-left-style:\s*dotted/i);
   });
 
   it("keeps the narrow Command context row sticky while the route panel scrolls independently", async () => {

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -474,8 +474,8 @@ describe("fullscreen map shell contract", () => {
     const { terminalShellCss } = await readViewerHtml();
     const mobileBlock = terminalShellCss.match(/@media\s*\(max-width:\s*640px\)[\s\S]*$/i)?.[0] || "";
     expect(mobileBlock).toMatch(/\[data-viewer-overlay=["']feed["']\][^{]*\{[^}]*top:\s*104px/i);
-    expect(mobileBlock).toMatch(/\[data-viewer-overlay=["']renderer-unavailable["']\][^{]*\{[^}]*top:\s*158px/i);
-    expect(mobileBlock).toMatch(/\.pixel-world-render-diagnostics\[data-renderer-state=["']unavailable["']\][^{]*\{[^}]*top:\s*232px/i);
+    expect(mobileBlock).toMatch(/\[data-viewer-overlay=["']renderer-unavailable["']\][^{]*\{[^}]*top:\s*calc\(132px \+ min\(20dvh, 128px\) \+ 8px\)/i);
+    expect(mobileBlock).toMatch(/\.pixel-world-render-diagnostics\[data-renderer-state=["']unavailable["']\][^{]*\{[^}]*top:\s*calc\(132px \+ min\(20dvh, 128px\) \+ 120px\)/i);
   });
 
   it("keeps a mobile More route for secondary Diagnostics without a narrow-screen hide rule", async () => {

--- a/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
+++ b/crates/oasis7_viewer/software_safe_src/fullscreen_map_shell_contract.test.js
@@ -159,6 +159,26 @@ describe("fullscreen map shell contract", () => {
     );
   });
 
+  it("keeps the mobile Feed band below top chrome and outside the decision band", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.stack\s*>\s*\[data-viewer-overlay="feed"\]\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?top:\s*132px;[\s\S]*?bottom:\s*auto;[\s\S]*?max-height:\s*min\(20dvh,\s*128px\)/i,
+    );
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.pixel-world-decision-area\s*\{[\s\S]*?max-height:\s*calc\(100dvh\s*-\s*276px\);[\s\S]*?align-content:\s*start;/i,
+    );
+  });
+
+  it("leaves a mobile gap between navigation, Cinematic, and Feed", async () => {
+    const { terminalShellCss } = await readViewerHtml();
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.secondary-viewer-nav\s*\{[\s\S]*?top:\s*56px;[\s\S]*?\[data-viewer-overlay="cinematic-entry"\]\s*\{[\s\S]*?top:\s*80px;/i,
+    );
+    expect(terminalShellCss).toMatch(
+      /@media\s*\(max-width:\s*640px\)[\s\S]*?\.stack\s*>\s*\[data-viewer-overlay="feed"\]\s*\{[\s\S]*?top:\s*132px;/i,
+    );
+  });
+
   it("bounds short-landscape Next Move content inside its receipt-safe band", async () => {
     const { terminalShellCss } = await readViewerHtml();
     expect(terminalShellCss).toMatch(

--- a/crates/oasis7_viewer/software_safe_src/legacy_core.js
+++ b/crates/oasis7_viewer/software_safe_src/legacy_core.js
@@ -4259,6 +4259,12 @@ function installTestApi() {
     togglePromptOverridesVisible,
     setStrongAuthApprovalCode,
     injectSnapshot,
+    injectWorldFeedForTest(feed) {
+      if (!isTestApiEnabled() || getSearchParams().get('connect') !== '0') throw new Error('feed fixture requires test_api=1&connect=0');
+      worldFeedTransport.handleWorldFeed(clone(feed));
+      render();
+      return clone(state.worldFeed);
+    },
     injectRefineQuotePreflightForTest,
     injectProductValidationQuoteForTest,
     injectPowerSaleQuoteForTest, injectPowerSurvivalQuoteForTest, injectWarDeclarationQuoteForTest, injectScheduleRecipeQuoteForTest, injectTransferMaterialQuoteForTest,

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -28,6 +28,7 @@ import { AgentIntentSurface } from "./agent_intent_surface.jsx";
 import { FactoryProductionFailureDispositionCard } from "./factory_production_failure_disposition_card.jsx";
 import { AgentContextLite } from "./agent_context_lite.jsx";
 import { buildAgentContextDisplayModel } from "./viewer_agent_context_display_model.js";
+import { pixelWorldBlockerPresentation, pixelWorldConnectionPresentation } from "./pixel_world_presentation.js";
 const VIEWER_VISUAL_FIXTURE_GLOBAL = "__OASIS7_VIEWER_VISUAL_FIXTURES__";
 const [viewerStateRevision, setViewerStateRevision] = createSignal(0);
 function observeViewerStateRevision() {
@@ -803,6 +804,7 @@ function HostedLoginGate() {
 function EmptyEntityRecoveryCard(props) {
   const locale = () => props.locale ?? uiLocale();
   const gameplay = () => (typeof props.gameplay === "function" ? props.gameplay() : props.gameplay);
+  const blockerPresentation = () => pixelWorldBlockerPresentation(gameplay()?.blockerKind, locale());
   const firstAgentClaimAction = () =>
     (gameplay()?.availableActions || []).find((action) => action.actionId === "claim_first_agent");
   const firstAgentClaimDisabledReason = () =>
@@ -813,29 +815,14 @@ function EmptyEntityRecoveryCard(props) {
       class="empty-entity-recovery"
       kind="empty_world_recovery"
       title={props.title ?? tr(locale(), "认领第一个 Agent", "Claim Your First Agent")}
-      badge={gameplay()?.blockerKind || "blocked"}
+      badge={blockerPresentation().label}
       badgeClass={firstAgentClaimAction() && !firstAgentClaimDisabledReason() ? "badge badge--good" : "badge badge--warn"}
       variant={firstAgentClaimAction() && !firstAgentClaimDisabledReason() ? null : "warn"}
     >
       <div class="feedback-summary">
-        {firstAgentClaimDisabledReason()
-          ? firstAgentClaimDisabledReason()
-          : firstAgentClaimAction()
-          ? tr(
-              locale(),
-              "这是新用户入口：当前还没有可玩实体，先用正式玩法动作认领你的第一个 Agent。",
-              "This is the new-user entry: there are no playable entities yet, so claim your first Agent through the canonical gameplay action.",
-            )
-          : gameplay()?.blockerDetail
-            || tr(
-              locale(),
-              "运行时已发布玩法摘要，但当前快照还没有可选行动体或地点。",
-              "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations.",
-            )}
+        {firstAgentClaimDisabledReason() || blockerPresentation().reason}
       </div>
-      <Show when={gameplay()?.nextStepHint}>
-        <div class="feedback-detail">{gameplay().nextStepHint}</div>
-      </Show>
+      <div class="feedback-detail">{gameplay()?.nextStepHint || blockerPresentation().nextAction}</div>
       <Show when={gameplay()?.entityCounts}>
         <div class="badge-row">
           <Badge>{`agents=${gameplay().entityCounts.agents}`}</Badge>
@@ -1940,16 +1927,7 @@ function chatEntryMessage(entry, locale) {
 }
 
 function connectionStatusLabel(status, locale) {
-  if (status === "connected") {
-    return tr(locale, "世界在线", "World Live");
-  }
-  if (status === "connecting") {
-    return tr(locale, "正在连入世界", "Connecting to World");
-  }
-  if (status === "closed") {
-    return tr(locale, "连接已关闭", "Connection Closed");
-  }
-  return tr(locale, `连接异常：${status || "unknown"}`, `Connection Issue: ${status || "unknown"}`);
+  return pixelWorldConnectionPresentation(status, locale).label;
 }
 
 function renderResourceSummary(resources) {
@@ -2646,7 +2624,7 @@ function WorldSummaryPanel(props = {}) {
                 <Show when={gameplay().blockerKind || gameplay().narrativeBlockerDetail}>
                   <div class="badge-row badge-row--spaced">
                     <Badge class="badge badge--warn">
-                      {gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker")}
+                      {pixelWorldBlockerPresentation(gameplay().blockerKind, locale()).label}
                     </Badge>
                   </div>
                   <div class="feedback-detail">

--- a/crates/oasis7_viewer/software_safe_src/main.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.jsx
@@ -2100,35 +2100,37 @@ function WorldStageHero() {
       </div>
       <Show when={recommendedAction()}>
         {(action) => (
-          <CalloutCard
-            title={tr(locale(), "推荐动作", "Recommended Action")}
-            badge={action().executeKind || "ready"}
-            badgeClass="badge badge--good"
-          >
-            <div class="feedback-summary">
-              {action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move.")}
-            </div>
-            <div
-              class="feedback-detail"
-              id={gameplayActionDisabledReason(action(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action()) : undefined}
+          <div class="stage-hero__secondary-action" data-hero-secondary-action="true">
+            <CalloutCard
+              title={tr(locale(), "推荐动作", "Recommended Action")}
+              badge={action().executeKind || "ready"}
+              badgeClass="badge badge--good"
             >
-              {gameplayActionDisabledReason(action(), gameplaySummary(), locale())
-                || gameplayActionDetail(action(), gameplaySummary(), locale())}
-            </div>
-            <div class="toolbar" aria-label={tr(locale(), "下一步动作", "Next Move action")}>
-              <button
-                type="button"
-                data-testid={gameplayActionTestId(action(), "recommended")}
-                class={gameplayActionButtonClass(action())}
-                aria-busy={gameplayActionButtonBusyAttrs(action())}
-                disabled={gameplayActionButtonDisabled(action(), gameplaySummary(), locale())}
-                aria-describedby={gameplayActionDisabledReason(action(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action()) : undefined}
-                onClick={() => renderGameplayAction(action())}
+              <div class="feedback-summary">
+                {action().label || action().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move.")}
+              </div>
+              <div
+                class="feedback-detail"
+                id={gameplayActionDisabledReason(action(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action()) : undefined}
               >
-                {gameplayActionDisplayLabel(action(), locale())}
-              </button>
-            </div>
-          </CalloutCard>
+                {gameplayActionDisabledReason(action(), gameplaySummary(), locale())
+                  || gameplayActionDetail(action(), gameplaySummary(), locale())}
+              </div>
+              <div class="toolbar" aria-label={tr(locale(), "下一步动作", "Next Move action")}>
+                <button
+                  type="button"
+                  data-testid={gameplayActionTestId(action(), "recommended")}
+                  class={gameplayActionButtonClass(action())}
+                  aria-busy={gameplayActionButtonBusyAttrs(action())}
+                  disabled={gameplayActionButtonDisabled(action(), gameplaySummary(), locale())}
+                  aria-describedby={gameplayActionDisabledReason(action(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action()) : undefined}
+                  onClick={() => renderGameplayAction(action())}
+                >
+                  {gameplayActionDisplayLabel(action(), locale())}
+                </button>
+              </div>
+            </CalloutCard>
+          </div>
         )}
       </Show>
       <Show when={gameplaySummary()?.blockerKind === "runtime_snapshot_empty_entities"}>

--- a/crates/oasis7_viewer/software_safe_src/main.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/main.test.jsx
@@ -3436,6 +3436,8 @@ describe("viewer web ui automation baseline", () => {
     expect(state.gameplaySummary.blockerKind).toBe("runtime_snapshot_empty_entities");
     expect(within(container.querySelector("#viewer-targets-panel")).getByText("No agents in current snapshot.")).toBeInTheDocument();
     expect(within(container.querySelector("#viewer-stage-panel")).getByText("Recover World Snapshot")).toBeInTheDocument();
+    expect(within(container.querySelector("#viewer-stage-panel")).getAllByText("No published entities yet").length).toBeGreaterThan(0);
+    expect(within(container.querySelector("#viewer-stage-panel")).getAllByText(/Request a fresh snapshot|Reload the authoritative snapshot|first published entity/i).length).toBeGreaterThan(0);
     expect(within(container.querySelector("#viewer-stage-panel")).getAllByText("Request snapshot").length).toBeGreaterThan(0);
     expect(within(container.querySelector("#viewer-details-panel")).getByText("Claim Your First Agent")).toBeInTheDocument();
     expect(container.querySelector("[data-callout-kind='empty_world_recovery']")).toBeTruthy();

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -6,10 +6,11 @@ import { applyPixelWorldRendererRoute, createPixelWorldRendererRouteSignals, res
 import { installPixelWorldRenderDtoProbe, installPixelWorldVisualFixtureHook, pixelWorldTestApiEnabled } from "./pixel_world_visual_fixture.js";
 import { pixelWorldSelectedBlockerVisualFixture } from "./pixel_world_visual_fixture_data.js";
 import { pixelWorldReadableAgentLabel, pixelWorldReadableEntityText, pixelWorldSelectedEntityLabel } from "./pixel_world_identity.js";
-import { PixelWorldCanvasAgentHitTargets, PixelWorldCanvasLegend, PixelWorldHostVisualLayer, arrayField, fieldValue, pixelWorldVisualState } from "./pixel_world_visual_clarity.jsx";
+import { PixelWorldCanvasAgentHitTargets, PixelWorldCanvasLegend, PixelWorldHostVisualLayer, PixelWorldSparseSceneGuidance, arrayField, fieldValue, pixelWorldVisualState } from "./pixel_world_visual_clarity.jsx";
 import { applyPixelWorldMobileSelectionSafeArea, installPixelWorldMobileSelectionSafeArea } from "./pixel_world_mobile_safe_area.js";
 import { createHotspotFocusRestoration, PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
 import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
+import { pixelWorldBlockerPresentation, pixelWorldConnectionPresentation, pixelWorldFeedFreshnessPresentation } from "./pixel_world_presentation.js";
 import { pixelWorldHotspotGlyphSize, pixelWorldHotspotStyle } from "./pixel_world_hotspot_projection.js";
 export { pixelWorldSelectedBlockerVisualFixture };
 function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
@@ -315,7 +316,7 @@ function PixelWorldCanvasRenderer(props) {
         </Show>
         <Show when={visualState().blockerHighlight}>
           <div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">
-            {`${tr(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`}
+            {`${tr(props.locale(), "阻塞", "Blocker")}: ${pixelWorldBlockerPresentation(visualState().blockerHighlight.kind, props.locale()).label}`}
           </div>
         </Show>
         <Show when={activeHotspot()}>
@@ -426,6 +427,14 @@ export function resolvePixelWorldDirectNextMoveAction(gameplay, executeKind) {
 function PixelWorldCommercialHud(props) {
   const surface = () => props.renderState().commercial_surface; const readoutStatus = () => worldReadoutStatus(props.locale(), props.renderState);
   const readoutFeedStatus = () => String(core.state.worldFeed?.status || "loading").trim().toLowerCase() || "loading";
+  const worldConnection = () => pixelWorldConnectionPresentation(core.state.connectionStatus, props.locale());
+  const feedFreshness = () => pixelWorldFeedFreshnessPresentation(readoutFeedStatus(), core.state.worldFeed?.stale, props.locale());
+  const playerBlockerLabel = () => {
+    const candidate = String(surface().blocker?.label || "").trim();
+    const kind = String(gameplay()?.blockerKind || "").trim();
+    if (kind) return pixelWorldBlockerPresentation(kind, props.locale()).label;
+    return candidate || null;
+  };
   const activeAgentId = () => String(surface()?.active_agent_id || "").trim(); const activeAgent = () => props.renderState().agents.find((agent) => agent.id === activeAgentId()); const activeAgentLabel = () => pixelWorldReadableAgentLabel(activeAgent(), activeAgentId(), core.isLocaleZh(props.locale())) || tr(props.locale(), "未选择 Agent", "No Agent selected");
   const executableNextMoveKinds = new Set([
     "gameplay_action",
@@ -487,15 +496,15 @@ function PixelWorldCommercialHud(props) {
           data-shell-region="next-move-primary"
           data-next-move-route={nextMoveRoute()}
           data-execute-kind={surface().next_action.execute_kind || "none"}
-          data-blocker-present={surface().blocker.label ? "true" : "false"}
+          data-blocker-present={playerBlockerLabel() ? "true" : "false"}
         >
           <div class="pixel-world-command-cell__header">
             <div class="pixel-world-command-cell__label">
               {tr(props.locale(), "下一步", "Next Move")}
             </div>
-            <Show when={surface().blocker.label}>
+            <Show when={playerBlockerLabel()}>
               <span class="pixel-world-command-cell__blocker-chip">
-                {`${tr(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`}
+                {`${tr(props.locale(), "阻塞", "Blocker")}: ${playerBlockerLabel()}`}
               </span>
             </Show>
           </div>
@@ -541,13 +550,15 @@ function PixelWorldCommercialHud(props) {
         </div>
         </div>
         <Show when={!props.focusMode?.()}><PixelWorldActionReceipt id="viewer-action-receipt" locale={props.locale} surface={surface} /></Show>
-        <div class="pixel-world-readout badge-row">
-          <span class={readoutStatus().className} data-world-feed-readout-status={readoutFeedStatus()}>{readoutStatus().label}</span>
+        <div class="pixel-world-readout badge-row" aria-label={tr(props.locale(), "世界连接与动态新鲜度", "World connection and feed freshness")}>
+          <span class={worldConnection().className} data-world-connection-status={worldConnection().state}>{worldConnection().label}</span>
+          <span class={feedFreshness().className} data-world-feed-readout-status={readoutFeedStatus()}>{feedFreshness().label}</span>
           <Show when={surface().world_read.tick !== null && surface().world_read.tick !== undefined}>
             <span class="badge badge--accent" data-world-tick={String(surface().world_read.tick)}>{`tick=${surface().world_read.tick}`}</span>
           </Show>
           <span class="badge badge--accent">{`agents=${surface().world_read.agents}`}</span>
         </div>
+        <PixelWorldSparseSceneGuidance locale={props.locale} renderState={props.renderState} />
         <PixelWorldCanvasLegend locale={props.locale} />
       </div>
     </Show>
@@ -802,8 +813,11 @@ function PixelWorldFocusCommandSurface(props) {
   const chatFeedbackDisplay = () => core.describeSemanticFeedback(chatFeedback(), locale());
   const chatControlsEnabled = () => chatCapability().enabled && !core.isAgentChatInFlight();
   const gameplaySummary = () => core.buildGameplaySummary(locale());
-  const blockerLabel = () =>
-    gameplaySummary()?.blockerLabel || gameplaySummary()?.blockerKind || tr(locale(), "无阻塞", "No blocker");
+  const blockerLabel = () => {
+    const kind = gameplaySummary()?.blockerKind;
+    if (!kind) return tr(locale(), "无阻塞", "No blocker");
+    return pixelWorldBlockerPresentation(kind, locale()).label;
+  };
   const receiptLabel = () =>
     gameplaySummary()?.executionStateLabel
       || gameplaySummary()?.recentFeedback?.stage

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -6,12 +6,32 @@ import { applyPixelWorldRendererRoute, createPixelWorldRendererRouteSignals, res
 import { installPixelWorldRenderDtoProbe, installPixelWorldVisualFixtureHook, pixelWorldTestApiEnabled } from "./pixel_world_visual_fixture.js";
 import { pixelWorldSelectedBlockerVisualFixture } from "./pixel_world_visual_fixture_data.js";
 import { pixelWorldReadableAgentLabel, pixelWorldReadableEntityText, pixelWorldSelectedEntityLabel } from "./pixel_world_identity.js";
+import { PixelWorldCanvasAgentHitTargets, PixelWorldCanvasLegend, PixelWorldHostVisualLayer, arrayField, fieldValue, pixelWorldVisualState } from "./pixel_world_visual_clarity.jsx";
 import { applyPixelWorldMobileSelectionSafeArea, installPixelWorldMobileSelectionSafeArea } from "./pixel_world_mobile_safe_area.js";
 import { createHotspotFocusRestoration, PixelWorldHotspot, PixelWorldHotspotTooltip } from "./pixel_world_hotspot.jsx";
 import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
 import { pixelWorldHotspotGlyphSize, pixelWorldHotspotStyle } from "./pixel_world_hotspot_projection.js";
 export { pixelWorldSelectedBlockerVisualFixture };
 function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
+async function waitForRuntimeCanvasAttachment(canvas) {
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    if (canvas?.isConnected && document.getElementById(PIXEL_WORLD_RUNTIME_CANVAS_ID) === canvas) {
+      return true;
+    }
+    await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  return false;
+}
+function snapshotTick(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return null;
+  }
+  const tick = Number(fieldValue(snapshot, "time", "time", null));
+  return Number.isFinite(tick) ? Math.max(0, Math.floor(tick)) : null;
+}
+function pixelWorldAgentIdentity(agent, fallbackId = "", isLocaleZh = false) {
+  return pixelWorldReadableAgentLabel(agent, fallbackId, isLocaleZh) || "Agent";
+}
 const PIXEL_WORLD_RUNTIME_CANVAS_ID = "pixel-world-embedded-runtime-canvas"; const PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID = "pixel-world-renderer-unavailable-message";
 const pixelWorldFocusUiSessionState = {
   focusMode: false,
@@ -19,198 +39,6 @@ const pixelWorldFocusUiSessionState = {
   diagnosticsDrawerOpen: false,
   maximized: false,
 };
-const FRAGMENT_TERRAIN_PALETTE = {
-  silicate_matrix: [126, 144, 99],
-  iron_nickel_alloy: [176, 184, 196],
-  water_ice: [125, 211, 252],
-  hydrated_mineral: [96, 165, 250],
-  carbonaceous_organic: [120, 113, 108],
-  sulfide_ore: [202, 138, 4],
-  rare_earth_oxide: [167, 139, 250],
-  uranium_bearing_ore: [132, 204, 22],
-  thorium_bearing_ore: [244, 114, 182],
-  unknown: [148, 163, 184],
-};
-async function waitForRuntimeCanvasAttachment(canvas) {
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    if (
-      canvas?.isConnected
-      && document.getElementById(PIXEL_WORLD_RUNTIME_CANVAS_ID) === canvas
-    ) {
-      return true;
-    }
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => resolve());
-    });
-  }
-  return false;
-}
-function safeNumber(value, fallback = 0) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : fallback;
-}
-function pixelWorldAgentIdentity(agent, fallbackId = "", isLocaleZh = false) {
-  return pixelWorldReadableAgentLabel(agent, fallbackId, isLocaleZh) || "Agent";
-}
-function snapshotTick(snapshot) {
-  if (!snapshot || typeof snapshot !== "object") {
-    return null;
-  }
-  const tick = Number(fieldValue(snapshot, "time", "time", null));
-  if (!Number.isFinite(tick)) {
-    return null;
-  }
-  return Math.max(0, Math.floor(tick));
-}
-function colorToCss(color, alpha = 0.36) {
-  const [red, green, blue] = Array.isArray(color) ? color : FRAGMENT_TERRAIN_PALETTE.unknown;
-  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-}
-function clampRatio(value) {
-  return Math.min(1, Math.max(0, Number(value) || 0));
-}
-function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
-  if (!pos || !worldBounds) {
-    return fallbackStyle;
-  }
-  const point = worldPercentPoint(pos, worldBounds, 8, 10);
-  return {
-    left: `${point.x.toFixed(1)}%`,
-    top: `${point.y.toFixed(1)}%`,
-  };
-}
-function agentMarkerStyle(agent, index, worldBounds) {
-  const base = toWorldPercentStyle(agent.pos, worldBounds, {
-    left: `${18 + ((index % 5) * 15)}%`,
-    top: `${14 + (Math.floor(index / 5) * 22)}%`,
-  });
-  const offsets = [
-    [-18, -18],
-    [18, -18],
-    [-18, 18],
-    [18, 18],
-    [0, -30],
-    [0, 30],
-    [-30, 0],
-    [30, 0],
-    [-28, -28],
-    [28, 28],
-  ];
-  const [x, y] = offsets[index % offsets.length] || [0, 0];
-  return {
-    ...base,
-    transform: `translate(${x}px, ${y}px)`,
-  };
-}
-function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
-  if (!pos || !worldBounds) {
-    return { x: fallbackX, y: fallbackY };
-  }
-  return {
-    x: 8 + (clampRatio(pos.x_cm / Math.max(1, worldBounds.width_cm)) * 84),
-    y: 10 + (clampRatio(pos.y_cm / Math.max(1, worldBounds.depth_cm)) * 78),
-  };
-}
-const FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO = 9 / 16;
-function routeStyle(link, worldBounds, index) {
-  const fallbackFrom = {
-    x: 14 + ((index % 5) * 15),
-    y: 18 + (Math.floor(index / 5) * 14),
-  };
-  const fallbackTo = {
-    x: fallbackFrom.x + 14,
-    y: fallbackFrom.y + 8,
-  };
-  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
-  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
-  const deltaX = to.x - from.x;
-  const deltaY = to.y - from.y;
-  const scaledDeltaY = deltaY * FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO;
-  const length = Math.max(4, Math.hypot(deltaX, scaledDeltaY));
-  const angle = Math.atan2(scaledDeltaY, deltaX) * (180 / Math.PI);
-  return {
-    left: `${from.x.toFixed(1)}%`,
-    top: `${from.y.toFixed(1)}%`,
-    width: `${length.toFixed(1)}%`,
-    opacity: `${0.32 + (clampRatio(link.emphasis ?? 0.72) * 0.38)}`,
-    transform: `rotate(${angle.toFixed(1)}deg)`,
-    "transform-origin": "0 50%",
-  };
-}
-function fragmentTerrainStyle(patch, worldBounds, index) {
-  const sizePx = Math.max(12, Math.min(48, safeNumber(patch.footprint_cm, 1) / 840));
-  return {
-    ...toWorldPercentStyle(patch.pos, worldBounds, {
-      left: `${12 + ((index % 6) * 13)}%`,
-      top: `${16 + (Math.floor(index / 6) * 13)}%`,
-    }),
-    width: `${sizePx.toFixed(1)}px`,
-    height: `${sizePx.toFixed(1)}px`,
-    "background-color": colorToCss(patch.color),
-    transform: "translate(-50%, -50%)",
-  };
-}
-function routeWaypointStyle(link, worldBounds, index, stop) {
-  const fallbackFrom = {
-    x: 14 + ((index % 5) * 15),
-    y: 18 + (Math.floor(index / 5) * 14),
-  };
-  const fallbackTo = {
-    x: fallbackFrom.x + 14,
-    y: fallbackFrom.y + 8,
-  };
-  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
-  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
-  const ratio = stop === "to" ? 1 : 0.52;
-  return {
-    left: `${(from.x + ((to.x - from.x) * ratio)).toFixed(1)}%`,
-    top: `${(from.y + ((to.y - from.y) * ratio)).toFixed(1)}%`,
-  };
-}
-function fieldValue(value, snakeName, camelName, fallback = undefined) {
-  if (!value || typeof value !== "object") {
-    return fallback;
-  }
-  if (value[snakeName] !== undefined) {
-    return value[snakeName];
-  }
-  if (camelName && value[camelName] !== undefined) {
-    return value[camelName];
-  }
-  return fallback;
-}
-function arrayField(value, snakeName, camelName) {
-  const candidate = fieldValue(value, snakeName, camelName, []);
-  return Array.isArray(candidate) ? candidate : [];
-}
-function normalizeVisualEntity(entry) {
-  if (!entry || typeof entry !== "object") {
-    return entry;
-  }
-  return {
-    ...entry,
-    location_id: fieldValue(entry, "location_id", "locationId", null),
-    marker_role: fieldValue(entry, "marker_role", "markerRole", null),
-    marker_alpha: fieldValue(entry, "marker_alpha", "markerAlpha", undefined),
-    position_source: fieldValue(entry, "position_source", "positionSource", null),
-    dominant_compound: fieldValue(entry, "dominant_compound", "dominantCompound", undefined),
-    footprint_cm: fieldValue(entry, "footprint_cm", "footprintCm", undefined),
-  };
-}
-function pixelWorldVisualState(renderState) {
-  const state = renderState || {};
-  return {
-    worldBounds: fieldValue(state, "world_bounds", "worldBounds", null),
-    fragmentTerrain: arrayField(state, "fragment_terrain", "fragmentTerrain").map(normalizeVisualEntity),
-    links: arrayField(state, "links", "links"),
-    locations: arrayField(state, "locations", "locations").map(normalizeVisualEntity),
-    agents: arrayField(state, "agents", "agents").map(normalizeVisualEntity),
-    selection: fieldValue(state, "selection", "selection", null),
-    goalHighlight: fieldValue(state, "goal_highlight", "goalHighlight", null),
-    blockerHighlight: fieldValue(state, "blocker_highlight", "blockerHighlight", null),
-    visualHotspots: arrayField(state, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity),
-  };
-}
 function PixelWorldHostHotspotLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
   return <Index each={visualState().visualHotspots.slice(0, 8)}>{(hotspot, index) => (
@@ -222,126 +50,6 @@ function PixelWorldHostHotspotLayer(props) {
       onHotspotHoverIntent={props.onHotspotHoverIntent}
       onHotspotTrigger={props.onHotspotTrigger} onHotspotRestoreFocus={props.onHotspotRestoreFocus} />
   )}</Index>;
-}
-function PixelWorldHostVisualLayer(props) {
-  const visualState = () => pixelWorldVisualState(props.renderState());
-  const selection = () => props.selection?.() || visualState().selection;
-  if (!props.enabled) {
-    return <></>;
-  }
-  return (
-    <>
-      <div class="pixel-world-canvas__grid" />
-      <div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one" />
-      <div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two" />
-      <For each={visualState().fragmentTerrain.slice(0, 96)}>
-        {(patch, index) => (
-          <div
-            class="pixel-world-fragment-terrain"
-            data-compound={patch.dominant_compound}
-            style={fragmentTerrainStyle(patch, visualState().worldBounds, index())}
-            title={`${patch.location_id}:${patch.dominant_compound}`}
-          />
-        )}
-      </For>
-      <For each={visualState().links.slice(0, 10)}>
-        {(link, index) => (
-          <>
-            <div
-              class="pixel-world-route"
-              data-route-kind={link.kind}
-              style={routeStyle(link, visualState().worldBounds, index())}
-              title={`${link.kind}:${link.id}`}
-            />
-            <div
-              class="pixel-world-route-waypoint pixel-world-route-waypoint--mid"
-              data-route-kind={link.kind}
-              style={routeWaypointStyle(link, visualState().worldBounds, index(), "mid")}
-              title={`${link.kind}:waypoint`}
-            />
-            <div
-              class="pixel-world-route-waypoint pixel-world-route-waypoint--target"
-              data-route-kind={link.kind}
-              style={routeWaypointStyle(link, visualState().worldBounds, index(), "to")}
-              title={`${link.kind}:target`}
-            />
-          </>
-        )}
-      </For>
-      <Index each={visualState().locations.slice(0, 8)}>
-        {(location, index) => (
-          <button
-            class="pixel-world-entity pixel-world-entity--location"
-            data-pixel-world-location-marker="true"
-            data-location-id={location().id}
-            data-selected={selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false"}
-            aria-pressed={selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`}
-            data-marker-role={location().marker_role}
-            style={{
-              ...toWorldPercentStyle(location().pos, visualState().worldBounds, {
-                left: `${12 + ((index % 4) * 21)}%`,
-                top: `${18 + (Math.floor(index / 4) * 26)}%`,
-              }),
-              opacity: location().marker_alpha,
-            }}
-            title={location().label}
-            onMouseEnter={() => props.onHover({ kind: "location", id: location().id })}
-            onMouseLeave={() => props.onHover(null)}
-            onClick={() => props.onSelect({ kind: "location", id: location().id })}
-          >
-            <span>{location().label.slice(0, 2).toUpperCase()}</span>
-          </button>
-        )}
-      </Index>
-      <Index each={visualState().agents.slice(0, 10)}>
-        {(agent, index) => {
-            const label = () => pixelWorldReadableAgentLabel(agent(), agent().id, core.isLocaleZh(props.locale())); return (
-              <button
-                class="pixel-world-entity pixel-world-entity--agent"
-                data-pixel-world-agent-marker="true"
-                data-agent-id={agent().id}
-                data-selected={selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false"}
-                data-position-source={agent().position_source}
-                aria-pressed={selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${label()}`}
-                style={agentMarkerStyle(agent(), index, visualState().worldBounds)}
-                title={label()}
-                onMouseEnter={() => props.onHover({ kind: "agent", id: agent().id })}
-                onMouseLeave={() => props.onHover(null)}
-                onClick={() => props.onSelect({ kind: "agent", id: agent().id })}
-              >
-                <span>{label().slice(0, 1).toUpperCase()}</span>
-              </button>
-            );
-        }}
-      </Index>
-    </>
-  );
-}
-function PixelWorldCanvasAgentHitTargets(props) {
-  const visualState = () => pixelWorldVisualState(props.renderState());
-  return (
-    <For each={visualState().agents.slice(0, 10)}>
-      {(agent, index) => {
-          const label = pixelWorldReadableAgentLabel(agent, agent.id, core.isLocaleZh(props.locale())); return (
-            <button
-              type="button"
-              class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"
-              data-pixel-world-agent-marker="true"
-              data-agent-id={agent.id}
-              data-position-source={agent.position_source}
-              data-selected={props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false"} aria-pressed={props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${label}`}
-              style={agentMarkerStyle(agent, index(), visualState().worldBounds)}
-              title={label}
-              onMouseEnter={() => props.onHover({ kind: "agent", id: agent.id })}
-              onMouseLeave={() => props.onHover(null)}
-              onClick={() => props.onSelect({ kind: "agent", id: agent.id })}
-            >
-              <span>{label.slice(0, 1).toUpperCase()}</span>
-            </button>
-          );
-      }}
-    </For>
-  );
 }
 function createPixelWorldHostAdapter({ onSelectEntity, onHoverEntity, onFatal }) {
   let bridge = null;
@@ -582,6 +290,7 @@ function PixelWorldCanvasRenderer(props) {
       <div class="pixel-world-canvas__overlay">
         <PixelWorldCanvasAgentHitTargets
           locale={props.locale} renderState={props.renderState} selection={props.selection}
+          hovered={props.hoveredEntity}
           onSelect={props.onSelect}
           onHover={props.onHover}
         />
@@ -590,6 +299,7 @@ function PixelWorldCanvasRenderer(props) {
           locale={props.locale}
           renderState={props.renderState}
           selection={props.selection}
+          hovered={props.hoveredEntity}
           onSelect={props.onSelect}
           onHover={props.onHover}
         />
@@ -632,10 +342,14 @@ function PixelWorldCanvasRenderer(props) {
 }
 function PixelWorldActionReceipt(props) {
   const receipt = () => props.surface().action_receipt;
+  const receiptChanges = () => [
+    receipt().delta_logical_time == null ? null : `${tr(props.locale(), "世界 Tick 变化", "World tick change")} ${receipt().delta_logical_time}`,
+    receipt().delta_event_seq == null ? null : `${tr(props.locale(), "事件序列变化", "Event sequence change")} ${receipt().delta_event_seq}`,
+  ].filter(Boolean);
   return (
     <div
       id={props.id}
-      class={`pixel-world-action-receipt ${props.class ?? ""}`} data-viewer-overlay="receipt"
+      class={`pixel-world-action-receipt pixel-world-action-receipt--${receipt().state || "unknown"} pixel-world-action-receipt--${receipt().confidence || "none"} ${props.class ?? ""}`} data-viewer-overlay="receipt"
       data-receipt-present={receipt().present ? "true" : "false"}
       data-receipt-state={receipt().state}
       data-receipt-confidence={receipt().confidence}
@@ -655,6 +369,11 @@ function PixelWorldActionReceipt(props) {
             {receipt().detail}
           </div>
         </Show>
+        <Show when={receiptChanges().length > 0}>
+          <div class="pixel-world-action-receipt__changes" data-receipt-changes="true">
+            {receiptChanges().join(" · ")}
+          </div>
+        </Show>
       </div>
       <Show when={receipt().present}>
         <div class="pixel-world-action-receipt__meta">
@@ -669,6 +388,7 @@ function PixelWorldActionReceipt(props) {
 }
 function receiptConfidenceLabel(confidence, locale, state) {
   const value = String(confidence || "").trim().toLowerCase(); const receiptState = String(state || "").trim().toLowerCase();
+  if (receiptState === "blocked") return tr(locale, "行动被阻塞", "Action blocked");
   if (receiptState === "rejected") return tr(locale, "行动已拒绝", "Action rejected");
   return value === "world_delta" ? tr(locale, "世界变化已确认", "World change confirmed") : value === "accepted_intent" ? tr(locale, "行动已接受", "Action accepted") : value === "none" ? tr(locale, "等待确认", "Waiting for confirmation") : tr(locale, "状态已记录", "Status recorded");
 }
@@ -756,11 +476,12 @@ function PixelWorldCommercialHud(props) {
   };
   return (
     <Show when={surface()}>
-      <div
-        class="pixel-world-command-strip" data-viewer-overlay="next-move"
-        data-active-agent={activeAgentId()}
-        data-leverage-state={surface().player_leverage.state}
-      >
+      <div id="viewer-decision-area" class="pixel-world-decision-area" data-viewer-decision-area="true">
+        <div
+          class="pixel-world-command-strip" data-viewer-overlay="next-move"
+          data-active-agent={activeAgentId()}
+          data-leverage-state={surface().player_leverage.state}
+        >
         <div
           class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"
           data-shell-region="next-move-primary"
@@ -784,10 +505,12 @@ function PixelWorldCommercialHud(props) {
           </Show>
           <a
             class="pixel-world-command-cell__action"
+            data-primary-action="true"
             href={nextMoveHref()}
             aria-label={`${tr(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`}
             aria-disabled={nextMoveDisabledReason() ? "true" : undefined}
             aria-busy={nextMovePending() ? "true" : "false"}
+            aria-live="polite"
             tabIndex={nextMoveDisabledReason() ? -1 : undefined}
             onClick={activateNextMove}
           >
@@ -797,6 +520,13 @@ function PixelWorldCommercialHud(props) {
                 ? tr(props.locale(), "打开玩法明细", "Open Gameplay Details")
               : tr(props.locale(), "去指挥面板", "Go to Command")}
           </a>
+          <Show when={nextMovePending() || surface().action_receipt?.present}>
+            <div class="pixel-world-command-cell__feedback" data-primary-action-feedback="true" aria-live="polite">
+              {nextMovePending()
+                ? tr(props.locale(), "动作已提交，等待世界确认。", "Action submitted; waiting for world confirmation.")
+                : surface().action_receipt?.title}
+            </div>
+          </Show>
         </div>
         <div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting" data-shell-region="supporting-context">
           <div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective">
@@ -809,14 +539,16 @@ function PixelWorldCommercialHud(props) {
             <div class="pixel-world-shell-context-group__agent" data-selected-agent-label={activeAgentLabel()}><span class="pixel-world-command-cell__label">{tr(props.locale(), "当前 Agent", "Selected Agent")}</span><strong>{activeAgentLabel()}</strong></div>
           </div>
         </div>
-      </div>
-      <Show when={!props.focusMode?.()}><PixelWorldActionReceipt id="viewer-action-receipt" locale={props.locale} surface={surface} /></Show>
-      <div class="pixel-world-readout badge-row">
-        <span class={readoutStatus().className} data-world-feed-readout-status={readoutFeedStatus()}>{readoutStatus().label}</span>
-        <Show when={surface().world_read.tick !== null && surface().world_read.tick !== undefined}>
-          <span class="badge badge--accent" data-world-tick={String(surface().world_read.tick)}>{`tick=${surface().world_read.tick}`}</span>
-        </Show>
-        <span class="badge badge--accent">{`agents=${surface().world_read.agents}`}</span>
+        </div>
+        <Show when={!props.focusMode?.()}><PixelWorldActionReceipt id="viewer-action-receipt" locale={props.locale} surface={surface} /></Show>
+        <div class="pixel-world-readout badge-row">
+          <span class={readoutStatus().className} data-world-feed-readout-status={readoutFeedStatus()}>{readoutStatus().label}</span>
+          <Show when={surface().world_read.tick !== null && surface().world_read.tick !== undefined}>
+            <span class="badge badge--accent" data-world-tick={String(surface().world_read.tick)}>{`tick=${surface().world_read.tick}`}</span>
+          </Show>
+          <span class="badge badge--accent">{`agents=${surface().world_read.agents}`}</span>
+        </div>
+        <PixelWorldCanvasLegend locale={props.locale} />
       </div>
     </Show>
   );
@@ -1525,6 +1257,7 @@ export function PixelWorldHost(props) {
           renderInput={renderInput}
           renderState={renderState}
           selection={selectedEntity}
+          hoveredEntity={hoverSelection}
           visualOverlayEnabled={visualOverlayEnabled}
           onSelect={(selection) => adapter().simulateSelect(selection)}
           onHover={(selection) => adapter().simulateHover(selection)}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.jsx
@@ -12,6 +12,7 @@ import { createHotspotFocusRestoration, PixelWorldHotspot, PixelWorldHotspotTool
 import { resolvePixelWorldReadoutStatus } from "./pixel_world_readout.js";
 import { pixelWorldBlockerPresentation, pixelWorldConnectionPresentation, pixelWorldFeedFreshnessPresentation } from "./pixel_world_presentation.js";
 import { pixelWorldHotspotGlyphSize, pixelWorldHotspotStyle } from "./pixel_world_hotspot_projection.js";
+import { PixelWorldRendererTargets } from './pixel_world_renderer_targets.jsx';
 export { pixelWorldSelectedBlockerVisualFixture };
 function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
 async function waitForRuntimeCanvasAttachment(canvas) {
@@ -44,7 +45,8 @@ function PixelWorldHostHotspotLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
   return <Index each={visualState().visualHotspots.slice(0, 8)}>{(hotspot, index) => (
     <PixelWorldHotspot locale={props.locale()} hotspot={hotspot()}
-      style={pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.())}
+      style={pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.(), props.stageSize?.())}
+      rendererProjection={props.rendererProjection?.()}
       glyphSize={pixelWorldHotspotGlyphSize(hotspot())}
       onHover={props.onHover}
       onHotspotInspect={props.onHotspotInspect} onHotspotClear={props.onHotspotClear}
@@ -241,6 +243,18 @@ export function buildPixelWorldRenderInput(locale = core.state.uiLocale) {
 }
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
+  const [stageSize, setStageSize] = createSignal({ width: 960, height: 540 });
+  onMount(() => {
+    const update = () => {
+      const rect = canvasRef?.getBoundingClientRect();
+      if (rect?.width && rect?.height) setStageSize({ width: rect.width, height: rect.height });
+    };
+    update();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(canvasRef);
+    onCleanup(() => observer.disconnect());
+  });
   const hotspotFocus = createHotspotFocusRestoration();
   const visualState = () => pixelWorldVisualState(props.renderState());
   const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
@@ -254,6 +268,11 @@ function PixelWorldCanvasRenderer(props) {
   };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, core.isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
+  createEffect(() => {
+    props.cameraState?.();
+    stageSize();
+    requestAnimationFrame(() => applyPixelWorldMobileSelectionSafeArea(canvasRef?.closest('.pixel-world-canvas')));
+  });
   createEffect(() => {
     if (!canvasRef) {
       return;
@@ -269,7 +288,7 @@ function PixelWorldCanvasRenderer(props) {
     requestAnimationFrame(() => applyPixelWorldMobileSelectionSafeArea(canvasRef?.closest(".pixel-world-canvas")));
   });
   return (
-    <div class="pixel-world-canvas pixel-world-canvas--rendered" data-renderer-ready={props.rendererStatus?.() === "ready" ? "true" : undefined}>
+    <div class="pixel-world-canvas pixel-world-canvas--rendered" data-renderer-projection={props.rendererProjection?.() ? 'true' : undefined} data-renderer-ready={props.rendererStatus?.() === "ready" ? "true" : undefined}>
       <canvas
         ref={canvasRef}
         id={PIXEL_WORLD_RUNTIME_CANVAS_ID}
@@ -289,6 +308,7 @@ function PixelWorldCanvasRenderer(props) {
         )}
       </div>
       <div class="pixel-world-canvas__overlay">
+        <Show when={props.rendererProjection?.()} fallback={<>
         <PixelWorldCanvasAgentHitTargets
           locale={props.locale} renderState={props.renderState} selection={props.selection}
           hovered={props.hoveredEntity}
@@ -304,7 +324,11 @@ function PixelWorldCanvasRenderer(props) {
           onSelect={props.onSelect}
           onHover={props.onHover}
         />
+        </>}>
+          <PixelWorldRendererTargets locale={props.locale} renderState={props.renderState} selection={props.selection} cameraState={props.cameraState} stageSize={stageSize} onSelect={props.onSelect} onHover={props.onHover} />
+        </Show>
         <PixelWorldHostHotspotLayer locale={props.locale} renderState={props.renderState} cameraState={props.cameraState}
+          rendererProjection={props.rendererProjection} stageSize={() => props.rendererProjection?.() ? stageSize() : undefined}
           onHover={props.onHover} onHotspotInspect={(selection) => { setHoverDismissed(false); setInspectedHotspot(selection); }}
           onHotspotHoverIntent={() => setHoverDismissed(false)}
           onHotspotClear={() => { setHoverDismissed(true); setInspectedHotspot(null); }}
@@ -1267,6 +1291,7 @@ export function PixelWorldHost(props) {
         <PixelWorldCanvasRenderer
           locale={locale}
           rendererStatus={rendererStatus}
+          rendererProjection={() => runtimeSource() === 'wasm_bindgen_runtime' && cameraState() !== null}
           cameraState={cameraState}
           renderInput={renderInput}
           renderState={renderState}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -598,6 +598,8 @@ describe("pixel world host", () => {
     expect(screen.getByText("Rust leverage summary")).toBeInTheDocument();
     expect(document.querySelector(".pixel-world-readout")).toHaveTextContent("tick=12");
     expect(document.querySelector(".pixel-world-readout [data-world-tick='12']")).toHaveTextContent("tick=12");
+    expect(document.querySelector(".pixel-world-readout [data-world-connection-status]")).toHaveTextContent(/World connection:/i);
+    expect(document.querySelector(".pixel-world-readout [data-world-feed-readout-status]")).toHaveTextContent(/Feed freshness:/i);
     await waitFor(() => {
       expect(document.querySelector(".pixel-world-canvas--rendered")).toBeInTheDocument();
     });
@@ -617,6 +619,53 @@ describe("pixel world host", () => {
     expect(canvas.querySelector(".pixel-world-route")).toBeNull();
     expect(canvas.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: Agent 0");
     expect(runtimeMock.deriveRenderState).toHaveBeenCalled();
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps sparse-scene guidance honest and read-only", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => ({
+      ...buildTestRustRenderState(input),
+      links: [],
+      fragmentTerrain: [],
+      fragment_terrain: [],
+      locations: [{ id: "loc-0", label: "Origin", pos: { x_cm: 1, y_cm: 2, z_cm: 0 } }],
+      agents: [{ id: "agent-0", label: "Agent 0", pos: { x_cm: 3, y_cm: 4, z_cm: 0 } }],
+    }));
+    await renderPixelWorldHost(sampleSnapshot(), "?test_api=1&connect=0&locale=en");
+    await waitFor(() => expect(document.querySelector("[data-pixel-world-sparse-guidance='true']")).toBeInTheDocument());
+    const guidance = document.querySelector("[data-pixel-world-sparse-guidance='true']");
+    expect(guidance).toHaveTextContent("No published routes in this snapshot");
+    expect(guidance).toHaveTextContent("No published terrain in this snapshot");
+    expect(guidance).toHaveTextContent("Published bounds:");
+    expect(guidance.querySelectorAll("button, a")).toHaveLength(0);
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("uses a safe generic label when an unknown blocker reaches the host", async () => {
+    useTestRustRenderState();
+    const snapshot = sampleSnapshot();
+    snapshot.player_gameplay.blocker_kind = "unknown_internal_code";
+    snapshot.player_gameplay.blocker_detail = "diagnostic only";
+    await renderPixelWorldHost(snapshot, "?test_api=1&connect=0&locale=en");
+    await waitFor(() => expect(document.querySelector("[data-shell-region='next-move-primary']")).toBeInTheDocument());
+    const primary = document.querySelector("[data-shell-region='next-move-primary']");
+    expect(primary).toHaveTextContent("Current blocker");
+    expect(primary).not.toHaveTextContent("unknown_internal_code");
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps unknown blocker codes out of the Cinematic command chip", async () => {
+    useTestRustRenderState();
+    const snapshot = sampleSnapshot();
+    snapshot.player_gameplay.blocker_kind = "unknown_internal_code";
+    snapshot.player_gameplay.blocker_detail = "diagnostic only";
+    await renderPixelWorldHost(snapshot, "?test_api=1&connect=0&locale=en");
+
+    await waitFor(() => expect(screen.getByText("Recover sustainable capability")).toBeInTheDocument());
+    screen.getByRole("button", { name: "Cinematic View" }).click();
+    await waitFor(() => expect(document.querySelector(".pixel-world-host")).toHaveAttribute("data-world-focus", "true"));
+    screen.getByRole("button", { name: "Command & Target" }).click();
+
+    const commandChip = document.querySelector(".pixel-world-focus-command-chip--blocker");
+    expect(commandChip).toHaveTextContent("Current blocker");
+    expect(commandChip).not.toHaveTextContent("unknown_internal_code");
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("keeps read-only hotspot controls available in production and resolves tooltip locale", async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -278,6 +278,33 @@ describe("pixel world host", () => {
     expect(readout).not.toHaveTextContent(/routes=|fragments=|hotspots=|renderer=|runtime=/i);
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
+  it("refreshes connection and feed badges across updates without remounting", async () => {
+    useTestRustRenderState();
+    const { core } = await renderPixelWorldHost(sampleSnapshot(), "?test_api=1&connect=0&locale=en");
+    await waitFor(() => expect(document.querySelector(".pixel-world-readout")).not.toBeNull());
+    const connection = document.querySelector("[data-world-connection-status]");
+    const feed = document.querySelector("[data-world-feed-readout-status]");
+    for (const [connectionStatus, status, stale, connectionLabel, feedLabel] of [
+      ["connecting", "loading", false, "CONNECTING", "SYNCING"],
+      ["connected", "ready", false, "ONLINE", "LIVE"],
+      ["closed", "ready", true, "CLOSED", "STALE"],
+    ]) {
+      core.state.connectionStatus = connectionStatus;
+      Object.assign(core.state.worldFeed, { status, stale });
+      core.requestRender();
+      await waitFor(() => {
+        expect(document.querySelector("[data-world-connection-status]")).toBe(connection);
+        expect(document.querySelector("[data-world-feed-readout-status]")).toBe(feed);
+        expect(connection).toHaveTextContent(`World connection: ${connectionLabel}`);
+        expect(feed).toHaveTextContent(`Feed freshness: ${feedLabel}`);
+        expect(connection).toHaveClass(`pixel-world-readout__connection--${connectionLabel.toLowerCase()}`);
+        expect(feed).toHaveClass(`pixel-world-readout__feed--${feedLabel.toLowerCase()}`);
+        expect(connection).toHaveAttribute("data-world-connection-status", connectionLabel.toLowerCase());
+        expect(feed).toHaveAttribute("data-world-feed-readout-status", status);
+      });
+    }
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
   it("does not label a disconnected or stale world as LIVE", async () => {
     useTestRustRenderState();
     const { core } = await renderPixelWorldHost(

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host.test.jsx
@@ -2,436 +2,18 @@ import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { verifyHotspotCameraAndFocus } from "./pixel_world_hotspot_test_helpers.js";
-const runtimeMock = vi.hoisted(() => ({
-  deriveRenderState: null,
-  mountError: null,
-  mountGates: [],
-  mountResults: [],
-  mountCalls: 0,
-  onEvent: null,
-}));
-vi.mock("./pixel_world_runtime_loader.js", async () => ({
-  ...(await vi.importActual("./pixel_world_runtime_loader.js")),
-  createPixelWorldRuntimeBridge: async ({ onEvent, onFatal }) => {
-    runtimeMock.onEvent = onEvent;
-    return {
-      source: runtimeMock.deriveRenderState ? "test_rust_runtime" : "wasm_import_failed",
-      moduleUrl: "http://127.0.0.1:4173/pixel-world-bridge/pixel_world_bridge.js",
-      deriveRenderState: runtimeMock.deriveRenderState,
-      bridge: {
-        mount() {
-          runtimeMock.mountCalls += 1;
-          if (runtimeMock.mountError) {
-            throw runtimeMock.mountError;
-          }
-          if (runtimeMock.mountGates.length) {
-            const gate = runtimeMock.mountGates.shift();
-            return gate.then(() => runtimeMock.mountResults.shift() || { status: "ready", fatal: null });
-          }
-          if (runtimeMock.deriveRenderState) {
-            return {
-              status: "ready",
-              fatal: null,
-            };
-          }
-          const fatal = {
-            code: "pixel_world_renderer_runtime_unavailable",
-            message: "pixel world wasm runtime is unavailable: missing wasm bridge",
-          };
-          onFatal?.(fatal);
-          return {
-            status: "fallback",
-            fatal,
-          };
-        },
-        update() {
-          if (runtimeMock.deriveRenderState) {
-            return {
-              status: "ready",
-              fatal: null,
-            };
-          }
-          return {
-            status: "fallback",
-          };
-        },
-        unmount() {
-          return {
-            status: "detached",
-          };
-        },
-      },
-    };
-  },
-}));
-let activeCleanup = null;
-let canvasContextSpy = null;
-const HEAVY_UI_TEST_TIMEOUT_MS = 60000;
-function clone(value) {
-  return JSON.parse(JSON.stringify(value));
-}
-function fieldValue(source, snake, camel, fallback = null) {
-  if (!source || typeof source !== "object") {
-    return fallback;
-  }
-  if (source[snake] != null) {
-    return source[snake];
-  }
-  if (source[camel] != null) {
-    return source[camel];
-  }
-  return fallback;
-}
-function dominantCompound(block) {
-  const ppm = block?.compounds?.ppm || {};
-  const entries = Object.entries(ppm);
-  if (!entries.length) {
-    return "unknown";
-  }
-  return entries.sort((left, right) => Number(right[1] || 0) - Number(left[1] || 0))[0][0];
-}
-function locationPos(location) {
-  return location?.pos || { x_cm: 0, y_cm: 0, z_cm: 0 };
-}
-function buildTestRustRenderState(input) {
-  const snapshot = input.snapshot || {};
-  const model = snapshot.model || {};
-  const gameplay = snapshot.player_gameplay || {};
-  const locations = Object.values(model.locations || {});
-  const agents = Object.values(model.agents || {});
-  const fragments = locations.flatMap((location) => {
-    const base = locationPos(location);
-    return (location.fragment_profile?.blocks?.blocks || []).map((block, index) => ({
-      id: `fragment:${location.id}:${index}`,
-      locationId: location.id,
-      pos: {
-        x_cm: base.x_cm + Number(block.origin_cm?.x_cm || 0),
-        y_cm: base.y_cm + Number(block.origin_cm?.z_cm || block.origin_cm?.y_cm || 0),
-        z_cm: base.z_cm + Number(block.origin_cm?.y_cm || 0),
-      },
-      dominantCompound: dominantCompound(block),
-      footprintCm: Math.max(Number(block.size_cm?.x_cm || 12_000), Number(block.size_cm?.z_cm || block.size_cm?.y_cm || 12_000)),
-    }));
-  });
-  const firstAction = (gameplay.available_actions || [])[0] || {};
-  const activeAgentId = gameplay.intent_target || agents[0]?.id || null;
-  const receiptPresent = Boolean(gameplay.recent_feedback || gameplay.last_world_change);
-  const blockerLabel = gameplay.blocker_kind === "material_shortage" ? "Missing Material" : gameplay.blocker_kind || null;
-  const renderState = {
-    locale: input.locale || "en",
-    worldBounds: snapshot.config?.space || { width_cm: 10_000_000, depth_cm: 5_000_000, height_cm: 1_000_000 },
-    world_bounds: snapshot.config?.space || { width_cm: 10_000_000, depth_cm: 5_000_000, height_cm: 1_000_000 },
-    locations: locations.map((location) => ({
-      id: location.id,
-      label: location.name || location.id,
-      pos: locationPos(location),
-      markerRole: "logic_anchor",
-      markerAlpha: 0.32,
-    })),
-    fragmentTerrain: fragments,
-    fragment_terrain: fragments,
-    agents: agents.map((agent, index) => {
-      const base = locationPos(model.locations?.[agent.location_id]);
-      return {
-        id: agent.id,
-        label: agent.name || agent.id,
-        pos: agent.pos || {
-          x_cm: base.x_cm + 20_000 + index * 15_000,
-          y_cm: base.y_cm + 10_000 + index * 12_000,
-          z_cm: base.z_cm,
-        },
-        positionSource: agent.pos ? "runtime_agent" : "location_derived",
-      };
-    }),
-    links: agents
-      .filter((agent) => agent.location_id && model.locations?.[agent.location_id])
-      .map((agent) => {
-        const from = agent.pos || {
-          x_cm: locationPos(model.locations[agent.location_id]).x_cm + 20_000,
-          y_cm: locationPos(model.locations[agent.location_id]).y_cm + 10_000,
-          z_cm: 0,
-        };
-        return {
-          id: `link:${agent.id}:${agent.location_id}`,
-          kind: "agent_assignment",
-          from,
-          to: locationPos(model.locations[agent.location_id]),
-          emphasis: 0.72,
-        };
-      }),
-    selection: activeAgentId ? { kind: "agent", id: activeAgentId } : null,
-    goalHighlight: {
-      title: gameplay.goal_title || "Current Objective",
-      objective: gameplay.objective || gameplay.progress_detail || "",
-    },
-    blockerHighlight: blockerLabel
-      ? { kind: gameplay.blocker_kind, label: blockerLabel, detail: gameplay.blocker_detail || null }
-      : null,
-    recentEventHotspots: [],
-    visualHotspots: [],
-    commercial_surface: {
-      objective: {
-        title: gameplay.goal_title || "Current Objective",
-        detail: gameplay.objective || gameplay.progress_detail || "No current objective.",
-        progress_percent: gameplay.progress_percent ?? null,
-      },
-      next_action: {
-        label: fieldValue(firstAction, "label", "label", "Unassigned"),
-        detail: gameplay.intent_summary || null,
-        target_agent_id: fieldValue(firstAction, "target_agent_id", "targetAgentId", activeAgentId),
-        execute_kind: fieldValue(firstAction, "execute_kind", "executeKind", "gameplay_action"),
-      },
-      active_agent_id: activeAgentId,
-      player_leverage: {
-        state: gameplay.stage_status || "waiting_for_intent",
-        label: receiptPresent ? "Blocked" : "Waiting for Intent",
-        summary: gameplay.progress_detail || "Waiting",
-        detail: gameplay.next_step_hint || null,
-      },
-      action_receipt: {
-        present: receiptPresent,
-        state: receiptPresent ? "blocked" : "waiting_for_intent",
-        confidence: receiptPresent ? "world_delta" : "none",
-        title: receiptPresent ? "Action blocked" : "No action receipt yet",
-        summary: receiptPresent ? "Action blocked" : "No receipt",
-        detail: gameplay.last_world_change || gameplay.recent_feedback?.effect || "No player-caused world change has been confirmed yet.",
-        target_agent_id: receiptPresent ? activeAgentId : null,
-        effect_kind: gameplay.causality_kind || null,
-        delta_logical_time: gameplay.recent_feedback?.delta_logical_time ?? null,
-        delta_event_seq: gameplay.recent_feedback?.delta_event_seq ?? null,
-      },
-      blocker: {
-        label: blockerLabel,
-        detail: gameplay.next_step_hint || gameplay.blocker_detail || null,
-      },
-      world_read: {
-        agents: agents.length,
-        routes: agents.filter((agent) => agent.location_id).length,
-        fragments: fragments.length,
-        hotspots: 0,
-      },
-    },
-    presentation: input.presentation || { world_bounds_label: "bounds", marker_truth_note: "truth" },
-  };
-  return renderState;
-}
-function useTestRustRenderState() {
-  runtimeMock.deriveRenderState = vi.fn((input) => buildTestRustRenderState(input));
-}
-function sampleSnapshot() {
-  return {
-    time: 12,
-    config: {
-      space: {
-        width_cm: 10_000_000,
-        depth_cm: 5_000_000,
-        height_cm: 1_000_000,
-      },
-    },
-    model: {
-      agents: {
-        "agent-0": {
-          id: "agent-0",
-          name: "Agent 0",
-          location_id: "loc-0",
-          resources: {},
-        },
-      },
-      locations: {
-        "loc-0": {
-          id: "loc-0",
-          name: "Factory Anchor",
-          pos: { x_cm: 5_000_000, y_cm: 2_500_000, z_cm: 0 },
-          profile: { radius_cm: 25_000, radiation_emission_per_tick: 0, material: "silicate" },
-          fragment_profile: {
-            blocks: {
-              blocks: [
-                {
-                  origin_cm: { x_cm: 0, y_cm: 0, z_cm: 0 },
-                  size_cm: { x_cm: 12_000, y_cm: 7_500, z_cm: 8_000 },
-                  density_kg_per_m3: 3200,
-                  compounds: {
-                    ppm: {
-                      silicate_matrix: 800_000,
-                      water_ice: 200_000,
-                    },
-                  },
-                },
-                {
-                  origin_cm: { x_cm: 20_000, y_cm: 1_000, z_cm: 18_000 },
-                  size_cm: { x_cm: 20_000, y_cm: 8_000, z_cm: 10_000 },
-                  density_kg_per_m3: 7800,
-                  compounds: {
-                    ppm: {
-                      iron_nickel_alloy: 900_000,
-                      sulfide_ore: 100_000,
-                    },
-                  },
-                },
-              ],
-            },
-          },
-          resources: {},
-        },
-      },
-      agent_prompt_profiles: {},
-      agent_execution_debug_contexts: {},
-      agent_player_bindings: {
-        "agent-0": "player-one",
-      },
-      agent_player_public_key_bindings: {
-        "agent-0": "abcdef0123456789abcdef0123456789",
-      },
-    },
-    player_gameplay: {
-      stage_id: "post_onboarding",
-      stage_status: "blocked",
-      execution_state: "blocked",
-      accepted_intent_id: "gameplay_action:build_factory_smelter_mk1",
-      intent_summary: "Queue build_factory_smelter_mk1 for agent-0",
-      intent_scope: "gameplay_action",
-      intent_target: "agent-0",
-      goal_id: "post_onboarding.recover_capability",
-      goal_kind: "RecoverCapability",
-      goal_title: "Recover sustainable capability",
-      objective: "Stabilize the first production line before expanding.",
-      progress_detail: "The primary line is blocked by missing material input.",
-      progress_percent: 68,
-      blocker_kind: "material_shortage",
-      blocker_detail: "iron input exhausted at factory-0",
-      causality_kind: "world_constraint",
-      causality_detail: "iron input exhausted at factory-0",
-      last_world_change: "Smelter build request reached factory-0; iron shortage blocks construction.",
-      blocker_supplemental_detail: null,
-      next_step_hint: "Replenish upstream materials, then advance again to confirm the line resumes.",
-      branch_hint: null,
-      available_actions: [
-        {
-          action_id: "build_factory_smelter_mk1",
-          target_agent_id: "agent-0",
-          label: "Build smelter mk1",
-          protocol_action: "gameplay_action.submit",
-          disabled_reason: null,
-        },
-      ],
-      recent_feedback: {
-        action: "build_factory_smelter_mk1",
-        stage: "completed_no_progress",
-        effect: "Smelter build request reached factory-0; iron shortage blocks construction.",
-        reason: "iron input exhausted at factory-0",
-        hint: "Replenish upstream materials, then advance again.",
-        delta_logical_time: 1,
-        delta_event_seq: 2,
-      },
-      agent_claim: null,
-    },
-  };
-}
-function acceptedOnlySnapshot() {
-  const snapshot = clone(sampleSnapshot());
-  const gameplay = snapshot.player_gameplay;
-  gameplay.stage_status = "executing";
-  gameplay.execution_state = "accepted";
-  gameplay.blocker_kind = null;
-  gameplay.blocker_detail = null;
-  gameplay.causality_kind = null;
-  gameplay.causality_detail = null;
-  gameplay.last_world_change = null;
-  gameplay.recent_feedback = {
-    action: "build_factory_smelter_mk1",
-    stage: "accepted",
-    effect: null,
-    reason: null,
-    hint: "Build request queued for agent-0.",
-    delta_logical_time: 0,
-    delta_event_seq: 1,
-  };
-  return snapshot;
-}
-function noReceiptSnapshot() {
-  const snapshot = clone(sampleSnapshot());
-  const gameplay = snapshot.player_gameplay;
-  gameplay.stage_status = "running";
-  delete gameplay.execution_state;
-  delete gameplay.accepted_intent_id;
-  delete gameplay.intent_summary;
-  delete gameplay.intent_scope;
-  delete gameplay.intent_target;
-  delete gameplay.blocker_kind;
-  delete gameplay.blocker_detail;
-  delete gameplay.causality_kind;
-  delete gameplay.causality_detail;
-  delete gameplay.last_world_change;
-  gameplay.progress_detail = "The first production line is waiting for a player command.";
-  gameplay.recent_feedback = null;
-  return snapshot;
-}
-function emptyWorldSnapshot() {
-  const snapshot = clone(noReceiptSnapshot());
-  snapshot.model.agents = {};
-  snapshot.model.locations = {};
-  snapshot.model.agent_prompt_profiles = {};
-  snapshot.model.agent_execution_debug_contexts = {};
-  snapshot.model.agent_player_bindings = {};
-  snapshot.model.agent_player_public_key_bindings = {};
-  return snapshot;
-}
-function bindFirstSnapshotAgentForTest(core, snapshot) {
-  const agentId = Object.keys(snapshot?.model?.agents || {})[0];
-  const playerId = snapshot?.model?.agent_player_bindings?.[agentId];
-  if (!agentId || !playerId) {
-    return;
-  }
-  core.state.auth = {
-    ...core.state.auth,
-    available: true,
-    playerId,
-    publicKey: snapshot?.model?.agent_player_public_key_bindings?.[agentId] || "abcdef0123456789abcdef0123456789",
-    privateKey: "private-key-must-stay-hidden",
-    source: "local_test_api_ephemeral",
-    registrationStatus: "registered",
-    runtimeStatus: "registered",
-    boundAgentId: agentId,
-  };
-}
-async function renderPixelWorldHost(snapshot = sampleSnapshot(), search = "?test_api=1&connect=0&locale=en", locale = "en") {
-  activeCleanup?.();
-  activeCleanup = null;
-  vi.resetModules();
-  window.history.replaceState({}, "", `/software_safe.html${search}`);
-  window.localStorage.clear();
-  document.body.innerHTML = "";
-  const core = await import("./legacy_core.js");
-  const { PixelWorldHost } = await import("./pixel_world_host.jsx");
-  core.setViewerLocale(locale);
-  core.injectSnapshot(snapshot);
-  bindFirstSnapshotAgentForTest(core, snapshot);
-  const view = render(() => <PixelWorldHost locale={locale} />);
-  activeCleanup = view.unmount;
-  return {
-    core,
-    ...view,
-  };
-}
-beforeEach(() => {
-  runtimeMock.deriveRenderState = null;
-  runtimeMock.mountError = null;
-  runtimeMock.mountGates = [];
-  runtimeMock.mountResults = [];
-  runtimeMock.mountCalls = 0;
-  runtimeMock.onEvent = null;
-  canvasContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({});
-  window.history.replaceState({}, "", "/software_safe.html?test_api=1&connect=0&locale=en");
-  window.localStorage.clear();
-  document.body.innerHTML = "";
-});
-afterEach(() => {
-  activeCleanup?.();
-  activeCleanup = null;
-  canvasContextSpy?.mockRestore();
-  canvasContextSpy = null;
-  document.body.innerHTML = "";
-});
+import {
+  HEAVY_UI_TEST_TIMEOUT_MS,
+  buildTestRustRenderState,
+  cleanupMountedHost,
+  emptyWorldSnapshot,
+  noReceiptSnapshot,
+  renderPixelWorldHost,
+  runtimeMock,
+  sampleSnapshot,
+  testHarness,
+  useTestRustRenderState,
+} from "./pixel_world_host_test_support.jsx";
 describe("pixel world host", () => {
   it("keeps world focus stage resets scoped away from nested command panels", () => {
     const html = readFileSync("software_safe.html", "utf8");
@@ -454,6 +36,179 @@ describe("pixel world host", () => {
     expect(html).toMatch(/\.pixel-world-focus-minimap__node--selected\s*\{[^}]*border-color:\s*rgba\(208,\s*168,\s*91,\s*0\.58\);/s);
     expect(html).toMatch(/\.pixel-world-focus-minimap__node--selected::before\s*\{[^}]*width:\s*18px;[^}]*height:\s*18px;[^}]*border:\s*1px solid rgba\(208,\s*168,\s*91,\s*0\.78\);/s);
   });
+
+  it("exposes one decision area with one primary action, receipt, and canvas legend", async () => {
+    useTestRustRenderState();
+    await renderPixelWorldHost(
+      sampleSnapshot(),
+      "?test_api=1&connect=0&locale=en&pixel_world_visual_fixture=selected_blocker",
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-viewer-decision-area="true"]')).toBeInTheDocument();
+    });
+
+    const decisionArea = document.querySelector('[data-viewer-decision-area="true"]');
+    expect(decisionArea).toHaveAttribute("id", "viewer-decision-area");
+    expect(decisionArea.querySelectorAll('[data-primary-action="true"]')).toHaveLength(1);
+    expect(decisionArea.querySelector("#viewer-action-receipt")).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-pixel-world-legend="true"]')).toHaveLength(1);
+    expect(document.querySelector('[data-pixel-world-legend="true"]')).toHaveTextContent(/route/i);
+    expect(document.querySelector('[data-pixel-world-legend="true"]')).toHaveTextContent(/goal/i);
+    expect(document.querySelector('[data-pixel-world-legend="true"]')).toHaveTextContent(/blocker/i);
+    expect(document.querySelector('[data-pixel-world-legend="true"]')).toHaveTextContent(/resource/i);
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("renders stable terse marker codes and exposes the selected full label in a safe callout", async () => {
+    const snapshot = sampleSnapshot();
+    snapshot.model.agents = {
+      "agent-builder": { id: "agent-builder", name: "Shared Name", location_id: "loc-0", resources: {} },
+      "agent-factory": { id: "agent-factory", name: "Shared Name", location_id: "loc-0", resources: {} },
+    };
+    snapshot.player_gameplay.intent_target = "agent-builder";
+    useTestRustRenderState();
+    await renderPixelWorldHost(snapshot);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[data-pixel-world-agent-marker="true"]').length).toBeGreaterThanOrEqual(2);
+    });
+    const markers = [...document.querySelectorAll('[data-pixel-world-agent-marker="true"]')];
+    const codes = markers.map((marker) => marker.querySelector(".pixel-world-entity__code")?.textContent);
+    expect(new Set(codes).size).toBe(codes.length);
+    expect(markers[0]).not.toHaveTextContent("Shared Name");
+    expect(markers[0].querySelector(".pixel-world-entity__label")).not.toBeInTheDocument();
+    expect(markers[0]).toHaveAttribute("title", "Shared Name");
+    expect(markers[0]).toHaveAttribute("aria-label", "Select Agent Shared Name");
+    expect(document.querySelector(".pixel-world-canvas__selection")).toHaveTextContent("Selected: Shared Name");
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("highlights only routes with explicit selected endpoint ids", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => ({
+      ...buildTestRustRenderState(input),
+      selection: { kind: "agent", id: "agent-0" },
+      links: [
+        { id: "link-associated", kind: "agent_assignment", from: { x_cm: 1, y_cm: 1 }, to: { x_cm: 2, y_cm: 2 }, agent_id: "agent-0", location_id: "loc-0" },
+        { id: "link-unassociated", kind: "agent_assignment", from: { x_cm: 3, y_cm: 3 }, to: { x_cm: 4, y_cm: 4 } },
+      ],
+    }));
+    await renderPixelWorldHost(
+      sampleSnapshot(),
+      "?test_api=1&connect=0&locale=en&pixel_world_visual_fixture=selected_blocker",
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".pixel-world-route")).toHaveLength(2);
+    });
+    const associated = document.querySelector('[data-route-id="link-associated"]');
+    const unassociated = document.querySelector('[data-route-id="link-unassociated"]');
+    expect(associated).toHaveAttribute("data-associated", "true");
+    expect(unassociated).toHaveAttribute("data-associated", "false");
+    expect(unassociated).toHaveClass("pixel-world-route--muted");
+    expect(document.querySelectorAll(".pixel-world-route[role='button'], .pixel-world-route button")).toHaveLength(0);
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("associates authoritative host relation projections by their canonical link id", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => {
+      const authoritative = { kind: "agent_assignment", status: "active", source_class: "runtime_projection", freshness: "current" };
+      const state = buildTestRustRenderState(input);
+      state.agents = [
+        { ...state.agents[0], location_id: "loc-0", relation: authoritative },
+        { id: "agent-1", location_id: "loc-1", pos: { x_cm: 3, y_cm: 3 }, relation: authoritative },
+      ];
+      return {
+      ...state,
+      selection: { kind: "agent", id: "agent-0" },
+      links: [
+        {
+          id: "link:agent-0:loc-0",
+          kind: "agent_assignment",
+          from: { x_cm: 1, y_cm: 1 },
+          to: { x_cm: 2, y_cm: 2 },
+          status: "active",
+          source_class: "runtime_projection",
+          freshness: "current",
+        },
+        {
+          id: "link:agent-1:loc-1",
+          kind: "agent_assignment",
+          from: { x_cm: 3, y_cm: 3 },
+          to: { x_cm: 4, y_cm: 4 },
+          status: "active",
+          source_class: "runtime_projection",
+          freshness: "current",
+        },
+      ],
+      };
+    });
+    const { core } = await renderPixelWorldHost(sampleSnapshot(), "?test_api=1&connect=0&locale=en");
+    document.body.setAttribute("data-viewer-visual-fixture", "authoritative-relation");
+    core.requestRender();
+
+    await waitFor(() => {
+      expect(document.querySelectorAll(".pixel-world-route")).toHaveLength(2);
+    });
+    expect(document.querySelector('[data-route-id="link:agent-0:loc-0"]')).toHaveAttribute("data-associated", "true");
+    expect(document.querySelector('[data-route-id="link:agent-1:loc-1"]')).toHaveAttribute("data-associated", "false");
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps accepted intent wording out of a blocked receipt", async () => {
+    runtimeMock.deriveRenderState = vi.fn((input) => {
+      const state = buildTestRustRenderState(input);
+      state.commercial_surface.action_receipt = {
+        present: true,
+        state: "blocked",
+        confidence: "accepted_intent",
+        title: "Action blocked",
+        summary: "The action was blocked by a material shortage.",
+        detail: "No world change was confirmed.",
+        target_agent_id: "agent-0",
+      };
+      return state;
+    });
+    await renderPixelWorldHost(sampleSnapshot(), "?test_api=1&connect=0&locale=en");
+
+    await waitFor(() => {
+      expect(document.querySelector("#viewer-action-receipt")).toHaveTextContent("Action blocked");
+    });
+    const receipt = document.querySelector("#viewer-action-receipt");
+    expect(receipt).not.toHaveTextContent("Action accepted");
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps marker codes unique across the first-screen agent and location caps", async () => {
+    const snapshot = sampleSnapshot();
+    snapshot.model.agents = Object.fromEntries(Array.from({ length: 10 }, (_, index) => [
+      `agent-${index}`,
+      { id: `agent-${index}`, name: index % 2 ? "Shared Long Agent Name" : "共享长名称行动体", location_id: `loc-${index % 8}`, resources: {} },
+    ]));
+    snapshot.model.locations = Object.fromEntries(Array.from({ length: 8 }, (_, index) => [
+      `loc-${index}`,
+      { id: `loc-${index}`, name: index % 2 ? "Shared Long Location Name" : "共享长名称地点", pos: { x_cm: 100_000 + index * 80_000, y_cm: 100_000 + index * 80_000, z_cm: 0 }, resources: {} },
+    ]));
+    snapshot.player_gameplay.intent_target = "agent-0";
+    useTestRustRenderState();
+    const { core } = await renderPixelWorldHost(snapshot, "?test_api=1&connect=0&locale=en");
+    document.body.setAttribute("data-viewer-visual-fixture", "long-identity");
+    core.requestRender();
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[data-pixel-world-agent-marker="true"]:not(.pixel-world-entity--canvas-hit-target)')).toHaveLength(10);
+      expect(document.querySelectorAll('[data-pixel-world-location-marker="true"]')).toHaveLength(8);
+    });
+    const codes = [...document.querySelectorAll(".pixel-world-entity:not(.pixel-world-entity--canvas-hit-target) .pixel-world-entity__code")].map((node) => node.textContent);
+    expect(new Set(codes).size).toBe(codes.length);
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
+
+  it("keeps the primary action hit area at least 44px on mobile and exposes pending state in place", async () => {
+    const css = readFileSync("viewer_terminal_shell.css", "utf8");
+    expect(css).toMatch(/@media\s*\(max-width:\s*1240px\)[\s\S]*?\.pixel-world-command-cell__action\s*\{[^}]*min-height:\s*44px;/);
+
+    useTestRustRenderState();
+    await renderPixelWorldHost(sampleSnapshot());
+    await waitFor(() => expect(document.querySelector('[data-primary-action="true"]')).toBeInTheDocument());
+    const primaryAction = document.querySelector('[data-primary-action="true"]');
+    expect(primaryAction).toHaveAttribute("aria-live", "polite");
+    expect(primaryAction.closest('[data-viewer-decision-area="true"]')).toBeInTheDocument();
+  }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("resolves claim onboarding next moves to executable gameplay actions", async () => {
     const { resolvePixelWorldDirectNextMoveAction } = await import("./pixel_world_host.jsx");
@@ -609,7 +364,7 @@ describe("pixel world host", () => {
 
   it("fails closed before bridge mount when the canvas cannot create a WebGL2 surface", async () => {
     useTestRustRenderState();
-    canvasContextSpy.mockReturnValue(null);
+    testHarness.canvasContextSpy.mockReturnValue(null);
 
     try {
       const { core } = await renderPixelWorldHost();
@@ -626,13 +381,13 @@ describe("pixel world host", () => {
         code: "pixel_world_webgl2_unavailable",
       }));
     } finally {
-      canvasContextSpy.mockReturnValue({});
+      testHarness.canvasContextSpy.mockReturnValue({});
     }
   }, HEAVY_UI_TEST_TIMEOUT_MS);
 
   it("keeps unavailable copy player-readable while raw fatal details stay folded", async () => {
     useTestRustRenderState();
-    canvasContextSpy.mockReturnValue(null);
+    testHarness.canvasContextSpy.mockReturnValue(null);
 
     const { container } = await renderPixelWorldHost();
 
@@ -1523,8 +1278,7 @@ describe("pixel world host", () => {
 
   it("preserves world focus UI state across host remounts", async () => {
     useTestRustRenderState();
-    activeCleanup?.();
-    activeCleanup = null;
+    cleanupMountedHost();
     vi.resetModules();
     window.history.replaceState({}, "", "/software_safe.html?test_api=1&connect=0&locale=en");
     window.localStorage.clear();
@@ -1536,7 +1290,7 @@ describe("pixel world host", () => {
     core.injectSnapshot(sampleSnapshot());
 
     const firstView = render(() => <PixelWorldHost locale="en" />);
-    activeCleanup = firstView.unmount;
+    testHarness.activeCleanup = firstView.unmount;
 
     await waitFor(() => {
       expect(screen.getByText("Recover sustainable capability")).toBeInTheDocument();
@@ -1554,12 +1308,10 @@ describe("pixel world host", () => {
     expect(document.querySelector(".pixel-world-focus-drawer--diagnostics")?.open).toBe(true);
 
     firstView.unmount();
-    if (activeCleanup === firstView.unmount) {
-      activeCleanup = null;
-    }
+    cleanupMountedHost();
 
     const secondView = render(() => <PixelWorldHost locale="en" />);
-    activeCleanup = secondView.unmount;
+    testHarness.activeCleanup = secondView.unmount;
 
     const secondHost = document.querySelector(".pixel-world-host");
     expect(secondHost).toHaveAttribute("data-world-focus", "true");

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_host_test_support.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_host_test_support.jsx
@@ -1,0 +1,461 @@
+import { render } from "@solidjs/testing-library";
+import { afterEach, beforeEach, vi } from "vitest";
+
+const runtimeMock = vi.hoisted(() => ({
+  deriveRenderState: null,
+  mountError: null,
+  mountGates: [],
+  mountResults: [],
+  mountCalls: 0,
+  onEvent: null,
+}));
+vi.mock("./pixel_world_runtime_loader.js", async () => ({
+  ...(await vi.importActual("./pixel_world_runtime_loader.js")),
+  createPixelWorldRuntimeBridge: async ({ onEvent, onFatal }) => {
+    runtimeMock.onEvent = onEvent;
+    return {
+      source: runtimeMock.deriveRenderState ? "test_rust_runtime" : "wasm_import_failed",
+      moduleUrl: "http://127.0.0.1:4173/pixel-world-bridge/pixel_world_bridge.js",
+      deriveRenderState: runtimeMock.deriveRenderState,
+      bridge: {
+        mount() {
+          runtimeMock.mountCalls += 1;
+          if (runtimeMock.mountError) {
+            throw runtimeMock.mountError;
+          }
+          if (runtimeMock.mountGates.length) {
+            const gate = runtimeMock.mountGates.shift();
+            return gate.then(() => runtimeMock.mountResults.shift() || { status: "ready", fatal: null });
+          }
+          if (runtimeMock.deriveRenderState) {
+            return {
+              status: "ready",
+              fatal: null,
+            };
+          }
+          const fatal = {
+            code: "pixel_world_renderer_runtime_unavailable",
+            message: "pixel world wasm runtime is unavailable: missing wasm bridge",
+          };
+          onFatal?.(fatal);
+          return {
+            status: "fallback",
+            fatal,
+          };
+        },
+        update() {
+          if (runtimeMock.deriveRenderState) {
+            return {
+              status: "ready",
+              fatal: null,
+            };
+          }
+          return {
+            status: "fallback",
+          };
+        },
+        unmount() {
+          return {
+            status: "detached",
+          };
+        },
+      },
+    };
+  },
+}));
+let activeCleanup = null;
+let canvasContextSpy = null;
+const testHarness = {
+  get activeCleanup() { return activeCleanup; },
+  set activeCleanup(value) { activeCleanup = value; },
+  get canvasContextSpy() { return canvasContextSpy; },
+  set canvasContextSpy(value) { canvasContextSpy = value; },
+};
+const HEAVY_UI_TEST_TIMEOUT_MS = 60000;
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+function fieldValue(source, snake, camel, fallback = null) {
+  if (!source || typeof source !== "object") {
+    return fallback;
+  }
+  if (source[snake] != null) {
+    return source[snake];
+  }
+  if (source[camel] != null) {
+    return source[camel];
+  }
+  return fallback;
+}
+function dominantCompound(block) {
+  const ppm = block?.compounds?.ppm || {};
+  const entries = Object.entries(ppm);
+  if (!entries.length) {
+    return "unknown";
+  }
+  return entries.sort((left, right) => Number(right[1] || 0) - Number(left[1] || 0))[0][0];
+}
+function locationPos(location) {
+  return location?.pos || { x_cm: 0, y_cm: 0, z_cm: 0 };
+}
+function buildTestRustRenderState(input) {
+  const snapshot = input.snapshot || {};
+  const model = snapshot.model || {};
+  const gameplay = snapshot.player_gameplay || {};
+  const locations = Object.values(model.locations || {});
+  const agents = Object.values(model.agents || {});
+  const fragments = locations.flatMap((location) => {
+    const base = locationPos(location);
+    return (location.fragment_profile?.blocks?.blocks || []).map((block, index) => ({
+      id: `fragment:${location.id}:${index}`,
+      locationId: location.id,
+      pos: {
+        x_cm: base.x_cm + Number(block.origin_cm?.x_cm || 0),
+        y_cm: base.y_cm + Number(block.origin_cm?.z_cm || block.origin_cm?.y_cm || 0),
+        z_cm: base.z_cm + Number(block.origin_cm?.y_cm || 0),
+      },
+      dominantCompound: dominantCompound(block),
+      footprintCm: Math.max(Number(block.size_cm?.x_cm || 12_000), Number(block.size_cm?.z_cm || block.size_cm?.y_cm || 12_000)),
+    }));
+  });
+  const firstAction = (gameplay.available_actions || [])[0] || {};
+  const activeAgentId = gameplay.intent_target || agents[0]?.id || null;
+  const receiptPresent = Boolean(gameplay.recent_feedback || gameplay.last_world_change);
+  const blockerLabel = gameplay.blocker_kind === "material_shortage" ? "Missing Material" : gameplay.blocker_kind || null;
+  const renderState = {
+    locale: input.locale || "en",
+    worldBounds: snapshot.config?.space || { width_cm: 10_000_000, depth_cm: 5_000_000, height_cm: 1_000_000 },
+    world_bounds: snapshot.config?.space || { width_cm: 10_000_000, depth_cm: 5_000_000, height_cm: 1_000_000 },
+    locations: locations.map((location) => ({
+      id: location.id,
+      label: location.name || location.id,
+      pos: locationPos(location),
+      markerRole: "logic_anchor",
+      markerAlpha: 0.32,
+    })),
+    fragmentTerrain: fragments,
+    fragment_terrain: fragments,
+    agents: agents.map((agent, index) => {
+      const base = locationPos(model.locations?.[agent.location_id]);
+      return {
+        id: agent.id,
+        label: agent.name || agent.id,
+        pos: agent.pos || {
+          x_cm: base.x_cm + 20_000 + index * 15_000,
+          y_cm: base.y_cm + 10_000 + index * 12_000,
+          z_cm: base.z_cm,
+        },
+        positionSource: agent.pos ? "runtime_agent" : "location_derived",
+      };
+    }),
+    links: agents
+      .filter((agent) => agent.location_id && model.locations?.[agent.location_id])
+      .map((agent) => {
+        const from = agent.pos || {
+          x_cm: locationPos(model.locations[agent.location_id]).x_cm + 20_000,
+          y_cm: locationPos(model.locations[agent.location_id]).y_cm + 10_000,
+          z_cm: 0,
+        };
+        return {
+          id: `link:${agent.id}:${agent.location_id}`,
+          kind: "agent_assignment",
+          from,
+          to: locationPos(model.locations[agent.location_id]),
+          emphasis: 0.72,
+        };
+      }),
+    selection: activeAgentId ? { kind: "agent", id: activeAgentId } : null,
+    goalHighlight: {
+      title: gameplay.goal_title || "Current Objective",
+      objective: gameplay.objective || gameplay.progress_detail || "",
+    },
+    blockerHighlight: blockerLabel
+      ? { kind: gameplay.blocker_kind, label: blockerLabel, detail: gameplay.blocker_detail || null }
+      : null,
+    recentEventHotspots: [],
+    visualHotspots: [],
+    commercial_surface: {
+      objective: {
+        title: gameplay.goal_title || "Current Objective",
+        detail: gameplay.objective || gameplay.progress_detail || "No current objective.",
+        progress_percent: gameplay.progress_percent ?? null,
+      },
+      next_action: {
+        label: fieldValue(firstAction, "label", "label", "Unassigned"),
+        detail: gameplay.intent_summary || null,
+        target_agent_id: fieldValue(firstAction, "target_agent_id", "targetAgentId", activeAgentId),
+        execute_kind: fieldValue(firstAction, "execute_kind", "executeKind", "gameplay_action"),
+      },
+      active_agent_id: activeAgentId,
+      player_leverage: {
+        state: gameplay.stage_status || "waiting_for_intent",
+        label: receiptPresent ? "Blocked" : "Waiting for Intent",
+        summary: gameplay.progress_detail || "Waiting",
+        detail: gameplay.next_step_hint || null,
+      },
+      action_receipt: {
+        present: receiptPresent,
+        state: receiptPresent ? "blocked" : "waiting_for_intent",
+        confidence: receiptPresent ? "world_delta" : "none",
+        title: receiptPresent ? "Action blocked" : "No action receipt yet",
+        summary: receiptPresent ? "Action blocked" : "No receipt",
+        detail: gameplay.last_world_change || gameplay.recent_feedback?.effect || "No player-caused world change has been confirmed yet.",
+        target_agent_id: receiptPresent ? activeAgentId : null,
+        effect_kind: gameplay.causality_kind || null,
+        delta_logical_time: gameplay.recent_feedback?.delta_logical_time ?? null,
+        delta_event_seq: gameplay.recent_feedback?.delta_event_seq ?? null,
+      },
+      blocker: {
+        label: blockerLabel,
+        detail: gameplay.next_step_hint || gameplay.blocker_detail || null,
+      },
+      world_read: {
+        agents: agents.length,
+        routes: agents.filter((agent) => agent.location_id).length,
+        fragments: fragments.length,
+        hotspots: 0,
+      },
+    },
+    presentation: input.presentation || { world_bounds_label: "bounds", marker_truth_note: "truth" },
+  };
+  return renderState;
+}
+function useTestRustRenderState() {
+  runtimeMock.deriveRenderState = vi.fn((input) => buildTestRustRenderState(input));
+}
+function sampleSnapshot() {
+  return {
+    time: 12,
+    config: {
+      space: {
+        width_cm: 10_000_000,
+        depth_cm: 5_000_000,
+        height_cm: 1_000_000,
+      },
+    },
+    model: {
+      agents: {
+        "agent-0": {
+          id: "agent-0",
+          name: "Agent 0",
+          location_id: "loc-0",
+          resources: {},
+        },
+      },
+      locations: {
+        "loc-0": {
+          id: "loc-0",
+          name: "Factory Anchor",
+          pos: { x_cm: 5_000_000, y_cm: 2_500_000, z_cm: 0 },
+          profile: { radius_cm: 25_000, radiation_emission_per_tick: 0, material: "silicate" },
+          fragment_profile: {
+            blocks: {
+              blocks: [
+                {
+                  origin_cm: { x_cm: 0, y_cm: 0, z_cm: 0 },
+                  size_cm: { x_cm: 12_000, y_cm: 7_500, z_cm: 8_000 },
+                  density_kg_per_m3: 3200,
+                  compounds: {
+                    ppm: {
+                      silicate_matrix: 800_000,
+                      water_ice: 200_000,
+                    },
+                  },
+                },
+                {
+                  origin_cm: { x_cm: 20_000, y_cm: 1_000, z_cm: 18_000 },
+                  size_cm: { x_cm: 20_000, y_cm: 8_000, z_cm: 10_000 },
+                  density_kg_per_m3: 7800,
+                  compounds: {
+                    ppm: {
+                      iron_nickel_alloy: 900_000,
+                      sulfide_ore: 100_000,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          resources: {},
+        },
+      },
+      agent_prompt_profiles: {},
+      agent_execution_debug_contexts: {},
+      agent_player_bindings: {
+        "agent-0": "player-one",
+      },
+      agent_player_public_key_bindings: {
+        "agent-0": "abcdef0123456789abcdef0123456789",
+      },
+    },
+    player_gameplay: {
+      stage_id: "post_onboarding",
+      stage_status: "blocked",
+      execution_state: "blocked",
+      accepted_intent_id: "gameplay_action:build_factory_smelter_mk1",
+      intent_summary: "Queue build_factory_smelter_mk1 for agent-0",
+      intent_scope: "gameplay_action",
+      intent_target: "agent-0",
+      goal_id: "post_onboarding.recover_capability",
+      goal_kind: "RecoverCapability",
+      goal_title: "Recover sustainable capability",
+      objective: "Stabilize the first production line before expanding.",
+      progress_detail: "The primary line is blocked by missing material input.",
+      progress_percent: 68,
+      blocker_kind: "material_shortage",
+      blocker_detail: "iron input exhausted at factory-0",
+      causality_kind: "world_constraint",
+      causality_detail: "iron input exhausted at factory-0",
+      last_world_change: "Smelter build request reached factory-0; iron shortage blocks construction.",
+      blocker_supplemental_detail: null,
+      next_step_hint: "Replenish upstream materials, then advance again to confirm the line resumes.",
+      branch_hint: null,
+      available_actions: [
+        {
+          action_id: "build_factory_smelter_mk1",
+          target_agent_id: "agent-0",
+          label: "Build smelter mk1",
+          protocol_action: "gameplay_action.submit",
+          disabled_reason: null,
+        },
+      ],
+      recent_feedback: {
+        action: "build_factory_smelter_mk1",
+        stage: "completed_no_progress",
+        effect: "Smelter build request reached factory-0; iron shortage blocks construction.",
+        reason: "iron input exhausted at factory-0",
+        hint: "Replenish upstream materials, then advance again.",
+        delta_logical_time: 1,
+        delta_event_seq: 2,
+      },
+      agent_claim: null,
+    },
+  };
+}
+function acceptedOnlySnapshot() {
+  const snapshot = clone(sampleSnapshot());
+  const gameplay = snapshot.player_gameplay;
+  gameplay.stage_status = "executing";
+  gameplay.execution_state = "accepted";
+  gameplay.blocker_kind = null;
+  gameplay.blocker_detail = null;
+  gameplay.causality_kind = null;
+  gameplay.causality_detail = null;
+  gameplay.last_world_change = null;
+  gameplay.recent_feedback = {
+    action: "build_factory_smelter_mk1",
+    stage: "accepted",
+    effect: null,
+    reason: null,
+    hint: "Build request queued for agent-0.",
+    delta_logical_time: 0,
+    delta_event_seq: 1,
+  };
+  return snapshot;
+}
+function noReceiptSnapshot() {
+  const snapshot = clone(sampleSnapshot());
+  const gameplay = snapshot.player_gameplay;
+  gameplay.stage_status = "running";
+  delete gameplay.execution_state;
+  delete gameplay.accepted_intent_id;
+  delete gameplay.intent_summary;
+  delete gameplay.intent_scope;
+  delete gameplay.intent_target;
+  delete gameplay.blocker_kind;
+  delete gameplay.blocker_detail;
+  delete gameplay.causality_kind;
+  delete gameplay.causality_detail;
+  delete gameplay.last_world_change;
+  gameplay.progress_detail = "The first production line is waiting for a player command.";
+  gameplay.recent_feedback = null;
+  return snapshot;
+}
+function emptyWorldSnapshot() {
+  const snapshot = clone(noReceiptSnapshot());
+  snapshot.model.agents = {};
+  snapshot.model.locations = {};
+  snapshot.model.agent_prompt_profiles = {};
+  snapshot.model.agent_execution_debug_contexts = {};
+  snapshot.model.agent_player_bindings = {};
+  snapshot.model.agent_player_public_key_bindings = {};
+  return snapshot;
+}
+function bindFirstSnapshotAgentForTest(core, snapshot) {
+  const agentId = Object.keys(snapshot?.model?.agents || {})[0];
+  const playerId = snapshot?.model?.agent_player_bindings?.[agentId];
+  if (!agentId || !playerId) {
+    return;
+  }
+  core.state.auth = {
+    ...core.state.auth,
+    available: true,
+    playerId,
+    publicKey: snapshot?.model?.agent_player_public_key_bindings?.[agentId] || "abcdef0123456789abcdef0123456789",
+    privateKey: "private-key-must-stay-hidden",
+    source: "local_test_api_ephemeral",
+    registrationStatus: "registered",
+    runtimeStatus: "registered",
+    boundAgentId: agentId,
+  };
+}
+async function renderPixelWorldHost(snapshot = sampleSnapshot(), search = "?test_api=1&connect=0&locale=en", locale = "en") {
+  activeCleanup?.();
+  activeCleanup = null;
+  vi.resetModules();
+  window.history.replaceState({}, "", `/software_safe.html${search}`);
+  window.localStorage.clear();
+  document.body.innerHTML = "";
+  const core = await import("./legacy_core.js");
+  const { PixelWorldHost } = await import("./pixel_world_host.jsx");
+  core.setViewerLocale(locale);
+  core.injectSnapshot(snapshot);
+  bindFirstSnapshotAgentForTest(core, snapshot);
+  const view = render(() => <PixelWorldHost locale={locale} />);
+  activeCleanup = view.unmount;
+  return {
+    core,
+    ...view,
+  };
+}
+function cleanupMountedHost() {
+  activeCleanup?.();
+  activeCleanup = null;
+}
+beforeEach(() => {
+  runtimeMock.deriveRenderState = null;
+  runtimeMock.mountError = null;
+  runtimeMock.mountGates = [];
+  runtimeMock.mountResults = [];
+  runtimeMock.mountCalls = 0;
+  runtimeMock.onEvent = null;
+  canvasContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({});
+  window.history.replaceState({}, "", "/software_safe.html?test_api=1&connect=0&locale=en");
+  window.localStorage.clear();
+  document.body.removeAttribute("data-viewer-visual-fixture");
+  document.body.innerHTML = "";
+});
+afterEach(() => {
+  activeCleanup?.();
+  activeCleanup = null;
+  canvasContextSpy?.mockRestore();
+  canvasContextSpy = null;
+  document.body.removeAttribute("data-viewer-visual-fixture");
+  document.body.innerHTML = "";
+});
+
+export {
+  HEAVY_UI_TEST_TIMEOUT_MS,
+  buildTestRustRenderState,
+  cleanupMountedHost,
+  clone,
+  emptyWorldSnapshot,
+  noReceiptSnapshot,
+  acceptedOnlySnapshot,
+  bindFirstSnapshotAgentForTest,
+  renderPixelWorldHost,
+  runtimeMock,
+  sampleSnapshot,
+  testHarness,
+  useTestRustRenderState,
+};

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot.jsx
@@ -88,6 +88,7 @@ export function PixelWorldHotspot(props) {
       class="pixel-world-hotspot"
       data-hotspot-kind={hotspot().kind}
       data-hotspot-hit-target="44"
+      data-renderer-target={props.rendererProjection ? 'true' : undefined}
       disabled={!visible()}
       tabIndex={visible() ? 0 : -1}
       aria-hidden={!visible()}
@@ -96,8 +97,8 @@ export function PixelWorldHotspot(props) {
         display: visible() ? undefined : "none",
         "--hotspot-projected-x": props.style?.left,
         "--hotspot-projected-y": props.style?.top,
-        left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
-        top: `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`,
+        left: props.rendererProjection ? props.style?.left : `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
+        top: props.rendererProjection ? props.style?.top : `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`,
       }}
       title={`${hotspot().kind}:${hotspot().label}`}
       aria-label={pixelWorldHotspotAccessibleLabel(props.locale, hotspot())}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_probe.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_probe.js
@@ -21,7 +21,7 @@ export function installPixelWorldHotspotPointerProbe({
   getHoverSelection,
   getHoveredHotspot,
 }) {
-  if (typeof window === "undefined" || !["hotspot_tooltip", "recent_event_glyphs"].includes(fixtureName)) {
+  if (typeof window === "undefined" || !["hotspot_tooltip", "recent_event_glyphs", "routes_and_events"].includes(fixtureName)) {
     return () => {};
   }
 
@@ -51,6 +51,10 @@ export function installPixelWorldHotspotPointerProbe({
       }));
       dispatchMove(point.clientX, point.clientY);
       await nextFrame();
+      for (let frame = 0; frame < 8 && getHoveredHotspot()?.id !== hotspot.id; frame += 1) {
+        dispatchMove(point.clientX, point.clientY);
+        await nextFrame();
+      }
       const visibleHotspot = getHoveredHotspot();
       return {
         ...receiptBase(),

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_hotspot_projection.js
@@ -42,6 +42,7 @@ export function pixelWorldHotspotStyle(
   worldBounds,
   index = 0,
   cameraState,
+  stageSize = { width: PIXEL_WORLD_CANVAS_WIDTH, height: PIXEL_WORLD_CANVAS_HEIGHT },
 ) {
   const fallback = {
     left: `${20 + ((index % 4) * 16)}%`,
@@ -57,11 +58,11 @@ export function pixelWorldHotspotStyle(
     };
   }
 
-  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
+  const point = toCanvasPoint(position, worldBounds, stageSize.width, stageSize.height, cameraState);
 
   return {
-    left: `${(point.x / PIXEL_WORLD_CANVAS_WIDTH) * 100}%`,
-    top: `${(point.y / PIXEL_WORLD_CANVAS_HEIGHT) * 100}%`,
+    left: `${(point.x / stageSize.width) * 100}%`,
+    top: `${(point.y / stageSize.height) * 100}%`,
     width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
     height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
     transform: "translate(-50%, -50%)",

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_identity.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_identity.js
@@ -20,6 +20,41 @@ function humanizeAgentId(id) {
   return words.length > 0 ? `Agent ${words.join(" ")}` : "";
 }
 
+function stableMarkerHash(value) {
+  let hash = 2166136261;
+  for (const character of String(value)) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36).toUpperCase().padStart(4, "0").slice(-4);
+}
+
+/**
+ * Return a compact, deterministic marker code for a rendered entity.
+ *
+ * The visible token is deliberately short, while the stable hash keeps
+ * same-label entities distinguishable without depending on array order.
+ */
+export function pixelWorldEntityMarkerCode(entity, fallbackId = "", kind = "agent") {
+  const id = String(entity?.id || fallbackId || "unknown").trim() || "unknown";
+  const prefix = kind === "location" ? "L" : "A";
+  // The runtime entity domain uses `agent-<n>` and `loc-<n>`. Keep those
+  // compact codes, while preserving distinct codes for compatibility-shaped
+  // IDs such as `agent_0` that are not the canonical runtime spelling.
+  const numericId = kind === "location"
+    ? id.match(/^loc-(\d+)$/i)?.[1]
+    : id.match(/^agent-(\d+)$/i)?.[1];
+  if (numericId) {
+    return `${prefix}${numericId}`;
+  }
+  const token = id
+    .replace(/^(?:agent|location|loc)[-_]?/i, "")
+    .replace(/[^a-z0-9]+/gi, "")
+    .toUpperCase()
+    .slice(0, 4) || "X";
+  return `${prefix}${token}-${stableMarkerHash(`${kind}:${id}`)}`;
+}
+
 export function pixelWorldReadableAgentLabel(agent, fallbackId = "", isLocaleZh = false) {
   const { id, explicitLabel, hasExplicitLabel } = agentIdentityParts(agent, fallbackId);
   const numericAgentId = id.match(/^agent[-_](\d+)$/i);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_identity.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_identity.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { pixelWorldReadableAgentLabel, pixelWorldReadableEntityText, pixelWorldSelectedEntityLabel } from "./pixel_world_identity.js";
+import {
+  pixelWorldEntityMarkerCode,
+  pixelWorldReadableAgentLabel,
+  pixelWorldReadableEntityText,
+  pixelWorldSelectedEntityLabel,
+} from "./pixel_world_identity.js";
 
 const visualState = {
   agents: [{ id: "agent-0", name: "Survey Agent" }],
@@ -31,5 +36,34 @@ describe("pixel world player-facing identity", () => {
     expect(pixelWorldSelectedEntityLabel(visualState, { kind: "location", id: "location-0" })).toBe("Location 0");
     expect(pixelWorldSelectedEntityLabel(visualState, { kind: "location", id: "location-0" }, true)).toBe("地点 0");
     expect(pixelWorldSelectedEntityLabel({ ...visualState, locations: [] }, { kind: "location", id: "loc-42" })).toBe("Location 42");
+  });
+
+  it("derives deterministic type-scoped marker codes from stable ids", () => {
+    const agents = [
+      { id: "agent-builder", name: "Shared Name" },
+      { id: "agent-factory", name: "Shared Name" },
+      { id: "agent-0", name: "Shared Name" },
+    ];
+    const reorderedCodes = agents
+      .slice()
+      .reverse()
+      .map((agent) => pixelWorldEntityMarkerCode(agent, "", "agent"));
+    const originalCodes = agents.map((agent) => pixelWorldEntityMarkerCode(agent, "", "agent"));
+
+    expect(new Set(originalCodes).size).toBe(originalCodes.length);
+    const originalById = new Map(agents.map((agent, index) => [agent.id, originalCodes[index]]));
+    agents.slice().reverse().forEach((agent, index) => {
+      expect(reorderedCodes[index]).toBe(originalById.get(agent.id));
+    });
+    expect(pixelWorldEntityMarkerCode({ id: "loc-0" }, "", "location")).not.toBe(
+      pixelWorldEntityMarkerCode({ id: "agent-0" }, "", "agent"),
+    );
+  });
+
+  it("keeps canonical id variants collision-free", () => {
+    const canonical = pixelWorldEntityMarkerCode({ id: "agent-0" }, "", "agent");
+    const underscoreVariant = pixelWorldEntityMarkerCode({ id: "agent_0" }, "", "agent");
+    expect(canonical).toBe("A0");
+    expect(underscoreVariant).not.toBe(canonical);
   });
 });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
@@ -29,6 +29,7 @@ export function pixelWorldMarkerClearance(marker, panels, bounds) {
 
 export function applyPixelWorldMarkerClearance(canvasRoot) {
   if (!canvasRoot) return;
+  if (canvasRoot.dataset.rendererProjection === 'true') return;
   const markers = [...canvasRoot.querySelectorAll('button.pixel-world-entity, button.pixel-world-hotspot')];
   for (const marker of markers) marker.style.translate = '';
   const visibleRect = (node) => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
@@ -1,0 +1,59 @@
+const GAP = 8;
+const PANELS = '[data-viewer-overlay="feed"], [data-viewer-overlay="next-move"], [data-viewer-overlay="receipt"], [data-viewer-overlay="navigation"], [data-viewer-overlay="cinematic-entry"], [data-focus-hud="true"], .pixel-world-canvas__selection, .pixel-world-canvas__sparse-guidance, .pixel-world-canvas__legend';
+
+// Find the nearest free presentation position; entity/world coordinates stay intact.
+export function pixelWorldMarkerClearance(marker, panels, bounds) {
+  const width = marker.right - marker.left;
+  const height = marker.bottom - marker.top;
+  const xs = [marker.left, bounds.left + GAP, bounds.right - width - GAP];
+  const ys = [marker.top, bounds.top + GAP, bounds.bottom - height - GAP];
+  for (const panel of panels) {
+    xs.push(panel.left - width - GAP, panel.right + GAP);
+    ys.push(panel.top - height - GAP, panel.bottom + GAP);
+  }
+  let best = null;
+  let distance = Infinity;
+  for (const left of xs) for (const top of ys) {
+    const right = left + width;
+    const bottom = top + height;
+    if (left < bounds.left + GAP || right > bounds.right - GAP || top < bounds.top + GAP || bottom > bounds.bottom - GAP) continue;
+    if (panels.some((panel) => left < panel.right + GAP && right > panel.left - GAP && top < panel.bottom + GAP && bottom > panel.top - GAP)) continue;
+    const nextDistance = (left - marker.left) ** 2 + (top - marker.top) ** 2;
+    if (nextDistance < distance) {
+      distance = nextDistance;
+      best = { x: left - marker.left, y: top - marker.top };
+    }
+  }
+  return best || { x: 0, y: 0 };
+}
+
+export function applyPixelWorldMarkerClearance(canvasRoot) {
+  if (!canvasRoot) return;
+  const markers = [...canvasRoot.querySelectorAll('button.pixel-world-entity, button.pixel-world-hotspot')];
+  for (const marker of markers) marker.style.translate = '';
+  const visibleRect = (node) => {
+    if (getComputedStyle(node).visibility === 'hidden' || getComputedStyle(node).display === 'none') return null;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 ? rect : null;
+  };
+  const panels = [...document.querySelectorAll(PANELS)].map(visibleRect).filter(Boolean);
+  const canvas = canvasRoot.getBoundingClientRect();
+  const bounds = { left: Math.max(0, canvas.left), top: Math.max(0, canvas.top), right: Math.min(window.innerWidth, canvas.right), bottom: Math.min(window.innerHeight, canvas.bottom) };
+  const positions = new Map();
+  for (const marker of markers) {
+    const rect = visibleRect(marker);
+    if (!rect) continue;
+    const key = marker.dataset.agentId ? `agent:${marker.dataset.agentId}` : marker;
+    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds);
+    marker.style.translate = `${offset.x}px ${offset.y}px`;
+    if (!positions.has(key)) panels.push({ left: rect.left + offset.x, right: rect.right + offset.x, top: rect.top + offset.y, bottom: rect.bottom + offset.y });
+    positions.set(key, offset);
+  }
+}
+
+export function observePixelWorldMarkerPanels(sync) {
+  if (typeof ResizeObserver === 'undefined') return () => {};
+  const observer = new ResizeObserver(sync);
+  for (const panel of document.querySelectorAll(PANELS)) observer.observe(panel);
+  return () => observer.disconnect();
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.js
@@ -2,7 +2,7 @@ const GAP = 8;
 const PANELS = '[data-viewer-overlay="feed"], [data-viewer-overlay="next-move"], [data-viewer-overlay="receipt"], [data-viewer-overlay="navigation"], [data-viewer-overlay="cinematic-entry"], [data-focus-hud="true"], .pixel-world-canvas__selection, .pixel-world-canvas__sparse-guidance, .pixel-world-canvas__legend';
 
 // Find the nearest free presentation position; entity/world coordinates stay intact.
-export function pixelWorldMarkerClearance(marker, panels, bounds) {
+export function pixelWorldMarkerClearance(marker, panels, bounds, fallback = { x: 0, y: 0 }) {
   const width = marker.right - marker.left;
   const height = marker.bottom - marker.top;
   const xs = [marker.left, bounds.left + GAP, bounds.right - width - GAP];
@@ -24,14 +24,25 @@ export function pixelWorldMarkerClearance(marker, panels, bounds) {
       best = { x: left - marker.left, y: top - marker.top };
     }
   }
-  return best || { x: 0, y: 0 };
+  return best || fallback;
 }
 
 export function applyPixelWorldMarkerClearance(canvasRoot) {
   if (!canvasRoot) return;
   if (canvasRoot.dataset.rendererProjection === 'true') return;
   const markers = [...canvasRoot.querySelectorAll('button.pixel-world-entity, button.pixel-world-hotspot')];
-  for (const marker of markers) marker.style.translate = '';
+  const fallbacks = new Map();
+  for (const marker of markers) {
+    // The mobile pass already prioritizes the selected command edge when the
+    // panels leave no free hit box. Retain that fallback, never stale offsets.
+    const selected = marker.matches(".pixel-world-entity--canvas-hit-target[data-selected='true']");
+    const previous = selected ? marker.getBoundingClientRect() : null;
+    marker.style.translate = '';
+    if (previous) {
+      const reset = marker.getBoundingClientRect();
+      fallbacks.set(marker, { x: previous.left - reset.left, y: previous.top - reset.top });
+    }
+  }
   const visibleRect = (node) => {
     if (getComputedStyle(node).visibility === 'hidden' || getComputedStyle(node).display === 'none') return null;
     const rect = node.getBoundingClientRect();
@@ -45,7 +56,7 @@ export function applyPixelWorldMarkerClearance(canvasRoot) {
     const rect = visibleRect(marker);
     if (!rect) continue;
     const key = marker.dataset.agentId ? `agent:${marker.dataset.agentId}` : marker;
-    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds);
+    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds, fallbacks.get(marker));
     marker.style.translate = `${offset.x}px ${offset.y}px`;
     if (!positions.has(key)) panels.push({ left: rect.left + offset.x, right: rect.right + offset.x, top: rect.top + offset.y, bottom: rect.bottom + offset.y });
     positions.set(key, offset);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { pixelWorldMarkerClearance } from './pixel_world_marker_clearance.js';
+
+describe('actionable marker overlay clearance', () => {
+  it('gives unselected desktop entities the same 44px minimum hit area', async () => {
+    const css = await readFile('viewer_terminal_shell.css', 'utf8');
+    const globalMarkerRule = css.slice(css.indexOf('/* Markers stay terse;')).match(/\.pixel-world-entity\s*\{([^}]+)\}/)?.[1];
+    expect(globalMarkerRule).toMatch(/min-width:\s*44px/);
+    expect(globalMarkerRule).toMatch(/min-height:\s*44px/);
+    expect(globalMarkerRule).toMatch(/box-sizing:\s*border-box/);
+  });
+  const rect = (left, top, right, bottom) => ({ left, top, right, bottom });
+  it.each([
+    [390, 844, rect(253, 353, 297, 397), [rect(10, 266, 380, 363), rect(252, 371, 380, 469)]],
+    [320, 844, rect(85, 344, 129, 388), [rect(10, 266, 310, 363)]],
+    [1440, 1000, rect(448, 620, 492, 664), [rect(16, 652, 776, 880)]],
+    [1440, 1000, rect(408, 654, 452, 698), [rect(16, 652, 776, 880)]],
+  ])('clears rendered panels at %i by %i without shrinking targets', (width, height, marker, panels) => {
+    const offset = pixelWorldMarkerClearance(marker, panels, rect(0, 0, width, height));
+    const moved = rect(marker.left + offset.x, marker.top + offset.y, marker.right + offset.x, marker.bottom + offset.y);
+    expect(moved.right - moved.left).toBe(44);
+    expect(moved.bottom - moved.top).toBe(44);
+    for (const panel of panels) expect(moved.right <= panel.left - 8 || moved.left >= panel.right + 8 || moved.bottom <= panel.top - 8 || moved.top >= panel.bottom + 8).toBe(true);
+    expect(pixelWorldMarkerClearance(moved, panels, rect(0, 0, width, height))).toEqual({ x: 0, y: 0 });
+  });
+  it('retains the original projection when already clear', () => {
+    expect(pixelWorldMarkerClearance(rect(100, 100, 144, 144), [rect(200, 200, 300, 300)], rect(0, 0, 400, 800))).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_marker_clearance.test.js
@@ -11,6 +11,13 @@ describe('actionable marker overlay clearance', () => {
     expect(globalMarkerRule).toMatch(/box-sizing:\s*border-box/);
   });
   const rect = (left, top, right, bottom) => ({ left, top, right, bottom });
+  it('uses the prioritized fallback only when no free placement exists', () => {
+    const marker = rect(170,319,214,363);
+    const bounds = rect(0,0,390,844);
+    const fallback = {x:0,y:-105};
+    expect(pixelWorldMarkerClearance(marker, [rect(0,0,390,260),rect(0,266,390,844)], bounds, fallback)).toEqual(fallback);
+    expect(pixelWorldMarkerClearance(marker, [], bounds, fallback)).toEqual({x:0,y:0});
+  });
   it.each([
     [390, 844, rect(253, 353, 297, 397), [rect(10, 266, 380, 363), rect(252, 371, 380, 469)]],
     [320, 844, rect(85, 344, 129, 388), [rect(10, 266, 310, 363)]],

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
@@ -1,10 +1,16 @@
+import { applyPixelWorldMarkerClearance, observePixelWorldMarkerPanels } from './pixel_world_marker_clearance.js';
 const MOBILE_SHELL_MAX_WIDTH = 640;
 const SAFE_AREA_GAP_PX = 8;
 
 export function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, commandTop, feedBottom = 0 }) {
   const clearCommandOffset = Math.min(0, commandTop - SAFE_AREA_GAP_PX - markerBottom);
   const clearFeedOffset = feedBottom + SAFE_AREA_GAP_PX - markerTop;
-  return Math.max(clearCommandOffset, clearFeedOffset);
+  // The marker must satisfy both edges: above the bottom decision band and
+  // below the top Feed band. When the bands leave no room for its hit box,
+  // prioritize the command edge so the selected target remains reachable.
+  if (clearCommandOffset < 0) return clearCommandOffset;
+  if (clearFeedOffset > 0) return clearFeedOffset;
+  return 0;
 }
 
 export function pixelWorldMobileSelectionChipOffset({ chipTop, feedBottom = 0, feedOpen = false }) {
@@ -16,7 +22,7 @@ export function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
   return hudRight + SAFE_AREA_GAP_PX - markerLeft;
 }
 
-export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+function applyMobileSelectionSafeArea(canvasRoot) {
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
   const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
@@ -58,6 +64,11 @@ export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   marker.style.translate = `0 ${Math.floor(offset)}px`;
 }
 
+export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+  applyMobileSelectionSafeArea(canvasRoot);
+  applyPixelWorldMarkerClearance(canvasRoot);
+}
+
 export function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const sync = () => applyPixelWorldMobileSelectionSafeArea(canvasRoot());
   window.addEventListener("resize", sync);
@@ -66,7 +77,9 @@ export function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
   feed?.addEventListener("toggle", sync, true);
   requestAnimationFrame(sync);
+  const stopObservingPanels = observePixelWorldMarkerPanels(() => requestAnimationFrame(sync));
   return () => {
+    stopObservingPanels();
     window.removeEventListener("resize", sync);
     focusStateObserver.disconnect();
     feed?.removeEventListener("toggle", sync, true);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.js
@@ -1,4 +1,5 @@
 import { applyPixelWorldMarkerClearance, observePixelWorldMarkerPanels } from './pixel_world_marker_clearance.js';
+import { applyRendererDecisionClearance } from './pixel_world_renderer_decision_area.js';
 const MOBILE_SHELL_MAX_WIDTH = 640;
 const SAFE_AREA_GAP_PX = 8;
 
@@ -23,6 +24,7 @@ export function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
 }
 
 function applyMobileSelectionSafeArea(canvasRoot) {
+  if (canvasRoot?.dataset.rendererProjection === 'true') return;
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
   const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
@@ -65,6 +67,7 @@ function applyMobileSelectionSafeArea(canvasRoot) {
 }
 
 export function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+  applyRendererDecisionClearance(canvasRoot);
   applyMobileSelectionSafeArea(canvasRoot);
   applyPixelWorldMarkerClearance(canvasRoot);
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
@@ -1,7 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyPixelWorldMobileSelectionSafeArea } from './pixel_world_mobile_safe_area.js';
 import { pixelWorldMobileFocusSelectionOffset, pixelWorldMobileSelectionChipOffset, pixelWorldMobileSelectionOffset } from "./pixel_world_mobile_safe_area.js";
 
 describe("pixel world mobile selection safe area", () => {
+  afterEach(() => { document.body.innerHTML = ''; vi.unstubAllGlobals(); });
+  it('retains selected command-edge fallback through the complete cramped mobile clearance pipeline', () => {
+    vi.stubGlobal('innerWidth', 390);
+    vi.stubGlobal('innerHeight', 844);
+    document.body.innerHTML = `<div id="canvas"><button class="pixel-world-entity pixel-world-entity--canvas-hit-target" data-selected="true"></button></div><div data-viewer-overlay="feed"></div><div data-viewer-overlay="next-move"></div>`;
+    const canvas = document.querySelector('#canvas');
+    const marker = canvas.querySelector('button');
+    const rect = (left, top, width, height) => ({left,top,right:left+width,bottom:top+height,width,height});
+    canvas.getBoundingClientRect = () => rect(0,0,390,844);
+    marker.getBoundingClientRect = () => rect(170,319 + (parseFloat(marker.style.translate.split(' ')[1]) || 0),44,44);
+    document.querySelector('[data-viewer-overlay="feed"]').getBoundingClientRect = () => rect(0,0,390,260);
+    document.querySelector('[data-viewer-overlay="next-move"]').getBoundingClientRect = () => rect(0,266,390,578);
+    applyPixelWorldMobileSelectionSafeArea(canvas);
+    expect(marker.getBoundingClientRect().bottom).toBe(258);
+    applyPixelWorldMobileSelectionSafeArea(canvas);
+    expect(marker.getBoundingClientRect().bottom).toBe(258);
+  });
   it("clears the command band while preserving the Feed gap", () => {
     expect(pixelWorldMobileSelectionOffset({ markerTop: 520, markerBottom: 566, commandTop: 420, feedBottom: 146 })).toBe(-154);
     expect(pixelWorldMobileSelectionOffset({ markerTop: 267, markerBottom: 313, commandTop: 208, feedBottom: 146 })).toBe(-113);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_mobile_safe_area.test.js
@@ -5,6 +5,7 @@ describe("pixel world mobile selection safe area", () => {
   it("clears the command band while preserving the Feed gap", () => {
     expect(pixelWorldMobileSelectionOffset({ markerTop: 520, markerBottom: 566, commandTop: 420, feedBottom: 146 })).toBe(-154);
     expect(pixelWorldMobileSelectionOffset({ markerTop: 267, markerBottom: 313, commandTop: 208, feedBottom: 146 })).toBe(-113);
+    expect(pixelWorldMobileSelectionOffset({ markerTop: 319, markerBottom: 363, commandTop: 266, feedBottom: 260 })).toBe(-105);
   });
 
   it("moves the selected marker beside an expanded Focus HUD", () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_presentation.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_presentation.js
@@ -1,0 +1,188 @@
+function isZhLocale(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+
+function localized(locale, zh, en) {
+  return isZhLocale(locale) ? zh : en;
+}
+
+function normalizedToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, "_");
+}
+
+const BLOCKER_PRESENTATIONS = {
+  runtime_snapshot_empty_entities: {
+    label: ["尚未发布世界实体", "No published entities yet"],
+    reason: [
+      "权威快照尚未发布可用的 Agent 或地点。",
+      "The authoritative snapshot has no published agents or locations yet.",
+    ],
+    nextAction: [
+      "重新加载权威快照，或等待第一个世界实体发布。",
+      "Reload the authoritative snapshot or wait for the first published entity.",
+    ],
+  },
+  material_shortage: {
+    label: ["缺料", "Missing Material"],
+    reason: ["当前行动缺少已发布的物料投入。", "The current action is missing a published material input."],
+    nextAction: ["先恢复物料流，再重新检查下一步。", "Restore material flow, then recheck the next step."],
+  },
+  power_shortage: {
+    label: ["缺电", "Missing Power"],
+    reason: ["当前行动缺少已发布的供电能力。", "The current action is missing published power capacity."],
+    nextAction: ["先恢复供电，再重新检查下一步。", "Restore power, then recheck the next step."],
+  },
+  governance_gate: {
+    label: ["治理限制", "Governance Restriction"],
+    reason: ["当前行动缺少已发布的许可或治理前提。", "The current action is missing a published permission or governance prerequisite."],
+    nextAction: ["先满足许可或治理前提，再重新检查下一步。", "Satisfy the permission or governance prerequisite, then recheck the next step."],
+  },
+  no_progress: {
+    label: ["没有前进", "No Forward Progress"],
+    reason: ["最近一次已确认执行没有产生新的世界进展。", "The latest confirmed execution produced no new world progress."],
+    nextAction: ["查看明确回执与下一步提示，再决定是否重试。", "Read the explicit receipt and next step before retrying."],
+  },
+  runtime_sync_unavailable: {
+    label: ["运行时同步不可用", "Runtime Sync Unavailable"],
+    reason: ["权威运行时同步当前不可验证。", "Authoritative runtime sync is not verifiable right now."],
+    nextAction: ["重试权威快照同步。", "Retry the authoritative snapshot sync."],
+  },
+  execution_world_not_ready: {
+    label: ["执行世界未就绪", "Execution World Not Ready"],
+    reason: ["执行所需的权威世界状态尚未就绪。", "The authoritative world state required for execution is not ready."],
+    nextAction: ["等待或重新加载权威世界状态。", "Wait for or reload the authoritative world state."],
+  },
+  product_validation: {
+    label: ["产品验证失败", "Product Validation Failed"],
+    reason: ["当前请求未通过已发布的产品验证。", "The current request did not pass published product validation."],
+    nextAction: ["修正请求前提，再重新检查可用动作。", "Correct the request prerequisites, then recheck available actions."],
+  },
+  product_validation_rejected: {
+    label: ["产品验证失败", "Product Validation Failed"],
+    reason: ["当前请求在执行前被已发布的产品规则拒绝。", "The current request was rejected by published product rules before execution."],
+    nextAction: ["修正请求前提，再重新检查可用动作。", "Correct the request prerequisites, then recheck available actions."],
+  },
+};
+
+export function pixelWorldBlockerPresentation(code, locale) {
+  const rawCode = String(code || "").trim();
+  const token = normalizedToken(rawCode);
+  const copy = BLOCKER_PRESENTATIONS[token];
+  if (!copy) {
+    return {
+      code: rawCode || null,
+      label: localized(locale, "当前阻塞", "Current blocker"),
+      reason: localized(locale, "当前阻塞原因尚未发布可读说明。", "A readable reason for the current blocker has not been published."),
+      nextAction: localized(locale, "等待下一次权威状态更新。", "Wait for the next authoritative state update."),
+    };
+  }
+  return {
+    code: rawCode || token,
+    label: localized(locale, copy.label[0], copy.label[1]),
+    reason: localized(locale, copy.reason[0], copy.reason[1]),
+    nextAction: localized(locale, copy.nextAction[0], copy.nextAction[1]),
+  };
+}
+
+const CONNECTION_PRESENTATIONS = {
+  connected: ["世界连接：在线", "World connection: ONLINE", "online"],
+  connecting: ["世界连接：连接中", "World connection: CONNECTING", "connecting"],
+  reconnecting: ["世界连接：重新连接中", "World connection: RECONNECTING", "reconnecting"],
+  closed: ["世界连接：已关闭", "World connection: CLOSED", "closed"],
+  error: ["世界连接：离线", "World connection: OFFLINE", "offline"],
+};
+
+export function pixelWorldConnectionPresentation(status, locale) {
+  const token = normalizedToken(status);
+  const copy = CONNECTION_PRESENTATIONS[token] || CONNECTION_PRESENTATIONS.error;
+  return {
+    label: localized(locale, copy[0], copy[1]),
+    state: copy[2],
+    className: `badge pixel-world-readout__connection pixel-world-readout__connection--${copy[2]}`,
+  };
+}
+
+const FEED_PRESENTATIONS = {
+  loading: ["动态新鲜度：同步中", "Feed freshness: SYNCING", "syncing"],
+  ready: ["动态新鲜度：实时", "Feed freshness: LIVE", "live"],
+  empty: ["动态新鲜度：暂无动态", "Feed freshness: NO EVENTS", "empty"],
+  replay: ["动态新鲜度：回放", "Feed freshness: REPLAY", "replay"],
+  gap: ["动态新鲜度：断档", "Feed freshness: GAP", "gap"],
+  unavailable: ["动态新鲜度：不可用", "Feed freshness: UNAVAILABLE", "unavailable"],
+};
+
+export function pixelWorldFeedFreshnessPresentation(status, stale = false, locale) {
+  const token = normalizedToken(status);
+  const copy = token === "ready" && stale
+    ? ["动态新鲜度：陈旧", "Feed freshness: STALE", "stale"]
+    : FEED_PRESENTATIONS[token] || FEED_PRESENTATIONS.unavailable;
+  return {
+    label: localized(locale, copy[0], copy[1]),
+    state: copy[2],
+    className: `badge pixel-world-readout__feed pixel-world-readout__feed--${copy[2]}`,
+  };
+}
+
+const LIFECYCLE_LABELS = {
+  active: ["进行中", "active"],
+  resolved: ["已解决", "resolved"],
+  timed_out: ["已超时", "timed out"],
+};
+
+export function pixelWorldMajorEventPresentation(event, locale) {
+  const value = event || {};
+  const lifecycleToken = normalizedToken(value.lifecycle);
+  const lifecycle = LIFECYCLE_LABELS[lifecycleToken];
+  const numericSeverity = Number(value.severity);
+  const hasSeverity = Number.isInteger(numericSeverity) && numericSeverity >= 1 && numericSeverity <= 5;
+  const severity = hasSeverity ? String(numericSeverity) : "unknown";
+  const severityText = hasSeverity
+    ? localized(locale, `严重度 ${severity}`, `severity ${severity}`)
+    : localized(locale, "严重度未发布", "severity unavailable");
+  const lifecycleText = lifecycle
+    ? localized(locale, `危机${lifecycle[0]}`, `Crisis ${lifecycle[1]}`)
+    : localized(locale, "危机状态已记录", "Crisis lifecycle recorded");
+  const lifecycleState = lifecycleToken && lifecycle ? lifecycleToken : "recorded";
+  return {
+    label: `${lifecycleText} · ${severityText}`,
+    severity,
+    lifecycle: lifecycleState,
+    shape: `severity-${severity} lifecycle-${lifecycleState}`,
+  };
+}
+
+function worldBoundValue(bounds, snakeName, camelName) {
+  const value = bounds?.[snakeName] ?? bounds?.[camelName];
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function countValue(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : 0;
+}
+
+export function pixelWorldSparseScenePresentation(data = {}, locale) {
+  const routeCount = countValue(data.routeCount ?? data.routes);
+  const terrainCount = countValue(data.terrainCount ?? data.terrain);
+  const locationCount = countValue(data.locationCount ?? data.locations);
+  const agentCount = countValue(data.agentCount ?? data.agents);
+  const width = worldBoundValue(data.worldBounds, "width_cm", "widthCm");
+  const depth = worldBoundValue(data.worldBounds, "depth_cm", "depthCm");
+  return {
+    routes: routeCount === 0
+      ? localized(locale, "此快照没有已发布路线", "No published routes in this snapshot")
+      : localized(locale, `已发布路线：${routeCount}`, `Published routes: ${routeCount}`),
+    terrain: terrainCount === 0
+      ? localized(locale, "此快照没有已发布地形", "No published terrain in this snapshot")
+      : localized(locale, `已发布地形：${terrainCount}`, `Published terrain: ${terrainCount}`),
+    entities: localized(locale, `已发布实体：${agentCount} 个 Agent · ${locationCount} 个地点`, `Published entities: ${agentCount} agents · ${locationCount} locations`),
+    bounds: width != null && depth != null
+      ? localized(locale, `已发布范围：${width} × ${depth} cm`, `Published bounds: ${width} × ${depth} cm`)
+      : localized(locale, "范围未发布", "Published bounds unavailable"),
+    hasSparseTopology: routeCount === 0 || terrainCount === 0,
+  };
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_presentation.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_presentation.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  pixelWorldBlockerPresentation,
+  pixelWorldConnectionPresentation,
+  pixelWorldFeedFreshnessPresentation,
+  pixelWorldMajorEventPresentation,
+  pixelWorldSparseScenePresentation,
+} from "./pixel_world_presentation.js";
+
+describe("pixel world player presentation", () => {
+  it("localizes the empty entity blocker and keeps its protocol code out of player copy", () => {
+    const english = pixelWorldBlockerPresentation("runtime_snapshot_empty_entities", "en");
+    expect(english).toMatchObject({
+      label: "No published entities yet",
+      reason: "The authoritative snapshot has no published agents or locations yet.",
+      nextAction: "Reload the authoritative snapshot or wait for the first published entity.",
+    });
+    expect(`${english.label} ${english.reason} ${english.nextAction}`).not.toContain("runtime_snapshot_empty_entities");
+
+    const chinese = pixelWorldBlockerPresentation("runtime_snapshot_empty_entities", "zh-CN");
+    expect(chinese.label).toBe("尚未发布世界实体");
+    expect(`${chinese.reason} ${chinese.nextAction}`).not.toContain("runtime_snapshot_empty_entities");
+  });
+
+  it("maps other known blocker codes to readable labels without exposing raw enums", () => {
+    expect(pixelWorldBlockerPresentation("material_shortage", "en").label).toBe("Missing Material");
+    expect(pixelWorldBlockerPresentation("power_shortage", "zh-CN").label).toBe("缺电");
+    expect(pixelWorldBlockerPresentation("unknown_internal_code", "en").label).toBe("Current blocker");
+  });
+
+  it("keeps world connection and feed freshness as separate status scopes", () => {
+    expect(pixelWorldConnectionPresentation("connecting", "en")).toMatchObject({
+      label: "World connection: CONNECTING",
+      state: "connecting",
+    });
+    expect(pixelWorldConnectionPresentation("closed", "zh-CN").label).toBe("世界连接：已关闭");
+    expect(pixelWorldFeedFreshnessPresentation("ready", false, "en")).toMatchObject({
+      label: "Feed freshness: LIVE",
+      state: "live",
+    });
+    expect(pixelWorldFeedFreshnessPresentation("ready", true, "en").label).toBe("Feed freshness: STALE");
+  });
+
+  it("presents published crisis severity and lifecycle without implying action success", () => {
+    const active = pixelWorldMajorEventPresentation({ severity: 4, lifecycle: "active" }, "en");
+    expect(active).toMatchObject({
+      label: "Crisis active · severity 4",
+      severity: "4",
+      lifecycle: "active",
+      shape: "severity-4 lifecycle-active",
+    });
+    expect(active.label).not.toMatch(/accepted|success|completed/i);
+
+    const resolved = pixelWorldMajorEventPresentation({ severity: 2, lifecycle: "resolved" }, "zh-CN");
+    expect(resolved.label).toBe("危机已解决 · 严重度 2");
+    expect(resolved.shape).toBe("severity-2 lifecycle-resolved");
+  });
+
+  it("reports absent routes and terrain from actual counts and preserves published bounds", () => {
+    const sparse = pixelWorldSparseScenePresentation({
+      routeCount: 0,
+      terrainCount: 0,
+      locationCount: 1,
+      agentCount: 1,
+      worldBounds: { width_cm: 1000000, depth_cm: 500000 },
+    }, "en");
+    expect(sparse).toMatchObject({
+      routes: "No published routes in this snapshot",
+      terrain: "No published terrain in this snapshot",
+      bounds: "Published bounds: 1000000 × 500000 cm",
+    });
+    expect(sparse.routes).not.toMatch(/route object|terrain object|synthetic/i);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_decision_area.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_decision_area.js
@@ -1,0 +1,25 @@
+const CLEARANCE = 8;
+const MIN_PANEL_HEIGHT = 160;
+
+export function rendererDecisionMaxHeight(panel, viewportHeight, hotspots) {
+  let height = Math.max(MIN_PANEL_HEIGHT, viewportHeight / 2 - 76);
+  for (const hotspot of hotspots) {
+    if (hotspot.right <= panel.left || hotspot.left >= panel.right || hotspot.bottom <= 0 || hotspot.top >= viewportHeight) continue;
+    height = Math.min(height, panel.bottom - hotspot.bottom - CLEARANCE);
+  }
+  // An edge event must not make primary actions or receipts unreachable.
+  // Keep a scrollable decision surface even when complete clearance is impossible.
+  return Math.max(MIN_PANEL_HEIGHT, Math.floor(height));
+}
+
+export function applyRendererDecisionClearance(canvasRoot) {
+  if (canvasRoot?.dataset.rendererProjection !== 'true') return;
+  const host = canvasRoot.closest('.pixel-world-host');
+  const panel = host?.querySelector('.pixel-world-decision-area');
+  if (!panel) return;
+  const hotspots = [...canvasRoot.querySelectorAll('.pixel-world-hotspot[data-renderer-target="true"]')]
+    .filter(node => getComputedStyle(node).display !== 'none')
+    .map(node => node.getBoundingClientRect());
+  const height = rendererDecisionMaxHeight(panel.getBoundingClientRect(),window.innerHeight,hotspots);
+  panel.style.setProperty('--renderer-decision-max-height',`${height}px`);
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_decision_area.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_decision_area.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { rendererDecisionMaxHeight } from './pixel_world_renderer_decision_area.js';
+
+describe('renderer decision panel clearance', () => {
+  const rect = (left,top,right,bottom) => ({left,top,right,bottom});
+  it('puts desktop and narrow event glyphs above the scrollable panel', () => {
+    expect(rendererDecisionMaxHeight(rect(16,0,776,884),900,[rect(367,590,411,634)])).toBe(242);
+    expect(rendererDecisionMaxHeight(rect(10,0,380,834),844,[rect(90,551,134,595)])).toBe(231);
+  });
+  it('keeps a usable panel for near-bottom events and ignores offscreen events', () => {
+    const panel = rect(10,0,380,834);
+    expect(rendererDecisionMaxHeight(panel,844,[rect(90,798,134,842)])).toBe(160);
+    expect(rendererDecisionMaxHeight(panel,844,[rect(90,850,134,894)])).toBe(346);
+    expect(rendererDecisionMaxHeight(panel,844,[rect(400,551,444,595)])).toBe(346);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_target_input.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_target_input.js
@@ -1,0 +1,11 @@
+export function forwardRendererTargetPointer(event) {
+  const canvas = event.currentTarget.closest('.pixel-world-canvas')?.querySelector('canvas');
+  if (!canvas) return;
+  // Capture belongs to the renderer, so subsequent drag/up events keep the
+  // same native pointer identity and use its existing click-suppression path.
+  canvas.dispatchEvent(new PointerEvent('pointerdown', {
+    clientX:event.clientX, clientY:event.clientY, pointerId:event.pointerId,
+    pointerType:event.pointerType, button:event.button, buttons:event.buttons,
+    isPrimary:event.isPrimary,
+  }));
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_target_input.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_target_input.test.js
@@ -1,0 +1,13 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { forwardRendererTargetPointer } from './pixel_world_renderer_target_input.js';
+
+afterEach(()=>vi.unstubAllGlobals());
+it('delegates the original pointer identity and coordinates to renderer capture', () => {
+  class Pointer extends Event { constructor(type,properties){super(type);Object.assign(this,properties);} }
+  vi.stubGlobal('PointerEvent',Pointer);
+  const root=document.createElement('div');root.className='pixel-world-canvas';
+  root.innerHTML='<canvas></canvas><button></button>';
+  const received=vi.fn();root.querySelector('canvas').addEventListener('pointerdown',received);
+  forwardRendererTargetPointer({currentTarget:root.querySelector('button'),clientX:120,clientY:210,pointerId:27,pointerType:'touch',button:0,buttons:1,isPrimary:true});
+  expect(received.mock.calls[0][0]).toMatchObject({clientX:120,clientY:210,pointerId:27,pointerType:'touch',buttons:1});
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
@@ -3,6 +3,7 @@ import { toCanvasPoint } from './pixel_world_hotspot_projection.js';
 import { pixelWorldVisualState } from './pixel_world_visual_clarity.jsx';
 import { pixelWorldReadableAgentLabel } from './pixel_world_identity.js';
 import { isLocaleZh } from './legacy_core.js';
+import { forwardRendererTargetPointer } from './pixel_world_renderer_target_input.js';
 
 // Mirrors the renderer's logical-canvas projection, including missing-position
 // presentation. Never apply collision offsets to a true world hit target.
@@ -30,6 +31,7 @@ export function PixelWorldRendererTargets(props) {
     aria-label={`${isZh() ? '选择' : 'Select'} ${kind === 'agent' ? pixelWorldReadableAgentLabel(entity, entity.id, isZh()) : entity.label || entity.id}`}
     style={rendererEntityTargetStyle(entity,state().worldBounds,props.stageSize(),props.cameraState?.())}
     onClick={() => props.onSelect({kind,id:entity.id})}
+    onPointerDown={forwardRendererTargetPointer}
     onMouseEnter={() => props.onHover({kind,id:entity.id})}
     onMouseLeave={() => props.onHover(null)} />}</For>;
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
@@ -1,4 +1,4 @@
-import { For } from 'solid-js';
+import { createMemo, For } from 'solid-js';
 import { toCanvasPoint } from './pixel_world_hotspot_projection.js';
 import { pixelWorldVisualState } from './pixel_world_visual_clarity.jsx';
 import { pixelWorldReadableAgentLabel } from './pixel_world_identity.js';
@@ -16,22 +16,32 @@ export function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
 }
 
 export function PixelWorldRendererTargets(props) {
-  const state = () => pixelWorldVisualState(props.renderState());
+  const state = createMemo(() => pixelWorldVisualState(props.renderState()));
   const isZh = () => isLocaleZh(props.locale());
-  const entities = () => [...state().agents.map(entity => ({entity,kind:'agent'})), ...(state().worldBounds ? state().locations.filter(entity => entity.pos) : []).map(entity => ({entity,kind:'location'}))];
-  return <For each={entities()}>{({entity,kind}) => <button type="button"
+  // Solid's For retains nodes by key; snapshot objects are replaced routinely.
+  // Keep kind/id keys stable while reading labels and positions from the latest map.
+  const entities = createMemo(() => new Map([
+    ...state().agents.map(entity => [JSON.stringify(['agent', entity.id]), entity]),
+    ...(state().worldBounds ? state().locations.filter(entity => entity.pos) : [])
+      .map(entity => [JSON.stringify(['location', entity.id]), entity]),
+  ]));
+  const keys = createMemo(() => [...entities().keys()]);
+  return <For each={keys()}>{key => {
+    const [kind] = JSON.parse(key);
+    const entity = createMemo(previous => entities().get(key) || previous);
+    return <button type="button"
     class="pixel-world-entity pixel-world-renderer-target"
-    data-agent-id={kind === 'agent' ? entity.id : undefined}
-    data-location-id={kind === 'location' ? entity.id : undefined}
+    data-agent-id={kind === 'agent' ? entity().id : undefined}
+    data-location-id={kind === 'location' ? entity().id : undefined}
     data-pixel-world-agent-marker={kind === 'agent' ? 'true' : undefined}
     data-pixel-world-location-marker={kind === 'location' ? 'true' : undefined}
     data-renderer-target="true"
-    data-selected={props.selection()?.kind === kind && props.selection()?.id === entity.id ? 'true' : 'false'}
-    aria-pressed={props.selection()?.kind === kind && props.selection()?.id === entity.id}
-    aria-label={`${isZh() ? '选择' : 'Select'} ${kind === 'agent' ? pixelWorldReadableAgentLabel(entity, entity.id, isZh()) : entity.label || entity.id}`}
-    style={rendererEntityTargetStyle(entity,state().worldBounds,props.stageSize(),props.cameraState?.())}
-    onClick={() => props.onSelect({kind,id:entity.id})}
+    data-selected={props.selection()?.kind === kind && props.selection()?.id === entity().id ? 'true' : 'false'}
+    aria-pressed={props.selection()?.kind === kind && props.selection()?.id === entity().id}
+    aria-label={`${isZh() ? '选择' : 'Select'} ${kind === 'agent' ? pixelWorldReadableAgentLabel(entity(), entity().id, isZh()) : entity().label || entity().id}`}
+    style={rendererEntityTargetStyle(entity(),state().worldBounds,props.stageSize(),props.cameraState?.())}
+    onClick={() => props.onSelect({kind,id:entity().id})}
     onPointerDown={forwardRendererTargetPointer}
-    onMouseEnter={() => props.onHover({kind,id:entity.id})}
-    onMouseLeave={() => props.onHover(null)} />}</For>;
+    onMouseEnter={() => props.onHover({kind,id:entity().id})}
+    onMouseLeave={() => props.onHover(null)} />; }}</For>;
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
@@ -1,0 +1,35 @@
+import { For } from 'solid-js';
+import { toCanvasPoint } from './pixel_world_hotspot_projection.js';
+import { pixelWorldVisualState } from './pixel_world_visual_clarity.jsx';
+import { pixelWorldReadableAgentLabel } from './pixel_world_identity.js';
+import { isLocaleZh } from './legacy_core.js';
+
+// Mirrors the renderer's logical-canvas projection, including missing-position
+// presentation. Never apply collision offsets to a true world hit target.
+export function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
+  const { width, height } = size;
+  const idLength = new TextEncoder().encode(entity.id || '').length;
+  const point = toCanvasPoint(entity.pos, worldBounds, width, height, camera)
+    || toCanvasPoint({ x_cm: 36 + (idLength * 29) % Math.max(40, width - 72), y_cm: 44 + (idLength * 17) % Math.max(48, height - 88) }, { width_cm: width, depth_cm: height }, width, height, camera);
+  return { left: `${point.x / width * 100}%`, top: `${point.y / height * 100}%`, width: '44px', height: '44px', transform: 'translate(-50%, -50%)', display: point.x < 0 || point.y < 0 || point.x > width || point.y > height ? 'none' : undefined };
+}
+
+export function PixelWorldRendererTargets(props) {
+  const state = () => pixelWorldVisualState(props.renderState());
+  const isZh = () => isLocaleZh(props.locale());
+  const entities = () => [...state().agents.map(entity => ({entity,kind:'agent'})), ...(state().worldBounds ? state().locations.filter(entity => entity.pos) : []).map(entity => ({entity,kind:'location'}))];
+  return <For each={entities()}>{({entity,kind}) => <button type="button"
+    class="pixel-world-entity pixel-world-renderer-target"
+    data-agent-id={kind === 'agent' ? entity.id : undefined}
+    data-location-id={kind === 'location' ? entity.id : undefined}
+    data-pixel-world-agent-marker={kind === 'agent' ? 'true' : undefined}
+    data-pixel-world-location-marker={kind === 'location' ? 'true' : undefined}
+    data-renderer-target="true"
+    data-selected={props.selection()?.kind === kind && props.selection()?.id === entity.id ? 'true' : 'false'}
+    aria-pressed={props.selection()?.kind === kind && props.selection()?.id === entity.id}
+    aria-label={`${isZh() ? '选择' : 'Select'} ${kind === 'agent' ? pixelWorldReadableAgentLabel(entity, entity.id, isZh()) : entity.label || entity.id}`}
+    style={rendererEntityTargetStyle(entity,state().worldBounds,props.stageSize(),props.cameraState?.())}
+    onClick={() => props.onSelect({kind,id:entity.id})}
+    onMouseEnter={() => props.onHover({kind,id:entity.id})}
+    onMouseLeave={() => props.onHover(null)} />}</For>;
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.jsx
@@ -12,7 +12,7 @@ export function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
   const idLength = new TextEncoder().encode(entity.id || '').length;
   const point = toCanvasPoint(entity.pos, worldBounds, width, height, camera)
     || toCanvasPoint({ x_cm: 36 + (idLength * 29) % Math.max(40, width - 72), y_cm: 44 + (idLength * 17) % Math.max(48, height - 88) }, { width_cm: width, depth_cm: height }, width, height, camera);
-  return { left: `${point.x / width * 100}%`, top: `${point.y / height * 100}%`, width: '44px', height: '44px', transform: 'translate(-50%, -50%)', display: point.x < 0 || point.y < 0 || point.x > width || point.y > height ? 'none' : undefined };
+  return { left: `${point.x / width * 100}%`, top: `${point.y / height * 100}%`, width: '44px', height: '44px', transform: 'translate(-50%, -50%)', display: point.x + 22 <= 0 || point.y + 22 <= 0 || point.x - 22 >= width || point.y - 22 >= height ? 'none' : undefined };
 }
 
 export function PixelWorldRendererTargets(props) {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
@@ -6,6 +6,45 @@ import { PixelWorldRendererTargets, rendererEntityTargetStyle } from './pixel_wo
 describe('real renderer accessible projection', () => {
   const bounds = { width_cm: 1000, depth_cm: 1000 };
   const agent = { id: 'agent-0', pos: { x_cm: 250, y_cm: 600 } };
+  it('retains focused targets across snapshots while updating data, geometry and membership', async () => {
+    const other = { id: 'agent-1', pos: { x_cm: 100, y_cm: 200 } };
+    const location = { id: agent.id, label: 'Depot', pos: { x_cm: 300, y_cm: 400 } };
+    const snapshot = () => ({ world_bounds: bounds, agents: [{...agent}, {...other}], locations: [{...location}] });
+    const [state, setState] = createSignal(snapshot());
+    const [selection, setSelection] = createSignal(null);
+    const select = vi.fn();
+    const hover = vi.fn();
+    const size = { width: 960, height: 540 };
+    const view = render(() => <PixelWorldRendererTargets locale={() => 'en'} renderState={state} stageSize={() => size} selection={selection} onSelect={select} onHover={hover} />);
+    const target = view.container.querySelector('[data-agent-id="agent-0"]');
+    const depot = view.getByRole('button', {name: 'Select Depot'});
+    target.focus();
+    setState(snapshot());
+    expect(view.container.querySelector('[data-agent-id="agent-0"]')).toBe(target);
+    expect(document.activeElement).toBe(target);
+    const moved = {...agent, label: 'Courier', pos: { x_cm: 700, y_cm: 300 }};
+    setState({world_bounds: bounds, agents: [moved, {...other}], locations: [{...location, label: 'Warehouse'}]});
+    expect(target).toHaveAccessibleName('Select Courier');
+    expect(target.style.left).toBe(rendererEntityTargetStyle(moved, bounds, size).left);
+    expect(document.activeElement).toBe(target);
+    expect(view.getByRole('button', {name: 'Select Warehouse'})).toBe(depot);
+    setSelection({kind: 'agent', id: agent.id});
+    expect(target).toHaveAttribute('aria-pressed', 'true');
+    expect(depot).toHaveAttribute('aria-pressed', 'false');
+    setState({world_bounds: bounds, agents: [{...other}, {...moved}], locations: [{...location}]});
+    expect([...view.container.querySelectorAll('[data-agent-id]')].map(node => node.dataset.agentId)).toEqual(['agent-1', 'agent-0']);
+    expect(view.container.querySelector('[data-agent-id="agent-0"]')).toBe(target);
+    await fireEvent.click(target);
+    await fireEvent.mouseEnter(target);
+    expect(select).toHaveBeenCalledWith({kind: 'agent', id: agent.id});
+    expect(hover).toHaveBeenCalledWith({kind: 'agent', id: agent.id});
+    setState({world_bounds: bounds, agents: [{...moved}], locations: []});
+    expect(view.getByRole('button')).toBe(target);
+    expect(depot.isConnected).toBe(false);
+    setState({world_bounds: bounds, agents: [], locations: []});
+    expect(target.isConnected).toBe(false);
+    expect(view.queryByRole('button')).toBeNull();
+  });
   it('normalizes Chinese locale aliases and does not synthesize absent renderer locations', () => {
     const view = render(() => <PixelWorldRendererTargets locale={() => 'zh-CN'} renderState={() => ({ agents: [{id:'agent-0'}], locations:[{id:'location-0',pos:{x_cm:1,y_cm:1}}] })} stageSize={() => ({width:960,height:540})} selection={() => null} onSelect={() => {}} onHover={() => {}} />);
     expect(view.getByRole('button')).toHaveAccessibleName('选择 行动体 0');

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
@@ -4,6 +4,12 @@ import { createSignal } from 'solid-js';
 import { PixelWorldRendererTargets, rendererEntityTargetStyle } from './pixel_world_renderer_targets.jsx';
 
 describe('real renderer accessible projection', () => {
+  it('keeps partially visible hit boxes at each edge until their full bounds leave the canvas', () => {
+    for (const [x, y, visible] of [[-1,50,true],[101,50,true],[50,-1,true],[50,101,true],[-22,50,false],[122,50,false],[50,-22,false],[50,122,false]]) {
+      const style = rendererEntityTargetStyle({id:'edge',pos:{x_cm:50,y_cm:50}}, {width_cm:100,depth_cm:100}, {width:100,height:100}, {pan_x_px:x-50,pan_y_px:y-50});
+      expect(style.display, `${x},${y}`).toBe(visible ? undefined : 'none');
+    }
+  });
   const bounds = { width_cm: 1000, depth_cm: 1000 };
   const agent = { id: 'agent-0', pos: { x_cm: 250, y_cm: 600 } };
   it('retains focused targets across snapshots while updating data, geometry and membership', async () => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_renderer_targets.test.jsx
@@ -1,0 +1,36 @@
+import { render, fireEvent } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { createSignal } from 'solid-js';
+import { PixelWorldRendererTargets, rendererEntityTargetStyle } from './pixel_world_renderer_targets.jsx';
+
+describe('real renderer accessible projection', () => {
+  const bounds = { width_cm: 1000, depth_cm: 1000 };
+  const agent = { id: 'agent-0', pos: { x_cm: 250, y_cm: 600 } };
+  it('normalizes Chinese locale aliases and does not synthesize absent renderer locations', () => {
+    const view = render(() => <PixelWorldRendererTargets locale={() => 'zh-CN'} renderState={() => ({ agents: [{id:'agent-0'}], locations:[{id:'location-0',pos:{x_cm:1,y_cm:1}}] })} stageSize={() => ({width:960,height:540})} selection={() => null} onSelect={() => {}} onHover={() => {}} />);
+    expect(view.getByRole('button')).toHaveAccessibleName('选择 行动体 0');
+    expect(view.container.querySelector('[data-location-id]')).toBeNull();
+  });
+  it('centers the hit area over the camera-focused GPU agent rather than the old world-percent marker', () => {
+    const style = rendererEntityTargetStyle(agent, bounds, { width: 1440, height: 900 }, { zoom: 1, pan_x_px: 350, pan_y_px: -86 });
+    expect(style.left).toBe('50%');
+    expect(style.top).toBe('50%');
+    expect(style.transform).toBe('translate(-50%, -50%)');
+    expect(style.width).toBe('44px');
+  });
+  it('updates pan, zoom and resize without changing selection identity', async () => {
+    const [camera, setCamera] = createSignal({ zoom: 1, pan_x_px: 0, pan_y_px: 0 });
+    const [size, setSize] = createSignal({ width: 1440, height: 900 });
+    const select = vi.fn();
+    const view = render(() => <PixelWorldRendererTargets locale={() => 'en'} renderState={() => ({ world_bounds: bounds, agents: [agent], locations: [] })} cameraState={camera} stageSize={size} selection={() => ({kind:'agent',id:'agent-0'})} onSelect={select} onHover={() => {}} />);
+    const target = view.getByRole('button');
+    const initial = target.style.left;
+    setCamera({ zoom: 2, pan_x_px: 200, pan_y_px: -86 });
+    expect(target.style.left).not.toBe(initial);
+    setSize({ width: 390, height: 844 });
+    expect(target.style.left).toBe(rendererEntityTargetStyle(agent,bounds,size(),camera()).left);
+    await fireEvent.click(target);
+    expect(select).toHaveBeenCalledWith({kind:'agent',id:'agent-0'});
+    expect(view.container.querySelectorAll('[data-agent-id="agent-0"]')).toHaveLength(1);
+  });
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_route_fixture.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_route_fixture.test.js
@@ -1,0 +1,11 @@
+import { expect, it } from 'vitest';
+import { pixelWorldRoutesAndEventsVisualFixture, pixelWorldSelectedBlockerVisualFixture } from './pixel_world_visual_fixture_data.js';
+
+it('publishes explicit current assignment authority while retaining an honest no-route control', () => {
+  const route = pixelWorldRoutesAndEventsVisualFixture();
+  for (const agent of Object.values(route.model.agents)) {
+    expect(agent.relation).toEqual({kind:'agent_assignment',status:'active',source_class:'runtime_projection',freshness:'current'});
+    expect(route.model.locations[agent.location_id].pos).not.toEqual(agent.pos);
+  }
+  expect(pixelWorldSelectedBlockerVisualFixture().model.agents['agent-0'].relation).toBeUndefined();
+});

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
@@ -241,6 +241,7 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
   function startAnimationLoop() {
     stopAnimationLoop();
     reducedMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
+    runtime.set_reduced_motion(reducedMotion);
     if (reducedMotion || !canTick()) return;
     const generation = animationGeneration;
     const tick = (animationMs) => {
@@ -270,6 +271,7 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
     const mediaQuery = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)");
     const onMotionChange = (event) => {
       reducedMotion = event.matches === true;
+      runtime.set_reduced_motion(reducedMotion);
       if (reducedMotion) stopAnimationLoop(); else resume();
     };
     mediaQuery?.addEventListener?.("change", onMotionChange);

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.js
@@ -354,6 +354,9 @@ export async function createPixelWorldBridge({ onEvent, onFatal } = {}) {
       canvas.style.cursor = "default";
       runtime.pointer_move(0, 0, true, event.pointerId ?? -1);
       syncRuntime();
+      // Accessible DOM controls can set hover without changing Rust's hover
+      // key. Leaving the canvas clears that presentation state as well.
+      onEvent?.({ type: "hover_entity", selection: null });
     };
 
     const onPointerUp = (event) => {

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.test.js
@@ -446,6 +446,18 @@ describe("pixel world wasm runtime bridge", () => {
     }
   });
 
+  it("clears DOM-origin hover on canvas leave even when the runtime has no hover transition", async () => {
+    animationHarness();
+    const { createPixelWorldBridge } = await import("./pixel_world_runtime_module_wasm.js");
+    const onEvent = vi.fn();
+    const bridge = await createPixelWorldBridge({ onEvent });
+    const canvas = document.createElement('canvas');
+    bridge.mount(canvas, {});
+    canvas.dispatchEvent(pointerEvent('pointerleave'));
+    expect(onEvent).toHaveBeenCalledWith({ type: 'hover_entity', selection: null });
+    bridge.unmount();
+  });
+
   it("caps WASM ambient ticks at 12Hz while leaving pointer input immediate", async () => {
     const animation = animationHarness();
     const { createPixelWorldBridge } = await import("./pixel_world_runtime_module_wasm.js");

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.test.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_runtime_module_wasm.test.js
@@ -91,6 +91,7 @@ vi.mock("./pixel_world_bridge_bindgen.js", () => {
       this.wheel = vi.fn();
       this.click = vi.fn();
       this.tick = vi.fn();
+      this.set_reduced_motion = vi.fn();
       this.unmount = vi.fn(() => ({ status: "detached" }));
       this.update = vi.fn(() => ({ status: "ready" }));
       this.mount = vi.fn((canvas, renderState) => {
@@ -495,8 +496,12 @@ describe("pixel world wasm runtime bridge", () => {
     bridge.mount(canvas, { selection: null });
     expect(mediaQuery.addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
     mediaChange?.({ matches: true });
+    expect(runtimeState.instances[0].set_reduced_motion).toHaveBeenLastCalledWith(true);
     expect(runtimeState.instances[0].tick).toHaveBeenCalledTimes(1);
     expect(animation.runNext(100)).toBe(false);
+    mediaQuery.matches = false;
+    mediaChange?.({ matches: false });
+    expect(runtimeState.instances[0].set_reduced_motion).toHaveBeenLastCalledWith(false);
     bridge.unmount();
     expect(mediaQuery.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
   });

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_visual_clarity.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_visual_clarity.jsx
@@ -1,0 +1,157 @@
+import { For, Index, Show } from "solid-js";
+import * as core from "./legacy_core.js";
+import { pixelWorldEntityMarkerCode, pixelWorldReadableAgentLabel } from "./pixel_world_identity.js";
+
+const FRAGMENT_TERRAIN_PALETTE = {
+  silicate_matrix: [126, 144, 99], iron_nickel_alloy: [176, 184, 196], water_ice: [125, 211, 252],
+  hydrated_mineral: [96, 165, 250], carbonaceous_organic: [120, 113, 108], sulfide_ore: [202, 138, 4],
+  rare_earth_oxide: [167, 139, 250], uranium_bearing_ore: [132, 204, 22], thorium_bearing_ore: [244, 114, 182],
+  unknown: [148, 163, 184],
+};
+
+function tr(locale, zh, en) { return core.isLocaleZh(locale) ? zh : en; }
+function safeNumber(value, fallback = 0) { const number = Number(value); return Number.isFinite(number) ? number : fallback; }
+function colorToCss(color, alpha = 0.36) {
+  const [red, green, blue] = Array.isArray(color) ? color : FRAGMENT_TERRAIN_PALETTE.unknown;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
+function clampRatio(value) { return Math.min(1, Math.max(0, Number(value) || 0)); }
+export function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
+  if (!pos || !worldBounds) return fallbackStyle;
+  const point = worldPercentPoint(pos, worldBounds, 8, 10);
+  return { left: `${point.x.toFixed(1)}%`, top: `${point.y.toFixed(1)}%` };
+}
+export function agentMarkerStyle(agent, index, worldBounds) {
+  const base = toWorldPercentStyle(agent.pos, worldBounds, { left: `${18 + ((index % 5) * 15)}%`, top: `${14 + (Math.floor(index / 5) * 22)}%` });
+  const offsets = [[-18, -18], [18, -18], [-18, 18], [18, 18], [0, -30], [0, 30], [-30, 0], [30, 0], [-28, -28], [28, 28]];
+  const [x, y] = offsets[index % offsets.length] || [0, 0];
+  return { ...base, transform: `translate(${x}px, ${y}px)` };
+}
+function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
+  if (!pos || !worldBounds) return { x: fallbackX, y: fallbackY };
+  return { x: 8 + (clampRatio(pos.x_cm / Math.max(1, worldBounds.width_cm)) * 84), y: 10 + (clampRatio(pos.y_cm / Math.max(1, worldBounds.depth_cm)) * 78) };
+}
+const FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO = 9 / 16;
+export function routeStyle(link, worldBounds, index) {
+  const fallbackFrom = { x: 14 + ((index % 5) * 15), y: 18 + (Math.floor(index / 5) * 14) };
+  const fallbackTo = { x: fallbackFrom.x + 14, y: fallbackFrom.y + 8 };
+  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
+  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
+  const deltaX = to.x - from.x; const deltaY = to.y - from.y;
+  const scaledDeltaY = deltaY * FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO;
+  const length = Math.max(4, Math.hypot(deltaX, scaledDeltaY));
+  const angle = Math.atan2(scaledDeltaY, deltaX) * (180 / Math.PI);
+  return { left: `${from.x.toFixed(1)}%`, top: `${from.y.toFixed(1)}%`, width: `${length.toFixed(1)}%`, opacity: `${0.32 + (clampRatio(link.emphasis ?? 0.72) * 0.38)}`, transform: `rotate(${angle.toFixed(1)}deg)`, "transform-origin": "0 50%" };
+}
+export function fragmentTerrainStyle(patch, worldBounds, index) {
+  const sizePx = Math.max(12, Math.min(48, safeNumber(patch.footprint_cm, 1) / 840));
+  return { ...toWorldPercentStyle(patch.pos, worldBounds, { left: `${12 + ((index % 6) * 13)}%`, top: `${16 + (Math.floor(index / 6) * 13)}%` }), width: `${sizePx.toFixed(1)}px`, height: `${sizePx.toFixed(1)}px`, "background-color": colorToCss(patch.color), transform: "translate(-50%, -50%)" };
+}
+export function routeWaypointStyle(link, worldBounds, index, stop) {
+  const fallbackFrom = { x: 14 + ((index % 5) * 15), y: 18 + (Math.floor(index / 5) * 14) };
+  const fallbackTo = { x: fallbackFrom.x + 14, y: fallbackFrom.y + 8 };
+  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
+  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
+  const ratio = stop === "to" ? 1 : 0.52;
+  return { left: `${(from.x + ((to.x - from.x) * ratio)).toFixed(1)}%`, top: `${(from.y + ((to.y - from.y) * ratio)).toFixed(1)}%` };
+}
+export function fieldValue(value, snakeName, camelName, fallback = undefined) {
+  if (!value || typeof value !== "object") return fallback;
+  if (value[snakeName] !== undefined) return value[snakeName];
+  if (camelName && value[camelName] !== undefined) return value[camelName];
+  return fallback;
+}
+function explicitLinkEndpointIds(link) {
+  if (!link || typeof link !== "object") return { agent: [], location: [] };
+  const endpoint = (names) => names.map((name) => fieldValue(link, name, name.replace(/_([a-z])/g, (_, character) => character.toUpperCase()), null)).filter((value) => value != null && String(value).trim()).map((value) => String(value).trim());
+  const explicit = {
+    agent: endpoint(["agent_id", "source_agent_id", "target_agent_id", "from_agent_id", "to_agent_id"]),
+    location: endpoint(["location_id", "source_location_id", "target_location_id", "from_location_id", "to_location_id"]),
+  };
+  return explicit;
+}
+function hasAuthoritativeAssignment(agent) {
+  const envelope = [agent?.relation, agent?.assignment].find((candidate) => candidate && typeof candidate === "object");
+  return envelope?.kind === "agent_assignment"
+    && envelope?.status === "active"
+    && envelope?.source_class === "runtime_projection"
+    && envelope?.freshness === "current";
+}
+function linkReferencesSelection(link, selection, agents) {
+  if (!selection?.id || !selection?.kind) return false;
+  const endpointIds = explicitLinkEndpointIds(link);
+  if ((selection.kind === "agent" ? endpointIds.agent : endpointIds.location).includes(String(selection.id))) {
+    return true;
+  }
+  if (link?.kind !== "agent_assignment" || link?.status !== "active" || link?.source_class !== "runtime_projection" || link?.freshness !== "current") {
+    return false;
+  }
+  return agents.some((agent) => {
+    const agentId = String(agent?.id || "").trim();
+    const locationId = String(fieldValue(agent, "location_id", "locationId", "")).trim();
+    if (!agentId || !locationId || !hasAuthoritativeAssignment(agent)) {
+      return false;
+    }
+    if (link.id !== `link:${agentId}:${locationId}`) {
+      return false;
+    }
+    return selection.kind === "agent" ? selection.id === agentId : selection.id === locationId;
+  });
+}
+function terrainReferencesSelection(patch, selection) {
+  return selection?.kind === "location" && String(fieldValue(patch, "location_id", "locationId", "")).trim() === String(selection.id);
+}
+export function arrayField(value, snakeName, camelName) {
+  const candidate = fieldValue(value, snakeName, camelName, []);
+  return Array.isArray(candidate) ? candidate : [];
+}
+function normalizeVisualEntity(entry) {
+  if (!entry || typeof entry !== "object") return entry;
+  return { ...entry, location_id: fieldValue(entry, "location_id", "locationId", null), marker_role: fieldValue(entry, "marker_role", "markerRole", null), marker_alpha: fieldValue(entry, "marker_alpha", "markerAlpha", undefined), position_source: fieldValue(entry, "position_source", "positionSource", null), dominant_compound: fieldValue(entry, "dominant_compound", "dominantCompound", undefined), footprint_cm: fieldValue(entry, "footprint_cm", "footprintCm", undefined) };
+}
+export function pixelWorldVisualState(renderState) {
+  const state = renderState || {};
+  return { worldBounds: fieldValue(state, "world_bounds", "worldBounds", null), fragmentTerrain: arrayField(state, "fragment_terrain", "fragmentTerrain").map(normalizeVisualEntity), links: arrayField(state, "links", "links"), locations: arrayField(state, "locations", "locations").map(normalizeVisualEntity), agents: arrayField(state, "agents", "agents").map(normalizeVisualEntity), selection: fieldValue(state, "selection", "selection", null), goalHighlight: fieldValue(state, "goal_highlight", "goalHighlight", null), blockerHighlight: fieldValue(state, "blocker_highlight", "blockerHighlight", null), visualHotspots: arrayField(state, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity) };
+}
+
+export function PixelWorldCanvasAgentHitTargets(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return <For each={visualState().agents.slice(0, 10)}>{(agent, index) => {
+    const label = pixelWorldReadableAgentLabel(agent, agent.id, core.isLocaleZh(props.locale()));
+    return <button type="button" class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target" data-pixel-world-agent-marker="true" data-agent-id={agent.id} data-marker-code={pixelWorldEntityMarkerCode(agent, agent.id, "agent")} data-position-source={agent.position_source} data-selected={props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false"} aria-pressed={props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${label}`} style={agentMarkerStyle(agent, index(), visualState().worldBounds)} title={label} onMouseEnter={() => props.onHover({ kind: "agent", id: agent.id })} onMouseLeave={() => props.onHover(null)} onClick={() => props.onSelect({ kind: "agent", id: agent.id })}>
+      <span class="pixel-world-entity__code">{pixelWorldEntityMarkerCode(agent, agent.id, "agent")}</span>
+    </button>;
+  }}</For>;
+}
+
+export function PixelWorldHostVisualLayer(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  const selection = () => props.selection?.() || visualState().selection;
+  const projectedAgents = () => visualState().agents;
+  if (!props.enabled) return <></>;
+  return <>
+    <div class="pixel-world-canvas__grid" /><div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one" /><div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two" />
+    <For each={visualState().fragmentTerrain.slice(0, 96)}>{(patch, index) => <div class={`pixel-world-fragment-terrain${terrainReferencesSelection(patch, selection()) ? " pixel-world-fragment-terrain--associated" : selection() ? " pixel-world-fragment-terrain--muted" : ""}`} data-compound={patch.dominant_compound} data-associated={terrainReferencesSelection(patch, selection()) ? "true" : "false"} style={fragmentTerrainStyle(patch, visualState().worldBounds, index())} title={`${patch.location_id}:${patch.dominant_compound}`} />}</For>
+    <For each={visualState().links.slice(0, 10)}>{(link, index) => <>
+      <div class={`pixel-world-route${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route--associated" : selection() ? " pixel-world-route--muted" : ""}`} data-route-id={link.id} data-route-kind={link.kind} data-associated={linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false"} style={routeStyle(link, visualState().worldBounds, index())} title={`${link.kind}:${link.id}`} />
+      <div class={`pixel-world-route-waypoint pixel-world-route-waypoint--mid${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route-waypoint--associated" : selection() ? " pixel-world-route-waypoint--muted" : ""}`} data-route-id={link.id} data-route-kind={link.kind} data-associated={linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false"} style={routeWaypointStyle(link, visualState().worldBounds, index(), "mid")} title={`${link.kind}:waypoint`} />
+      <div class={`pixel-world-route-waypoint pixel-world-route-waypoint--target${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route-waypoint--associated" : selection() ? " pixel-world-route-waypoint--muted" : ""}`} data-route-id={link.id} data-route-kind={link.kind} data-associated={linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false"} style={routeWaypointStyle(link, visualState().worldBounds, index(), "to")} title={`${link.kind}:target`} />
+    </>}</For>
+    <Index each={visualState().locations.slice(0, 8)}>{(location, index) => <button class="pixel-world-entity pixel-world-entity--location" data-pixel-world-location-marker="true" data-location-id={location().id} data-selected={selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false"} data-marker-code={pixelWorldEntityMarkerCode(location(), location().id, "location")} aria-pressed={selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`} data-marker-role={location().marker_role} style={{ ...toWorldPercentStyle(location().pos, visualState().worldBounds, { left: `${12 + ((index % 4) * 21)}%`, top: `${18 + (Math.floor(index / 4) * 26)}%` }), opacity: location().marker_alpha }} title={location().label} onMouseEnter={() => props.onHover({ kind: "location", id: location().id })} onMouseLeave={() => props.onHover(null)} onClick={() => props.onSelect({ kind: "location", id: location().id })}>
+      <span class="pixel-world-entity__code">{pixelWorldEntityMarkerCode(location(), location().id, "location")}</span>
+    </button>}</Index>
+    <Index each={visualState().agents.slice(0, 10)}>{(agent, index) => { const label = () => pixelWorldReadableAgentLabel(agent(), agent().id, core.isLocaleZh(props.locale())); return <button class="pixel-world-entity pixel-world-entity--agent" data-pixel-world-agent-marker="true" data-agent-id={agent().id} data-selected={selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false"} data-marker-code={pixelWorldEntityMarkerCode(agent(), agent().id, "agent")} data-position-source={agent().position_source} aria-pressed={selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false"} aria-label={`${tr(props.locale(), "选择 Agent", "Select Agent")} ${label()}`} style={agentMarkerStyle(agent(), index, visualState().worldBounds)} title={label()} onMouseEnter={() => props.onHover({ kind: "agent", id: agent().id })} onMouseLeave={() => props.onHover(null)} onClick={() => props.onSelect({ kind: "agent", id: agent().id })}>
+      <span class="pixel-world-entity__code">{pixelWorldEntityMarkerCode(agent(), agent().id, "agent")}</span>
+    </button>; }}</Index>
+  </>;
+}
+
+export function PixelWorldCanvasLegend(props) {
+  return <div class="pixel-world-canvas__legend" data-pixel-world-legend="true" aria-label={tr(props.locale(), "世界图例", "World legend")}>
+    <div class="pixel-world-canvas__legend-title">{tr(props.locale(), "图例", "Legend")}</div>
+    <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true" /><span>{tr(props.locale(), "路线", "Route")}</span></div>
+    <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true">◆</span><span>{tr(props.locale(), "目标", "Goal")}</span></div>
+    <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true">!</span><span>{tr(props.locale(), "阻塞", "Blocker")}</span></div>
+    <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true">▪</span><span>{tr(props.locale(), "资源地形", "Resource terrain")}</span></div>
+  </div>;
+}

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_visual_clarity.jsx
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_visual_clarity.jsx
@@ -1,6 +1,7 @@
 import { For, Index, Show } from "solid-js";
 import * as core from "./legacy_core.js";
 import { pixelWorldEntityMarkerCode, pixelWorldReadableAgentLabel } from "./pixel_world_identity.js";
+import { pixelWorldSparseScenePresentation } from "./pixel_world_presentation.js";
 
 const FRAGMENT_TERRAIN_PALETTE = {
   silicate_matrix: [126, 144, 99], iron_nickel_alloy: [176, 184, 196], water_ice: [125, 211, 252],
@@ -154,4 +155,30 @@ export function PixelWorldCanvasLegend(props) {
     <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true">!</span><span>{tr(props.locale(), "阻塞", "Blocker")}</span></div>
     <div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class="pixel-world-canvas__legend-swatch" aria-hidden="true">▪</span><span>{tr(props.locale(), "资源地形", "Resource terrain")}</span></div>
   </div>;
+}
+
+export function PixelWorldSparseSceneGuidance(props) {
+  const visualState = () => pixelWorldVisualState(typeof props.renderState === "function" ? props.renderState() : props.renderState);
+  const presentation = () => pixelWorldSparseScenePresentation({
+    routeCount: visualState().links.length,
+    terrainCount: visualState().fragmentTerrain.length,
+    locationCount: visualState().locations.length,
+    agentCount: visualState().agents.length,
+    worldBounds: visualState().worldBounds,
+  }, typeof props.locale === "function" ? props.locale() : props.locale);
+  return (
+    <Show when={presentation().hasSparseTopology}>
+      <div
+        class="pixel-world-canvas__sparse-guidance"
+        data-pixel-world-sparse-guidance="true"
+        aria-label={tr(typeof props.locale === "function" ? props.locale() : props.locale, "当前世界的已发布数据范围", "Published data coverage for this world")}
+      >
+        <div class="pixel-world-canvas__sparse-title">{tr(typeof props.locale === "function" ? props.locale() : props.locale, "已发布数据范围", "Published data coverage")}</div>
+        <div data-sparse-field="entities">{presentation().entities}</div>
+        <div data-sparse-field="routes">{presentation().routes}</div>
+        <div data-sparse-field="terrain">{presentation().terrain}</div>
+        <div data-sparse-field="bounds">{presentation().bounds}</div>
+      </div>
+    </Show>
+  );
 }

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_visual_fixture.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_visual_fixture.js
@@ -4,6 +4,7 @@ import {
   pixelWorldRecommendedTargetVisualFixture,
   pixelWorldSelectedBlockerVisualFixture,
   pixelWorldModuleVisualEntitiesFixture,
+  pixelWorldRoutesAndEventsVisualFixture,
 } from "./pixel_world_visual_fixture_data.js";
 
 const PIXEL_WORLD_VISUAL_FIXTURE_GLOBAL = "__OASIS7_PIXEL_WORLD_VISUAL_FIXTURES__";
@@ -39,6 +40,7 @@ export function installPixelWorldVisualFixtureHook() {
     selected_blocker: () => core.clone(pixelWorldSelectedBlockerVisualFixture()),
     hotspot_tooltip: () => core.clone(pixelWorldSelectedBlockerVisualFixture()),
     recent_event_glyphs: () => core.clone(pixelWorldSelectedBlockerVisualFixture()),
+    routes_and_events: () => core.clone(pixelWorldRoutesAndEventsVisualFixture()),
     recommended_target: () => core.clone(pixelWorldRecommendedTargetVisualFixture()),
     module_visual_entities: () => core.clone(pixelWorldModuleVisualEntitiesFixture()),
     micro_depot_stock_runway: () => core.clone(pixelWorldMicroDepotStockRunwayVisualFixture()),
@@ -67,7 +69,7 @@ export function installPixelWorldVisualFixtureHook() {
       },
     };
   }
-  if (fixtureName === "recent_event_glyphs") {
+  if (["recent_event_glyphs", "routes_and_events"].includes(fixtureName)) {
     // Test-only input for the real WASM renderer smoke. These event kinds are
     // projected by the bridge into two independent, hoverable visual hotspots.
     core.state.recentEvents = [
@@ -88,6 +90,10 @@ export function installPixelWorldVisualFixtureHook() {
       ...(model.agent_player_public_key_bindings || {}),
       "agent-0": publicKey,
     };
+    if (fixtureName === 'routes_and_events') {
+      model.agent_player_bindings['agent-1'] = playerId;
+      model.agent_player_public_key_bindings['agent-1'] = publicKey;
+    }
     core.state.auth = {
     ...core.state.auth,
     available: true,

--- a/crates/oasis7_viewer/software_safe_src/pixel_world_visual_fixture_data.js
+++ b/crates/oasis7_viewer/software_safe_src/pixel_world_visual_fixture_data.js
@@ -1,4 +1,17 @@
 // Test-only snapshot fixtures for reproducible Pixel World visual evidence.
+export function pixelWorldRoutesAndEventsVisualFixture() {
+  const snapshot = pixelWorldSelectedBlockerVisualFixture();
+  const relation = { kind: 'agent_assignment', status: 'active', source_class: 'runtime_projection', freshness: 'current' };
+  snapshot.model.agents['agent-0'].relation = { ...relation };
+  snapshot.model.agents['agent-1'].relation = { ...relation };
+  snapshot.model.agents['agent-1'].pos = { x_cm: 3_700_000, y_cm: 2_300_000, z_cm: 0 };
+  snapshot.model.locations['loc-0'].pos = { x_cm: 4_300_000, y_cm: 3_100_000, z_cm: 0 };
+  snapshot.model.locations['loc-1'].pos = { x_cm: 5_200_000, y_cm: 2_650_000, z_cm: 0 };
+  snapshot.model.agent_player_bindings['agent-1'] = 'player-one';
+  snapshot.model.agent_player_public_key_bindings['agent-1'] = snapshot.model.agent_player_public_key_bindings['agent-0'];
+  return snapshot;
+}
+
 export function pixelWorldSelectedBlockerVisualFixture() {
   return {
     time: 12,

--- a/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.js
@@ -598,7 +598,7 @@ export function createViewerFeedbackModule({
         case "product_validation_rejected":
           return localeText(locale, "产品验证失败", "Product validation failed");
         default:
-          return resolvedBlockerKind || null;
+          return resolvedBlockerKind ? localeText(locale, "当前阻塞", "Current blocker") : null;
       }
     })();
     const factoryProductionFailureDisposition = normalizeFactoryProductionFailureDisposition(

--- a/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.test.js
+++ b/crates/oasis7_viewer/software_safe_src/viewer_feedback_module.test.js
@@ -14,6 +14,35 @@ function createFeedbackModule(state) {
 }
 
 describe("viewer feedback module", () => {
+  it.each([
+    ["en", "unknown_internal_code", "Current blocker"],
+    ["zh", "unknown_internal_code", "当前阻塞"],
+    ["en", "power_shortage", "Missing Power"],
+    ["zh", "power_shortage", "缺电"],
+    ["en", null, null],
+    ["zh", null, null],
+  ])("keeps the expanded Capability Economics blocker label safe in %s for %s", (locale, blockerKind, expectedLabel) => {
+    const summary = createFeedbackModule({
+      lastGameplayActionFeedback: null,
+      snapshot: {
+        model: { agents: { "agent-0": { id: "agent-0" } }, locations: { base: { id: "base" } } },
+        player_gameplay: {
+          goal_kind: "recover_capability",
+          stage_status: "blocked",
+          blocker_kind: blockerKind,
+          blocker_detail: "diagnostic only",
+          objective: "Restore production",
+        },
+      },
+      uiLocale: locale,
+    }).buildGameplaySummary();
+
+    // main.jsx renders this exact value in the expanded Capability Economics panel.
+    expect(summary.economicSurface.blockerLabel).toBe(expectedLabel);
+    expect(summary.blockerLabel).toBe(expectedLabel);
+    expect(summary.blockerKind).toBe(blockerKind);
+  });
+
   it("preserves camelCase runtime available actions in the gameplay summary", () => {
     const state = {
       lastGameplayActionFeedback: null,

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
@@ -1,5 +1,6 @@
 import { For, Show } from "solid-js";
 import { compareUnsignedDecimal } from "./world_feed_state.js";
+import { pixelWorldMajorEventPresentation } from "./pixel_world_presentation.js";
 
 function readFeed(props) {
   return typeof props.feed === "function" ? props.feed() : props.feed || {};
@@ -90,17 +91,8 @@ function eventKindLabel(event, locale, tr) {
 }
 
 function majorEventStatusCopy(event, locale, tr) {
-  const lifecycle = {
-    active: ["进行中", "active"],
-    resolved: ["已解决", "resolved"],
-    timed_out: ["已超时", "timed out"],
-  }[event?.major_event?.lifecycle];
-  if (!lifecycle) return null;
-  return tr(
-    locale,
-    `危机${lifecycle[0]} · 严重度 ${event.major_event.severity}`,
-    `Crisis ${lifecycle[1]} · severity ${event.major_event.severity}`,
-  );
+  const presentation = pixelWorldMajorEventPresentation(event?.major_event, locale);
+  return typeof tr === "function" ? presentation.label : presentation.label;
 }
 
 function WorldFeedPanel(props) {
@@ -214,7 +206,7 @@ function WorldFeedPanel(props) {
             <For each={presentationEvents()}>
               {(event) => (
                 <article
-                  class="event-card world-feed__event"
+                  class={`event-card world-feed__event${event.major_event ? ` world-feed__event--major ${pixelWorldMajorEventPresentation(event.major_event, locale()).shape.split(" ").map((token) => `world-feed__event--${token}`).join(" ")}` : ""}`}
                   data-world-feed-event={event.event_seq}
                   data-world-feed-major-event={event.major_event ? event.event_seq : undefined}
                   data-major-event-category={event.major_event?.category}
@@ -226,8 +218,13 @@ function WorldFeedPanel(props) {
                     <span class="badge">{`#${event.event_seq}`}</span>
                   </div>
                   <div class="event-card__meta">{eventKindLabel(event, locale(), tr)}</div>
-                  <Show when={event.major_event?.freshness === "current" && status() === "ready"}>
-                    <div class="feedback-detail" role="status" aria-live="polite">
+                  <Show when={event.major_event}>
+                    <div
+                      class="feedback-detail world-feed__major-event-status"
+                      data-major-event-status={pixelWorldMajorEventPresentation(event.major_event, locale()).shape}
+                      role={event.major_event.freshness === "current" && status() === "ready" ? "status" : undefined}
+                      aria-live={event.major_event.freshness === "current" && status() === "ready" ? "polite" : undefined}
+                    >
                       {majorEventStatusCopy(event, locale(), tr)}
                     </div>
                   </Show>

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.jsx
@@ -115,6 +115,7 @@ function WorldFeedPanel(props) {
   const status = () => String(feed().status || "unavailable");
   const statusLabel = () => statusCopy(locale(), tr, status());
   const summaryStatusLabel = () => statusBadgeLabel(locale(), tr, status());
+  const latestEvent = () => presentationEvents().at(-1) || null;
   const shouldReload = () => status() !== "unavailable"
     && Boolean(feed().snapshotReloadRequired || status() === "gap");
 
@@ -127,7 +128,10 @@ function WorldFeedPanel(props) {
       data-world-feed-status={status()}
       aria-live="polite"
     >
-      <summary class="panel__header panel__header--stack world-feed__summary">
+      <summary
+        class="panel__header panel__header--stack world-feed__summary"
+        data-world-feed-latest={latestEvent()?.event_seq == null ? undefined : String(latestEvent().event_seq)}
+      >
         <div class="panel__eyebrow">{tr(locale(), "环境上下文", "Ambient Context")}</div>
         <div class="world-feed__summary-line">
           <div class="panel__title">{tr(locale(), "World Feed", "World Feed")}</div>
@@ -136,6 +140,22 @@ function WorldFeedPanel(props) {
         <div class="panel__meta-copy">
           {tr(locale(), "只读的运行时环境投影；不会替代 Action Receipt，也不会证明玩家动作成功。", "Read-only runtime context; it never replaces Action Receipt or proves a player action succeeded.")}
         </div>
+        <Show
+          when={latestEvent()}
+          fallback={(
+            <div class="world-feed__latest world-feed__latest--empty" data-world-feed-latest-empty="true">
+              {status() === "loading"
+                ? tr(locale(), "等待最新环境动态。", "Waiting for the latest ambient activity.")
+                : status() === "unavailable"
+                  ? tr(locale(), "最新环境动态不可用。", "The latest ambient activity is unavailable.")
+                  : tr(locale(), "暂无最新环境动态。", "No latest ambient activity is available.")}
+            </div>
+          )}
+        >
+          <div class="world-feed__latest" data-world-feed-latest="true">
+            <span class="world-feed__latest-copy">{`${tr(locale(), "最新", "Latest")}: ${latestEvent().summary} · ${eventKindLabel(latestEvent(), locale(), tr)}`}</span>
+          </div>
+        </Show>
       </summary>
       <div class="panel__body world-feed__body">
         <div class="world-feed__status-row">

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
@@ -145,6 +145,27 @@ describe("WorldFeedPanel", () => {
     expect(document.querySelectorAll("a[data-world-feed-receipt-ref]")).toHaveLength(1);
   });
 
+  it("surfaces the highest event sequence in the collapsed summary while preserving feed status", () => {
+    render(() => (
+      <WorldFeedPanel
+        feed={() => ({
+          status: "ready",
+          events: [
+            { event_seq: 7, kind: "resource_change", summary: "Ore changed", detail: "ore +1", receipt_ref: null },
+            { event_seq: 8, kind: "weather_shift", summary: "Solar flare reached the belt", detail: "ambient", receipt_ref: null },
+          ],
+        })}
+        locale={() => "en"}
+        tr={tr}
+      />
+    ));
+
+    const summary = document.querySelector(".world-feed__summary");
+    expect(summary).toHaveAttribute("data-world-feed-latest", "8");
+    expect(summary).toHaveTextContent("LIVE");
+    expect(summary).toHaveTextContent("Latest: Solar flare reached the belt");
+  });
+
   it("formats runtime kinds and keeps diagnostic JSON out of the player feed", () => {
     render(() => (
       <WorldFeedPanel

--- a/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
+++ b/crates/oasis7_viewer/software_safe_src/world_feed_panel.test.jsx
@@ -257,6 +257,9 @@ describe("WorldFeedPanel", () => {
     expect(event).toHaveAttribute("data-major-event-category", "crisis");
     expect(event).toHaveAttribute("data-major-event-lifecycle", "active");
     expect(event).toHaveAttribute("data-major-event-severity", "4");
+    expect(event).toHaveClass("world-feed__event--severity-4");
+    expect(event).toHaveClass("world-feed__event--lifecycle-active");
+    expect(event).toHaveTextContent("Crisis active · severity 4");
     expect(event.querySelector("[data-major-event-stage-marker]")).toBeNull();
     expect(event.querySelector("[data-major-event-highlight]")).toBeNull();
     expect(event.querySelector("[data-world-feed-receipt-ref]")).toBeNull();
@@ -288,6 +291,7 @@ describe("WorldFeedPanel", () => {
     expect(document.querySelector('[data-world-feed-major-event="7"]')).toBeInTheDocument();
     expect(document.querySelector('[data-world-feed-major-event-toast="7"]')).toBeNull();
     expect(document.querySelector('[data-world-feed-major-event="7"] [role="status"]')).toBeNull();
+    expect(document.querySelector('[data-world-feed-major-event="7"]')).toHaveTextContent("Crisis active · severity 4");
   });
 
   it("provides a CJK-readable polite status for current crisis context without leaking raw protocol enums", () => {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10986,7 +10986,7 @@ function PixelWorldSparseSceneGuidance(props) {
 delegateEvents(["click"]);
 const GAP = 8;
 const PANELS = '[data-viewer-overlay="feed"], [data-viewer-overlay="next-move"], [data-viewer-overlay="receipt"], [data-viewer-overlay="navigation"], [data-viewer-overlay="cinematic-entry"], [data-focus-hud="true"], .pixel-world-canvas__selection, .pixel-world-canvas__sparse-guidance, .pixel-world-canvas__legend';
-function pixelWorldMarkerClearance(marker, panels, bounds) {
+function pixelWorldMarkerClearance(marker, panels, bounds, fallback = { x: 0, y: 0 }) {
   const width = marker.right - marker.left;
   const height = marker.bottom - marker.top;
   const xs = [marker.left, bounds.left + GAP, bounds.right - width - GAP];
@@ -11008,13 +11008,22 @@ function pixelWorldMarkerClearance(marker, panels, bounds) {
       best = { x: left - marker.left, y: top - marker.top };
     }
   }
-  return best || { x: 0, y: 0 };
+  return best || fallback;
 }
 function applyPixelWorldMarkerClearance(canvasRoot) {
   if (!canvasRoot) return;
   if (canvasRoot.dataset.rendererProjection === "true") return;
   const markers = [...canvasRoot.querySelectorAll("button.pixel-world-entity, button.pixel-world-hotspot")];
-  for (const marker of markers) marker.style.translate = "";
+  const fallbacks = /* @__PURE__ */ new Map();
+  for (const marker of markers) {
+    const selected = marker.matches(".pixel-world-entity--canvas-hit-target[data-selected='true']");
+    const previous = selected ? marker.getBoundingClientRect() : null;
+    marker.style.translate = "";
+    if (previous) {
+      const reset = marker.getBoundingClientRect();
+      fallbacks.set(marker, { x: previous.left - reset.left, y: previous.top - reset.top });
+    }
+  }
   const visibleRect = (node) => {
     if (getComputedStyle(node).visibility === "hidden" || getComputedStyle(node).display === "none") return null;
     const rect = node.getBoundingClientRect();
@@ -11028,7 +11037,7 @@ function applyPixelWorldMarkerClearance(canvasRoot) {
     const rect = visibleRect(marker);
     if (!rect) continue;
     const key = marker.dataset.agentId ? `agent:${marker.dataset.agentId}` : marker;
-    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds);
+    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds, fallbacks.get(marker));
     marker.style.translate = `${offset.x}px ${offset.y}px`;
     if (!positions.has(key)) panels.push({ left: rect.left + offset.x, right: rect.right + offset.x, top: rect.top + offset.y, bottom: rect.bottom + offset.y });
     positions.set(key, offset);
@@ -11502,7 +11511,7 @@ function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
     width: "44px",
     height: "44px",
     transform: "translate(-50%, -50%)",
-    display: point.x < 0 || point.y < 0 || point.x > width || point.y > height ? "none" : void 0
+    display: point.x + 22 <= 0 || point.y + 22 <= 0 || point.x - 22 >= width || point.y - 22 >= height ? "none" : void 0
   };
 }
 function PixelWorldRendererTargets(props) {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -10352,11 +10352,171 @@ function pixelWorldSelectedEntityLabel(visualState, selection, isLocaleZh2 = fal
   const location = visualState.locations.find((candidate) => candidate.id === selection.id);
   return pixelWorldReadableLocationLabel(location, selection.id, isLocaleZh2);
 }
-var _tmpl$$r = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$3$n = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$4$k = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$5$j = /* @__PURE__ */ template(`<div>`), _tmpl$6$d = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span class=pixel-world-entity__code>`), _tmpl$7$9 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$8$6 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__legend data-pixel-world-legend=true><div class=pixel-world-canvas__legend-title></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class=pixel-world-canvas__legend-swatch aria-hidden=true></span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>◆</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>!</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>▪</span><span>`);
+function isZhLocale$1(locale) {
+  return String(locale || "").trim().toLowerCase().startsWith("zh");
+}
+function localized$1(locale, zh, en) {
+  return isZhLocale$1(locale) ? zh : en;
+}
+function normalizedToken(value2) {
+  return String(value2 || "").trim().toLowerCase().replace(/[-\s]+/g, "_");
+}
+const BLOCKER_PRESENTATIONS = {
+  runtime_snapshot_empty_entities: {
+    label: ["尚未发布世界实体", "No published entities yet"],
+    reason: [
+      "权威快照尚未发布可用的 Agent 或地点。",
+      "The authoritative snapshot has no published agents or locations yet."
+    ],
+    nextAction: [
+      "重新加载权威快照，或等待第一个世界实体发布。",
+      "Reload the authoritative snapshot or wait for the first published entity."
+    ]
+  },
+  material_shortage: {
+    label: ["缺料", "Missing Material"],
+    reason: ["当前行动缺少已发布的物料投入。", "The current action is missing a published material input."],
+    nextAction: ["先恢复物料流，再重新检查下一步。", "Restore material flow, then recheck the next step."]
+  },
+  power_shortage: {
+    label: ["缺电", "Missing Power"],
+    reason: ["当前行动缺少已发布的供电能力。", "The current action is missing published power capacity."],
+    nextAction: ["先恢复供电，再重新检查下一步。", "Restore power, then recheck the next step."]
+  },
+  governance_gate: {
+    label: ["治理限制", "Governance Restriction"],
+    reason: ["当前行动缺少已发布的许可或治理前提。", "The current action is missing a published permission or governance prerequisite."],
+    nextAction: ["先满足许可或治理前提，再重新检查下一步。", "Satisfy the permission or governance prerequisite, then recheck the next step."]
+  },
+  no_progress: {
+    label: ["没有前进", "No Forward Progress"],
+    reason: ["最近一次已确认执行没有产生新的世界进展。", "The latest confirmed execution produced no new world progress."],
+    nextAction: ["查看明确回执与下一步提示，再决定是否重试。", "Read the explicit receipt and next step before retrying."]
+  },
+  runtime_sync_unavailable: {
+    label: ["运行时同步不可用", "Runtime Sync Unavailable"],
+    reason: ["权威运行时同步当前不可验证。", "Authoritative runtime sync is not verifiable right now."],
+    nextAction: ["重试权威快照同步。", "Retry the authoritative snapshot sync."]
+  },
+  execution_world_not_ready: {
+    label: ["执行世界未就绪", "Execution World Not Ready"],
+    reason: ["执行所需的权威世界状态尚未就绪。", "The authoritative world state required for execution is not ready."],
+    nextAction: ["等待或重新加载权威世界状态。", "Wait for or reload the authoritative world state."]
+  },
+  product_validation: {
+    label: ["产品验证失败", "Product Validation Failed"],
+    reason: ["当前请求未通过已发布的产品验证。", "The current request did not pass published product validation."],
+    nextAction: ["修正请求前提，再重新检查可用动作。", "Correct the request prerequisites, then recheck available actions."]
+  },
+  product_validation_rejected: {
+    label: ["产品验证失败", "Product Validation Failed"],
+    reason: ["当前请求在执行前被已发布的产品规则拒绝。", "The current request was rejected by published product rules before execution."],
+    nextAction: ["修正请求前提，再重新检查可用动作。", "Correct the request prerequisites, then recheck available actions."]
+  }
+};
+function pixelWorldBlockerPresentation(code, locale) {
+  const rawCode = String(code || "").trim();
+  const token = normalizedToken(rawCode);
+  const copy2 = BLOCKER_PRESENTATIONS[token];
+  if (!copy2) {
+    return {
+      code: rawCode || null,
+      label: localized$1(locale, "当前阻塞", "Current blocker"),
+      reason: localized$1(locale, "当前阻塞原因尚未发布可读说明。", "A readable reason for the current blocker has not been published."),
+      nextAction: localized$1(locale, "等待下一次权威状态更新。", "Wait for the next authoritative state update.")
+    };
+  }
+  return {
+    code: rawCode || token,
+    label: localized$1(locale, copy2.label[0], copy2.label[1]),
+    reason: localized$1(locale, copy2.reason[0], copy2.reason[1]),
+    nextAction: localized$1(locale, copy2.nextAction[0], copy2.nextAction[1])
+  };
+}
+const CONNECTION_PRESENTATIONS = {
+  connected: ["世界连接：在线", "World connection: ONLINE", "online"],
+  connecting: ["世界连接：连接中", "World connection: CONNECTING", "connecting"],
+  reconnecting: ["世界连接：重新连接中", "World connection: RECONNECTING", "reconnecting"],
+  closed: ["世界连接：已关闭", "World connection: CLOSED", "closed"],
+  error: ["世界连接：离线", "World connection: OFFLINE", "offline"]
+};
+function pixelWorldConnectionPresentation(status, locale) {
+  const token = normalizedToken(status);
+  const copy2 = CONNECTION_PRESENTATIONS[token] || CONNECTION_PRESENTATIONS.error;
+  return {
+    label: localized$1(locale, copy2[0], copy2[1]),
+    state: copy2[2],
+    className: `badge pixel-world-readout__connection pixel-world-readout__connection--${copy2[2]}`
+  };
+}
+const FEED_PRESENTATIONS = {
+  loading: ["动态新鲜度：同步中", "Feed freshness: SYNCING", "syncing"],
+  ready: ["动态新鲜度：实时", "Feed freshness: LIVE", "live"],
+  empty: ["动态新鲜度：暂无动态", "Feed freshness: NO EVENTS", "empty"],
+  replay: ["动态新鲜度：回放", "Feed freshness: REPLAY", "replay"],
+  gap: ["动态新鲜度：断档", "Feed freshness: GAP", "gap"],
+  unavailable: ["动态新鲜度：不可用", "Feed freshness: UNAVAILABLE", "unavailable"]
+};
+function pixelWorldFeedFreshnessPresentation(status, stale = false, locale) {
+  const token = normalizedToken(status);
+  const copy2 = token === "ready" && stale ? ["动态新鲜度：陈旧", "Feed freshness: STALE", "stale"] : FEED_PRESENTATIONS[token] || FEED_PRESENTATIONS.unavailable;
+  return {
+    label: localized$1(locale, copy2[0], copy2[1]),
+    state: copy2[2],
+    className: `badge pixel-world-readout__feed pixel-world-readout__feed--${copy2[2]}`
+  };
+}
+const LIFECYCLE_LABELS = {
+  active: ["进行中", "active"],
+  resolved: ["已解决", "resolved"],
+  timed_out: ["已超时", "timed out"]
+};
+function pixelWorldMajorEventPresentation(event, locale) {
+  const value2 = event || {};
+  const lifecycleToken = normalizedToken(value2.lifecycle);
+  const lifecycle = LIFECYCLE_LABELS[lifecycleToken];
+  const numericSeverity = Number(value2.severity);
+  const hasSeverity = Number.isInteger(numericSeverity) && numericSeverity >= 1 && numericSeverity <= 5;
+  const severity = hasSeverity ? String(numericSeverity) : "unknown";
+  const severityText = hasSeverity ? localized$1(locale, `严重度 ${severity}`, `severity ${severity}`) : localized$1(locale, "严重度未发布", "severity unavailable");
+  const lifecycleText = lifecycle ? localized$1(locale, `危机${lifecycle[0]}`, `Crisis ${lifecycle[1]}`) : localized$1(locale, "危机状态已记录", "Crisis lifecycle recorded");
+  const lifecycleState = lifecycleToken && lifecycle ? lifecycleToken : "recorded";
+  return {
+    label: `${lifecycleText} · ${severityText}`,
+    severity,
+    lifecycle: lifecycleState,
+    shape: `severity-${severity} lifecycle-${lifecycleState}`
+  };
+}
+function worldBoundValue(bounds, snakeName, camelName) {
+  const value2 = bounds?.[snakeName] ?? bounds?.[camelName];
+  const numeric = Number(value2);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+function countValue(value2) {
+  const numeric = Number(value2);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : 0;
+}
+function pixelWorldSparseScenePresentation(data = {}, locale) {
+  const routeCount = countValue(data.routeCount ?? data.routes);
+  const terrainCount = countValue(data.terrainCount ?? data.terrain);
+  const locationCount = countValue(data.locationCount ?? data.locations);
+  const agentCount = countValue(data.agentCount ?? data.agents);
+  const width = worldBoundValue(data.worldBounds, "width_cm", "widthCm");
+  const depth = worldBoundValue(data.worldBounds, "depth_cm", "depthCm");
+  return {
+    routes: routeCount === 0 ? localized$1(locale, "此快照没有已发布路线", "No published routes in this snapshot") : localized$1(locale, `已发布路线：${routeCount}`, `Published routes: ${routeCount}`),
+    terrain: terrainCount === 0 ? localized$1(locale, "此快照没有已发布地形", "No published terrain in this snapshot") : localized$1(locale, `已发布地形：${terrainCount}`, `Published terrain: ${terrainCount}`),
+    entities: localized$1(locale, `已发布实体：${agentCount} 个 Agent · ${locationCount} 个地点`, `Published entities: ${agentCount} agents · ${locationCount} locations`),
+    bounds: width != null && depth != null ? localized$1(locale, `已发布范围：${width} × ${depth} cm`, `Published bounds: ${width} × ${depth} cm`) : localized$1(locale, "范围未发布", "Published bounds unavailable"),
+    hasSparseTopology: routeCount === 0 || terrainCount === 0
+  };
+}
+var _tmpl$$r = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$3$n = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$4$k = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$5$j = /* @__PURE__ */ template(`<div>`), _tmpl$6$d = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span class=pixel-world-entity__code>`), _tmpl$7$9 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$8$6 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__legend data-pixel-world-legend=true><div class=pixel-world-canvas__legend-title></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class=pixel-world-canvas__legend-swatch aria-hidden=true></span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>◆</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>!</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>▪</span><span>`), _tmpl$9$5 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__sparse-guidance data-pixel-world-sparse-guidance=true><div class=pixel-world-canvas__sparse-title></div><div data-sparse-field=entities></div><div data-sparse-field=routes></div><div data-sparse-field=terrain></div><div data-sparse-field=bounds>`);
 const FRAGMENT_TERRAIN_PALETTE = {
   unknown: [148, 163, 184]
 };
-function tr$4(locale, zh, en) {
+function tr$3(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
 }
 function safeNumber$1(value2, fallback = 0) {
@@ -10554,7 +10714,7 @@ function PixelWorldCanvasAgentHitTargets(props) {
         setAttribute(_el$, "title", label);
         insert(_el$2, () => pixelWorldEntityMarkerCode(agent, agent.id, "agent"));
         createRenderEffect((_p$) => {
-          var _v$ = agent.id, _v$2 = pixelWorldEntityMarkerCode(agent, agent.id, "agent"), _v$3 = agent.position_source, _v$4 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$5 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$6 = `${tr$4(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$7 = agentMarkerStyle(agent, index(), visualState().worldBounds);
+          var _v$ = agent.id, _v$2 = pixelWorldEntityMarkerCode(agent, agent.id, "agent"), _v$3 = agent.position_source, _v$4 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$5 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$6 = `${tr$3(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$7 = agentMarkerStyle(agent, index(), visualState().worldBounds);
           _v$ !== _p$.e && setAttribute(_el$, "data-agent-id", _p$.e = _v$);
           _v$2 !== _p$.t && setAttribute(_el$, "data-marker-code", _p$.t = _v$2);
           _v$3 !== _p$.a && setAttribute(_el$, "data-position-source", _p$.a = _v$3);
@@ -10687,7 +10847,7 @@ function PixelWorldHostVisualLayer(props) {
       }));
       insert(_el$1, () => pixelWorldEntityMarkerCode(location(), location().id, "location"));
       createRenderEffect((_p$) => {
-        var _v$29 = location().id, _v$30 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$31 = pixelWorldEntityMarkerCode(location(), location().id, "location"), _v$32 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$33 = `${tr$4(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$34 = location().marker_role, _v$35 = {
+        var _v$29 = location().id, _v$30 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$31 = pixelWorldEntityMarkerCode(location(), location().id, "location"), _v$32 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$33 = `${tr$3(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$34 = location().marker_role, _v$35 = {
           ...toWorldPercentStyle(location().pos, visualState().worldBounds, {
             left: `${12 + index % 4 * 21}%`,
             top: `${18 + Math.floor(index / 4) * 26}%`
@@ -10734,7 +10894,7 @@ function PixelWorldHostVisualLayer(props) {
         }));
         insert(_el$11, () => pixelWorldEntityMarkerCode(agent(), agent().id, "agent"));
         createRenderEffect((_p$) => {
-          var _v$37 = agent().id, _v$38 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$39 = pixelWorldEntityMarkerCode(agent(), agent().id, "agent"), _v$40 = agent().position_source, _v$41 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$42 = `${tr$4(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$43 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$44 = label();
+          var _v$37 = agent().id, _v$38 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$39 = pixelWorldEntityMarkerCode(agent(), agent().id, "agent"), _v$40 = agent().position_source, _v$41 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$42 = `${tr$3(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$43 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$44 = label();
           _v$37 !== _p$.e && setAttribute(_el$10, "data-agent-id", _p$.e = _v$37);
           _v$38 !== _p$.t && setAttribute(_el$10, "data-selected", _p$.t = _v$38);
           _v$39 !== _p$.a && setAttribute(_el$10, "data-marker-code", _p$.a = _v$39);
@@ -10762,22 +10922,105 @@ function PixelWorldHostVisualLayer(props) {
 function PixelWorldCanvasLegend(props) {
   return (() => {
     var _el$12 = _tmpl$8$6(), _el$13 = _el$12.firstChild, _el$14 = _el$13.nextSibling, _el$15 = _el$14.firstChild, _el$16 = _el$15.nextSibling, _el$17 = _el$14.nextSibling, _el$18 = _el$17.firstChild, _el$19 = _el$18.nextSibling, _el$20 = _el$17.nextSibling, _el$21 = _el$20.firstChild, _el$22 = _el$21.nextSibling, _el$23 = _el$20.nextSibling, _el$24 = _el$23.firstChild, _el$25 = _el$24.nextSibling;
-    insert(_el$13, () => tr$4(props.locale(), "图例", "Legend"));
-    insert(_el$16, () => tr$4(props.locale(), "路线", "Route"));
-    insert(_el$19, () => tr$4(props.locale(), "目标", "Goal"));
-    insert(_el$22, () => tr$4(props.locale(), "阻塞", "Blocker"));
-    insert(_el$25, () => tr$4(props.locale(), "资源地形", "Resource terrain"));
-    createRenderEffect(() => setAttribute(_el$12, "aria-label", tr$4(props.locale(), "世界图例", "World legend")));
+    insert(_el$13, () => tr$3(props.locale(), "图例", "Legend"));
+    insert(_el$16, () => tr$3(props.locale(), "路线", "Route"));
+    insert(_el$19, () => tr$3(props.locale(), "目标", "Goal"));
+    insert(_el$22, () => tr$3(props.locale(), "阻塞", "Blocker"));
+    insert(_el$25, () => tr$3(props.locale(), "资源地形", "Resource terrain"));
+    createRenderEffect(() => setAttribute(_el$12, "aria-label", tr$3(props.locale(), "世界图例", "World legend")));
     return _el$12;
   })();
 }
+function PixelWorldSparseSceneGuidance(props) {
+  const visualState = () => pixelWorldVisualState(typeof props.renderState === "function" ? props.renderState() : props.renderState);
+  const presentation = () => pixelWorldSparseScenePresentation({
+    routeCount: visualState().links.length,
+    terrainCount: visualState().fragmentTerrain.length,
+    locationCount: visualState().locations.length,
+    agentCount: visualState().agents.length,
+    worldBounds: visualState().worldBounds
+  }, typeof props.locale === "function" ? props.locale() : props.locale);
+  return createComponent(Show, {
+    get when() {
+      return presentation().hasSparseTopology;
+    },
+    get children() {
+      var _el$26 = _tmpl$9$5(), _el$27 = _el$26.firstChild, _el$28 = _el$27.nextSibling, _el$29 = _el$28.nextSibling, _el$30 = _el$29.nextSibling, _el$31 = _el$30.nextSibling;
+      insert(_el$27, () => tr$3(typeof props.locale === "function" ? props.locale() : props.locale, "已发布数据范围", "Published data coverage"));
+      insert(_el$28, () => presentation().entities);
+      insert(_el$29, () => presentation().routes);
+      insert(_el$30, () => presentation().terrain);
+      insert(_el$31, () => presentation().bounds);
+      createRenderEffect(() => setAttribute(_el$26, "aria-label", tr$3(typeof props.locale === "function" ? props.locale() : props.locale, "当前世界的已发布数据范围", "Published data coverage for this world")));
+      return _el$26;
+    }
+  });
+}
 delegateEvents(["click"]);
+const GAP = 8;
+const PANELS = '[data-viewer-overlay="feed"], [data-viewer-overlay="next-move"], [data-viewer-overlay="receipt"], [data-viewer-overlay="navigation"], [data-viewer-overlay="cinematic-entry"], [data-focus-hud="true"], .pixel-world-canvas__selection, .pixel-world-canvas__sparse-guidance, .pixel-world-canvas__legend';
+function pixelWorldMarkerClearance(marker, panels, bounds) {
+  const width = marker.right - marker.left;
+  const height = marker.bottom - marker.top;
+  const xs = [marker.left, bounds.left + GAP, bounds.right - width - GAP];
+  const ys = [marker.top, bounds.top + GAP, bounds.bottom - height - GAP];
+  for (const panel of panels) {
+    xs.push(panel.left - width - GAP, panel.right + GAP);
+    ys.push(panel.top - height - GAP, panel.bottom + GAP);
+  }
+  let best = null;
+  let distance = Infinity;
+  for (const left of xs) for (const top of ys) {
+    const right = left + width;
+    const bottom = top + height;
+    if (left < bounds.left + GAP || right > bounds.right - GAP || top < bounds.top + GAP || bottom > bounds.bottom - GAP) continue;
+    if (panels.some((panel) => left < panel.right + GAP && right > panel.left - GAP && top < panel.bottom + GAP && bottom > panel.top - GAP)) continue;
+    const nextDistance = (left - marker.left) ** 2 + (top - marker.top) ** 2;
+    if (nextDistance < distance) {
+      distance = nextDistance;
+      best = { x: left - marker.left, y: top - marker.top };
+    }
+  }
+  return best || { x: 0, y: 0 };
+}
+function applyPixelWorldMarkerClearance(canvasRoot) {
+  if (!canvasRoot) return;
+  const markers = [...canvasRoot.querySelectorAll("button.pixel-world-entity, button.pixel-world-hotspot")];
+  for (const marker of markers) marker.style.translate = "";
+  const visibleRect = (node) => {
+    if (getComputedStyle(node).visibility === "hidden" || getComputedStyle(node).display === "none") return null;
+    const rect = node.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 ? rect : null;
+  };
+  const panels = [...document.querySelectorAll(PANELS)].map(visibleRect).filter(Boolean);
+  const canvas = canvasRoot.getBoundingClientRect();
+  const bounds = { left: Math.max(0, canvas.left), top: Math.max(0, canvas.top), right: Math.min(window.innerWidth, canvas.right), bottom: Math.min(window.innerHeight, canvas.bottom) };
+  const positions = /* @__PURE__ */ new Map();
+  for (const marker of markers) {
+    const rect = visibleRect(marker);
+    if (!rect) continue;
+    const key = marker.dataset.agentId ? `agent:${marker.dataset.agentId}` : marker;
+    const offset = positions.get(key) || pixelWorldMarkerClearance(rect, panels, bounds);
+    marker.style.translate = `${offset.x}px ${offset.y}px`;
+    if (!positions.has(key)) panels.push({ left: rect.left + offset.x, right: rect.right + offset.x, top: rect.top + offset.y, bottom: rect.bottom + offset.y });
+    positions.set(key, offset);
+  }
+}
+function observePixelWorldMarkerPanels(sync) {
+  if (typeof ResizeObserver === "undefined") return () => {
+  };
+  const observer = new ResizeObserver(sync);
+  for (const panel of document.querySelectorAll(PANELS)) observer.observe(panel);
+  return () => observer.disconnect();
+}
 const MOBILE_SHELL_MAX_WIDTH = 640;
 const SAFE_AREA_GAP_PX = 8;
 function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, commandTop, feedBottom = 0 }) {
   const clearCommandOffset = Math.min(0, commandTop - SAFE_AREA_GAP_PX - markerBottom);
   const clearFeedOffset = feedBottom + SAFE_AREA_GAP_PX - markerTop;
-  return Math.max(clearCommandOffset, clearFeedOffset);
+  if (clearCommandOffset < 0) return clearCommandOffset;
+  if (clearFeedOffset > 0) return clearFeedOffset;
+  return 0;
 }
 function pixelWorldMobileSelectionChipOffset({ chipTop, feedBottom = 0, feedOpen = false }) {
   if (feedOpen || !Number.isFinite(chipTop) || !Number.isFinite(feedBottom) || feedBottom <= 0) return 0;
@@ -10786,7 +11029,7 @@ function pixelWorldMobileSelectionChipOffset({ chipTop, feedBottom = 0, feedOpen
 function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
   return hudRight + SAFE_AREA_GAP_PX - markerLeft;
 }
-function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+function applyMobileSelectionSafeArea(canvasRoot) {
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
   const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
@@ -10827,6 +11070,10 @@ function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
   });
   marker.style.translate = `0 ${Math.floor(offset)}px`;
 }
+function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+  applyMobileSelectionSafeArea(canvasRoot);
+  applyPixelWorldMarkerClearance(canvasRoot);
+}
 function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const sync = () => applyPixelWorldMobileSelectionSafeArea(canvasRoot());
   window.addEventListener("resize", sync);
@@ -10835,7 +11082,9 @@ function installPixelWorldMobileSelectionSafeArea(canvasRoot) {
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
   feed?.addEventListener("toggle", sync, true);
   requestAnimationFrame(sync);
+  const stopObservingPanels = observePixelWorldMarkerPanels(() => requestAnimationFrame(sync));
   return () => {
+    stopObservingPanels();
     window.removeEventListener("resize", sync);
     focusStateObserver.disconnect();
     feed?.removeEventListener("toggle", sync, true);
@@ -10969,22 +11218,22 @@ function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
   };
 }
 var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span data-hotspot-tooltip-body></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
-function isZhLocale$1(locale) {
+function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
-function tr$3(locale, zh, en) {
-  return isZhLocale$1(locale) ? zh : en;
+function tr$2(locale, zh, en) {
+  return isZhLocale(locale) ? zh : en;
 }
 function pixelWorldHotspotKindLabel(locale, kind) {
   const normalizedKind = String(kind || "info").trim().toLowerCase();
-  if (normalizedKind === "blocker") return tr$3(locale, "阻塞", "Blocker");
-  if (normalizedKind === "goal") return tr$3(locale, "目标", "Goal");
-  return tr$3(locale, "信息", "Info");
+  if (normalizedKind === "blocker") return tr$2(locale, "阻塞", "Blocker");
+  if (normalizedKind === "goal") return tr$2(locale, "目标", "Goal");
+  return tr$2(locale, "信息", "Info");
 }
 function pixelWorldHotspotAccessibleLabel(locale, hotspot) {
   const kindLabel = pixelWorldHotspotKindLabel(locale, hotspot?.kind);
   const label = String(hotspot?.label || hotspot?.id || "").trim();
-  return tr$3(locale, `${kindLabel}热点：${label}；只读说明。`, `${kindLabel} hotspot: ${label}; read-only explanation.`);
+  return tr$2(locale, `${kindLabel}热点：${label}；只读说明。`, `${kindLabel} hotspot: ${label}; read-only explanation.`);
 }
 function pixelWorldHotspotTooltipId(hotspot) {
   const id = String(hotspot?.id || hotspot?.kind || "hotspot").trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
@@ -11156,7 +11405,7 @@ function PixelWorldHotspotTooltip(props) {
         }
       };
       createRenderEffect((_p$) => {
-        var _v$10 = pixelWorldHotspotTooltipId(hotspot()), _v$11 = tr$3(props.locale, "关闭热点说明", "Close hotspot explanation");
+        var _v$10 = pixelWorldHotspotTooltipId(hotspot()), _v$11 = tr$2(props.locale, "关闭热点说明", "Close hotspot explanation");
         _v$10 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$10);
         _v$11 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$11);
         return _p$;
@@ -11169,31 +11418,7 @@ function PixelWorldHotspotTooltip(props) {
   });
 }
 delegateEvents(["mousemove", "keydown", "click"]);
-function isZhLocale(locale) {
-  return String(locale || "").trim().toLowerCase().startsWith("zh");
-}
-function tr$2(locale, zh, en) {
-  return isZhLocale(locale) ? zh : en;
-}
-function warn(label, state2) {
-  return {
-    label,
-    className: `badge badge--warn pixel-world-readout__status pixel-world-readout__status--${state2}`
-  };
-}
-function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}) {
-  const status = String(connectionStatus || "").trim().toLowerCase();
-  const feedStatus = String(worldFeed.status || "").trim().toLowerCase();
-  if (feedStatus === "unavailable") return warn(tr$2(locale, "不可用", "UNAVAILABLE"), "unavailable");
-  if (feedStatus === "gap") return warn(tr$2(locale, "断档", "GAP"), "gap");
-  if (feedStatus === "replay") return { label: tr$2(locale, "回放", "REPLAY"), className: "badge badge--accent pixel-world-readout__status pixel-world-readout__status--replay" };
-  if (feedStatus === "empty") return { label: tr$2(locale, "暂无动态", "NO EVENTS"), className: "badge pixel-world-readout__status pixel-world-readout__status--empty" };
-  if (worldFeed.stale) return warn(tr$2(locale, "陈旧", "STALE"), "stale");
-  if (status === "connecting" || status === "reconnecting") return warn(tr$2(locale, "正在重连", "RECONNECTING"), "reconnecting");
-  if (status !== "connected") return warn(tr$2(locale, "离线", "OFFLINE"), "offline");
-  return feedStatus === "ready" ? { label: tr$2(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" } : warn(tr$2(locale, "同步中", "SYNCING"), "syncing");
-}
-var _tmpl$$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$j = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__changes data-receipt-changes=true>`), _tmpl$7$8 = /* @__PURE__ */ template(`<span>`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$0$4 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$1$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$10$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__feedback data-primary-action-feedback=true aria-live=polite>`), _tmpl$11$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div id=viewer-decision-area class=pixel-world-decision-area data-viewer-decision-area=true><div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action data-primary-action=true aria-live=polite></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong></strong></div></div></div></div><div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$15$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$23$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$24$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$25$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$37$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$39$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$40$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div>`), _tmpl$44$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
+var _tmpl$$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$j = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__changes data-receipt-changes=true>`), _tmpl$7$8 = /* @__PURE__ */ template(`<span>`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$0$4 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$1$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$10$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__feedback data-primary-action-feedback=true aria-live=polite>`), _tmpl$11$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div id=viewer-decision-area class=pixel-world-decision-area data-viewer-decision-area=true><div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action data-primary-action=true aria-live=polite></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong></strong></div></div></div></div><div class="pixel-world-readout badge-row"><span></span><span></span><span class="badge badge--accent">`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$15$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$23$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$24$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$25$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$37$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$39$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$40$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div>`), _tmpl$44$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
 }
@@ -11606,7 +11831,7 @@ function PixelWorldCanvasRenderer(props) {
       },
       get children() {
         var _el$6 = _tmpl$2$p();
-        insert(_el$6, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`);
+        insert(_el$6, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${pixelWorldBlockerPresentation(visualState().blockerHighlight.kind, props.locale()).label}`);
         return _el$6;
       }
     }), null);
@@ -11727,10 +11952,6 @@ function receiptConfidenceLabel(confidence, locale, state2) {
   if (receiptState === "rejected") return tr$1(locale, "行动已拒绝", "Action rejected");
   return value2 === "world_delta" ? tr$1(locale, "世界变化已确认", "World change confirmed") : value2 === "accepted_intent" ? tr$1(locale, "行动已接受", "Action accepted") : value2 === "none" ? tr$1(locale, "等待确认", "Waiting for confirmation") : tr$1(locale, "状态已记录", "Status recorded");
 }
-function worldReadoutStatus(locale, renderState) {
-  renderState?.();
-  return resolvePixelWorldReadoutStatus(locale, state.connectionStatus, state.worldFeed);
-}
 const DIRECT_PIXEL_WORLD_NEXT_MOVE_KINDS = /* @__PURE__ */ new Set(["claim_first_agent", "claim_starter_oc"]);
 const PIXEL_WORLD_PENDING_GAMEPLAY_STAGES = /* @__PURE__ */ new Set(["accepted", "submitted", "queued", "ack", "registering", "signing", "sent"]);
 const PIXEL_WORLD_BUSY_GAMEPLAY_STAGES = /* @__PURE__ */ new Set(["queued", "registering", "signing", "sent"]);
@@ -11780,8 +12001,15 @@ function resolvePixelWorldDirectNextMoveAction(gameplay, executeKind) {
 }
 function PixelWorldCommercialHud(props) {
   const surface = () => props.renderState().commercial_surface;
-  const readoutStatus = () => worldReadoutStatus(props.locale(), props.renderState);
   const readoutFeedStatus = () => String(state.worldFeed?.status || "loading").trim().toLowerCase() || "loading";
+  const worldConnection = () => pixelWorldConnectionPresentation(state.connectionStatus, props.locale());
+  const feedFreshness = () => pixelWorldFeedFreshnessPresentation(readoutFeedStatus(), state.worldFeed?.stale, props.locale());
+  const playerBlockerLabel = () => {
+    const candidate = String(surface().blocker?.label || "").trim();
+    const kind = String(gameplay()?.blockerKind || "").trim();
+    if (kind) return pixelWorldBlockerPresentation(kind, props.locale()).label;
+    return candidate || null;
+  };
   const activeAgentId = () => String(surface()?.active_agent_id || "").trim();
   const activeAgent = () => props.renderState().agents.find((agent) => agent.id === activeAgentId());
   const activeAgentLabel = () => pixelWorldReadableAgentLabel(activeAgent(), activeAgentId(), isLocaleZh(props.locale())) || tr$1(props.locale(), "未选择 Agent", "No Agent selected");
@@ -11821,15 +12049,15 @@ function PixelWorldCommercialHud(props) {
       return surface();
     },
     get children() {
-      var _el$16 = _tmpl$12$1(), _el$17 = _el$16.firstChild, _el$18 = _el$17.firstChild, _el$19 = _el$18.firstChild, _el$20 = _el$19.firstChild, _el$22 = _el$19.nextSibling, _el$24 = _el$22.nextSibling, _el$26 = _el$18.nextSibling, _el$27 = _el$26.firstChild, _el$28 = _el$27.firstChild, _el$29 = _el$28.nextSibling, _el$30 = _el$29.nextSibling, _el$31 = _el$27.nextSibling, _el$32 = _el$31.firstChild, _el$33 = _el$32.nextSibling, _el$34 = _el$33.nextSibling, _el$35 = _el$34.nextSibling, _el$36 = _el$35.firstChild, _el$37 = _el$36.nextSibling, _el$38 = _el$17.nextSibling, _el$39 = _el$38.firstChild, _el$41 = _el$39.nextSibling;
+      var _el$16 = _tmpl$12$1(), _el$17 = _el$16.firstChild, _el$18 = _el$17.firstChild, _el$19 = _el$18.firstChild, _el$20 = _el$19.firstChild, _el$22 = _el$19.nextSibling, _el$24 = _el$22.nextSibling, _el$26 = _el$18.nextSibling, _el$27 = _el$26.firstChild, _el$28 = _el$27.firstChild, _el$29 = _el$28.nextSibling, _el$30 = _el$29.nextSibling, _el$31 = _el$27.nextSibling, _el$32 = _el$31.firstChild, _el$33 = _el$32.nextSibling, _el$34 = _el$33.nextSibling, _el$35 = _el$34.nextSibling, _el$36 = _el$35.firstChild, _el$37 = _el$36.nextSibling, _el$38 = _el$17.nextSibling, _el$39 = _el$38.firstChild, _el$40 = _el$39.nextSibling, _el$42 = _el$40.nextSibling;
       insert(_el$20, () => tr$1(props.locale(), "下一步", "Next Move"));
       insert(_el$19, createComponent(Show, {
         get when() {
-          return surface().blocker.label;
+          return playerBlockerLabel();
         },
         get children() {
           var _el$21 = _tmpl$0$4();
-          insert(_el$21, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`);
+          insert(_el$21, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${playerBlockerLabel()}`);
           return _el$21;
         }
       }), null);
@@ -11884,26 +12112,35 @@ function PixelWorldCommercialHud(props) {
           });
         }
       }), _el$38);
-      insert(_el$39, () => readoutStatus().label);
+      insert(_el$39, () => worldConnection().label);
+      insert(_el$40, () => feedFreshness().label);
       insert(_el$38, createComponent(Show, {
         get when() {
           return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
         },
         get children() {
-          var _el$40 = _tmpl$11$1();
-          insert(_el$40, () => `tick=${surface().world_read.tick}`);
-          createRenderEffect(() => setAttribute(_el$40, "data-world-tick", String(surface().world_read.tick)));
-          return _el$40;
+          var _el$41 = _tmpl$11$1();
+          insert(_el$41, () => `tick=${surface().world_read.tick}`);
+          createRenderEffect(() => setAttribute(_el$41, "data-world-tick", String(surface().world_read.tick)));
+          return _el$41;
         }
-      }), _el$41);
-      insert(_el$41, () => `agents=${surface().world_read.agents}`);
+      }), _el$42);
+      insert(_el$42, () => `agents=${surface().world_read.agents}`);
+      insert(_el$16, createComponent(PixelWorldSparseSceneGuidance, {
+        get locale() {
+          return props.locale;
+        },
+        get renderState() {
+          return props.renderState;
+        }
+      }), null);
       insert(_el$16, createComponent(PixelWorldCanvasLegend, {
         get locale() {
           return props.locale;
         }
       }), null);
       createRenderEffect((_p$) => {
-        var _v$8 = activeAgentId(), _v$9 = surface().player_leverage.state, _v$0 = nextMoveRoute(), _v$1 = surface().next_action.execute_kind || "none", _v$10 = surface().blocker.label ? "true" : "false", _v$11 = nextMoveHref(), _v$12 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$13 = nextMoveDisabledReason() ? "true" : void 0, _v$14 = nextMovePending() ? "true" : "false", _v$15 = nextMoveDisabledReason() ? -1 : void 0, _v$16 = activeAgentLabel(), _v$17 = readoutStatus().className, _v$18 = readoutFeedStatus();
+        var _v$8 = activeAgentId(), _v$9 = surface().player_leverage.state, _v$0 = nextMoveRoute(), _v$1 = surface().next_action.execute_kind || "none", _v$10 = playerBlockerLabel() ? "true" : "false", _v$11 = nextMoveHref(), _v$12 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$13 = nextMoveDisabledReason() ? "true" : void 0, _v$14 = nextMovePending() ? "true" : "false", _v$15 = nextMoveDisabledReason() ? -1 : void 0, _v$16 = activeAgentLabel(), _v$17 = tr$1(props.locale(), "世界连接与动态新鲜度", "World connection and feed freshness"), _v$18 = worldConnection().className, _v$19 = worldConnection().state, _v$20 = feedFreshness().className, _v$21 = readoutFeedStatus();
         _v$8 !== _p$.e && setAttribute(_el$17, "data-active-agent", _p$.e = _v$8);
         _v$9 !== _p$.t && setAttribute(_el$17, "data-leverage-state", _p$.t = _v$9);
         _v$0 !== _p$.a && setAttribute(_el$18, "data-next-move-route", _p$.a = _v$0);
@@ -11915,8 +12152,11 @@ function PixelWorldCommercialHud(props) {
         _v$14 !== _p$.r && setAttribute(_el$24, "aria-busy", _p$.r = _v$14);
         _v$15 !== _p$.d && setAttribute(_el$24, "tabindex", _p$.d = _v$15);
         _v$16 !== _p$.l && setAttribute(_el$35, "data-selected-agent-label", _p$.l = _v$16);
-        _v$17 !== _p$.u && className(_el$39, _p$.u = _v$17);
-        _v$18 !== _p$.c && setAttribute(_el$39, "data-world-feed-readout-status", _p$.c = _v$18);
+        _v$17 !== _p$.u && setAttribute(_el$38, "aria-label", _p$.u = _v$17);
+        _v$18 !== _p$.c && className(_el$39, _p$.c = _v$18);
+        _v$19 !== _p$.w && setAttribute(_el$39, "data-world-connection-status", _p$.w = _v$19);
+        _v$20 !== _p$.m && className(_el$40, _p$.m = _v$20);
+        _v$21 !== _p$.f && setAttribute(_el$40, "data-world-feed-readout-status", _p$.f = _v$21);
         return _p$;
       }, {
         e: void 0,
@@ -11931,7 +12171,10 @@ function PixelWorldCommercialHud(props) {
         d: void 0,
         l: void 0,
         u: void 0,
-        c: void 0
+        c: void 0,
+        w: void 0,
+        m: void 0,
+        f: void 0
       });
       return _el$16;
     }
@@ -11944,57 +12187,57 @@ function PixelWorldFocusHud(props) {
       return surface();
     },
     get children() {
-      var _el$42 = _tmpl$14$1(), _el$43 = _el$42.firstChild, _el$44 = _el$43.firstChild, _el$45 = _el$44.nextSibling, _el$46 = _el$43.nextSibling, _el$47 = _el$46.firstChild, _el$48 = _el$47.nextSibling, _el$49 = _el$48.nextSibling, _el$50 = _el$46.nextSibling, _el$51 = _el$50.firstChild, _el$52 = _el$51.nextSibling, _el$53 = _el$52.nextSibling, _el$58 = _el$50.nextSibling, _el$59 = _el$58.firstChild, _el$60 = _el$59.nextSibling, _el$61 = _el$58.nextSibling, _el$62 = _el$61.firstChild, _el$63 = _el$62.nextSibling, _el$64 = _el$63.nextSibling, _el$65 = _el$64.firstChild, _el$66 = _el$65.nextSibling, _el$67 = _el$66.nextSibling;
-      insert(_el$44, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
-      insert(_el$45, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
-      insert(_el$47, () => tr$1(props.locale(), "当前目标", "Current Objective"));
-      insert(_el$48, () => surface().objective.title);
-      insert(_el$49, () => surface().next_action.label);
-      insert(_el$51, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
-      insert(_el$52, (() => {
+      var _el$43 = _tmpl$14$1(), _el$44 = _el$43.firstChild, _el$45 = _el$44.firstChild, _el$46 = _el$45.nextSibling, _el$47 = _el$44.nextSibling, _el$48 = _el$47.firstChild, _el$49 = _el$48.nextSibling, _el$50 = _el$49.nextSibling, _el$51 = _el$47.nextSibling, _el$52 = _el$51.firstChild, _el$53 = _el$52.nextSibling, _el$54 = _el$53.nextSibling, _el$59 = _el$51.nextSibling, _el$60 = _el$59.firstChild, _el$61 = _el$60.nextSibling, _el$62 = _el$59.nextSibling, _el$63 = _el$62.firstChild, _el$64 = _el$63.nextSibling, _el$65 = _el$64.nextSibling, _el$66 = _el$65.firstChild, _el$67 = _el$66.nextSibling, _el$68 = _el$67.nextSibling;
+      insert(_el$45, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
+      insert(_el$46, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
+      insert(_el$48, () => tr$1(props.locale(), "当前目标", "Current Objective"));
+      insert(_el$49, () => surface().objective.title);
+      insert(_el$50, () => surface().next_action.label);
+      insert(_el$52, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
+      insert(_el$53, (() => {
         var _c$3 = memo(() => surface().objective.progress_percent == null);
         return () => _c$3() ? tr$1(props.locale(), "进行中", "In Progress") : `${surface().objective.progress_percent}%`;
       })());
-      insert(_el$53, () => surface().next_action.detail || surface().objective.detail);
-      insert(_el$42, createComponent(Show, {
+      insert(_el$54, () => surface().next_action.detail || surface().objective.detail);
+      insert(_el$43, createComponent(Show, {
         get when() {
           return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
         },
         get children() {
-          var _el$54 = _tmpl$13$1(), _el$55 = _el$54.firstChild, _el$56 = _el$55.nextSibling, _el$57 = _el$56.nextSibling;
-          insert(_el$55, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
-          insert(_el$56, () => surface().world_read.tick);
-          insert(_el$57, () => `tick=${surface().world_read.tick}`);
-          createRenderEffect(() => setAttribute(_el$54, "data-world-tick", String(surface().world_read.tick)));
-          return _el$54;
+          var _el$55 = _tmpl$13$1(), _el$56 = _el$55.firstChild, _el$57 = _el$56.nextSibling, _el$58 = _el$57.nextSibling;
+          insert(_el$56, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
+          insert(_el$57, () => surface().world_read.tick);
+          insert(_el$58, () => `tick=${surface().world_read.tick}`);
+          createRenderEffect(() => setAttribute(_el$55, "data-world-tick", String(surface().world_read.tick)));
+          return _el$55;
         }
-      }), _el$58);
-      insert(_el$59, () => tr$1(props.locale(), "阻塞", "Blocker"));
-      insert(_el$60, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
-      addEventListener(_el$62, "click", props.onOpenCommand);
-      insert(_el$62, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
-      addEventListener(_el$63, "click", props.onExit);
-      insert(_el$63, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
-      insert(_el$65, () => tr$1(props.locale(), "更多控制", "More controls"));
-      addEventListener(_el$66, "click", props.onOpenDiagnostics);
-      insert(_el$66, () => tr$1(props.locale(), "世界状态", "World Status"));
-      addEventListener(_el$67, "click", props.onToggleMaximized);
-      insert(_el$67, (() => {
+      }), _el$59);
+      insert(_el$60, () => tr$1(props.locale(), "阻塞", "Blocker"));
+      insert(_el$61, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
+      addEventListener(_el$63, "click", props.onOpenCommand);
+      insert(_el$63, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
+      addEventListener(_el$64, "click", props.onExit);
+      insert(_el$64, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
+      insert(_el$66, () => tr$1(props.locale(), "更多控制", "More controls"));
+      addEventListener(_el$67, "click", props.onOpenDiagnostics);
+      insert(_el$67, () => tr$1(props.locale(), "世界状态", "World Status"));
+      addEventListener(_el$68, "click", props.onToggleMaximized);
+      insert(_el$68, (() => {
         var _c$4 = memo(() => !!props.maximized());
         return () => _c$4() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
       })());
       createRenderEffect((_p$) => {
-        var _v$19 = surface().blocker.label ? "true" : "false", _v$20 = surface().blocker.label ? "critical" : "clear", _v$21 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
-        _v$19 !== _p$.e && setAttribute(_el$58, "data-blocker-present", _p$.e = _v$19);
-        _v$20 !== _p$.t && setAttribute(_el$58, "data-hud-priority", _p$.t = _v$20);
-        _v$21 !== _p$.a && setAttribute(_el$61, "aria-label", _p$.a = _v$21);
+        var _v$22 = surface().blocker.label ? "true" : "false", _v$23 = surface().blocker.label ? "critical" : "clear", _v$24 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
+        _v$22 !== _p$.e && setAttribute(_el$59, "data-blocker-present", _p$.e = _v$22);
+        _v$23 !== _p$.t && setAttribute(_el$59, "data-hud-priority", _p$.t = _v$23);
+        _v$24 !== _p$.a && setAttribute(_el$62, "aria-label", _p$.a = _v$24);
         return _p$;
       }, {
         e: void 0,
         t: void 0,
         a: void 0
       });
-      return _el$42;
+      return _el$43;
     }
   });
 }
@@ -12005,22 +12248,22 @@ function PixelWorldFocusCinematicBanner(props) {
       return surface();
     },
     get children() {
-      var _el$68 = _tmpl$16$1(), _el$69 = _el$68.firstChild, _el$70 = _el$69.nextSibling, _el$71 = _el$70.nextSibling, _el$72 = _el$71.nextSibling, _el$73 = _el$72.firstChild;
-      insert(_el$69, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
-      insert(_el$70, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
-      insert(_el$71, () => surface().objective.detail);
-      insert(_el$73, () => surface().objective.title);
-      insert(_el$72, createComponent(Show, {
+      var _el$69 = _tmpl$16$1(), _el$70 = _el$69.firstChild, _el$71 = _el$70.nextSibling, _el$72 = _el$71.nextSibling, _el$73 = _el$72.nextSibling, _el$74 = _el$73.firstChild;
+      insert(_el$70, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
+      insert(_el$71, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
+      insert(_el$72, () => surface().objective.detail);
+      insert(_el$74, () => surface().objective.title);
+      insert(_el$73, createComponent(Show, {
         get when() {
           return surface().blocker.label;
         },
         get children() {
-          var _el$74 = _tmpl$15$1();
-          insert(_el$74, () => surface().blocker.label);
-          return _el$74;
+          var _el$75 = _tmpl$15$1();
+          insert(_el$75, () => surface().blocker.label);
+          return _el$75;
         }
       }), null);
-      return _el$68;
+      return _el$69;
     }
   });
 }
@@ -12046,53 +12289,53 @@ function PixelWorldFocusRail(props) {
       return memo(() => !!surface())() && hasFocusItems();
     },
     get children() {
-      var _el$75 = _tmpl$19$1(), _el$76 = _el$75.firstChild;
-      insert(_el$76, () => tr$1(props.locale(), "焦点", "Focus"));
-      insert(_el$75, createComponent(Show, {
+      var _el$76 = _tmpl$19$1(), _el$77 = _el$76.firstChild;
+      insert(_el$77, () => tr$1(props.locale(), "焦点", "Focus"));
+      insert(_el$76, createComponent(Show, {
         get when() {
           return surface()?.blocker.label;
         },
         get children() {
-          var _el$77 = _tmpl$17$1(), _el$78 = _el$77.firstChild, _el$79 = _el$78.nextSibling;
-          insert(_el$78, () => tr$1(props.locale(), "阻塞", "Blocker"));
-          insert(_el$79, () => surface().blocker.label);
-          return _el$77;
+          var _el$78 = _tmpl$17$1(), _el$79 = _el$78.firstChild, _el$80 = _el$79.nextSibling;
+          insert(_el$79, () => tr$1(props.locale(), "阻塞", "Blocker"));
+          insert(_el$80, () => surface().blocker.label);
+          return _el$78;
         }
       }), null);
-      insert(_el$75, createComponent(Show, {
+      insert(_el$76, createComponent(Show, {
         get when() {
           return activeAgent();
         },
         get children() {
-          var _el$80 = _tmpl$18$1(), _el$81 = _el$80.firstChild, _el$82 = _el$81.nextSibling;
-          insert(_el$81, () => tr$1(props.locale(), "Agent", "Agent"));
-          insert(_el$82, activeAgentName);
-          return _el$80;
+          var _el$81 = _tmpl$18$1(), _el$82 = _el$81.firstChild, _el$83 = _el$82.nextSibling;
+          insert(_el$82, () => tr$1(props.locale(), "Agent", "Agent"));
+          insert(_el$83, activeAgentName);
+          return _el$81;
         }
       }), null);
-      insert(_el$75, createComponent(Show, {
+      insert(_el$76, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$83 = _tmpl$18$1(), _el$84 = _el$83.firstChild, _el$85 = _el$84.nextSibling;
-          insert(_el$84, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$85, selectedName);
-          return _el$83;
+          var _el$84 = _tmpl$18$1(), _el$85 = _el$84.firstChild, _el$86 = _el$85.nextSibling;
+          insert(_el$85, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$86, selectedName);
+          return _el$84;
         }
       }), null);
-      insert(_el$75, createComponent(Show, {
+      insert(_el$76, createComponent(Show, {
         get when() {
           return routeCount() > 0;
         },
         get children() {
-          var _el$86 = _tmpl$18$1(), _el$87 = _el$86.firstChild, _el$88 = _el$87.nextSibling;
-          insert(_el$87, () => tr$1(props.locale(), "路线", "Routes"));
-          insert(_el$88, routeCount);
-          return _el$86;
+          var _el$87 = _tmpl$18$1(), _el$88 = _el$87.firstChild, _el$89 = _el$88.nextSibling;
+          insert(_el$88, () => tr$1(props.locale(), "路线", "Routes"));
+          insert(_el$89, routeCount);
+          return _el$87;
         }
       }), null);
-      return _el$75;
+      return _el$76;
     }
   });
 }
@@ -12109,50 +12352,50 @@ function PixelWorldFocusMinimapCard(props) {
       return surface();
     },
     get children() {
-      var _el$89 = _tmpl$22$1(), _el$90 = _el$89.firstChild, _el$92 = _el$90.nextSibling, _el$93 = _el$92.nextSibling, _el$94 = _el$93.nextSibling, _el$95 = _el$94.firstChild, _el$96 = _el$95.nextSibling, _el$97 = _el$94.nextSibling, _el$98 = _el$97.firstChild, _el$99 = _el$98.nextSibling, _el$103 = _el$97.nextSibling, _el$104 = _el$103.firstChild, _el$105 = _el$104.nextSibling, _el$106 = _el$105.nextSibling, _el$107 = _el$106.nextSibling;
-      insert(_el$90, () => tr$1(props.locale(), "任务地图", "Mission Map"));
-      insert(_el$89, createComponent(Show, {
+      var _el$90 = _tmpl$22$1(), _el$91 = _el$90.firstChild, _el$93 = _el$91.nextSibling, _el$94 = _el$93.nextSibling, _el$95 = _el$94.nextSibling, _el$96 = _el$95.firstChild, _el$97 = _el$96.nextSibling, _el$98 = _el$95.nextSibling, _el$99 = _el$98.firstChild, _el$100 = _el$99.nextSibling, _el$104 = _el$98.nextSibling, _el$105 = _el$104.firstChild, _el$106 = _el$105.nextSibling, _el$107 = _el$106.nextSibling, _el$108 = _el$107.nextSibling;
+      insert(_el$91, () => tr$1(props.locale(), "任务地图", "Mission Map"));
+      insert(_el$90, createComponent(Show, {
         get when() {
           return primaryLocation();
         },
         get children() {
-          var _el$91 = _tmpl$20$1();
-          insert(_el$91, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
-          return _el$91;
+          var _el$92 = _tmpl$20$1();
+          insert(_el$92, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
+          return _el$92;
         }
-      }), _el$92);
-      insert(_el$95, () => tr$1(props.locale(), "目标", "Target"));
-      insert(_el$96, () => surface().next_action.label);
-      insert(_el$98, () => tr$1(props.locale(), "Agent", "Agent"));
-      insert(_el$99, (() => {
+      }), _el$93);
+      insert(_el$96, () => tr$1(props.locale(), "目标", "Target"));
+      insert(_el$97, () => surface().next_action.label);
+      insert(_el$99, () => tr$1(props.locale(), "Agent", "Agent"));
+      insert(_el$100, (() => {
         var _c$5 = memo(() => !!activeAgent());
         return () => _c$5() ? activeAgentName() : tr$1(props.locale(), "待分配", "Unassigned");
       })());
-      insert(_el$89, createComponent(Show, {
+      insert(_el$90, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$100 = _tmpl$21$1(), _el$101 = _el$100.firstChild, _el$102 = _el$101.nextSibling;
-          insert(_el$101, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$102, selectedName);
-          return _el$100;
+          var _el$101 = _tmpl$21$1(), _el$102 = _el$101.firstChild, _el$103 = _el$102.nextSibling;
+          insert(_el$102, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$103, selectedName);
+          return _el$101;
         }
-      }), _el$103);
-      insert(_el$104, () => `agents=${props.renderState().agents.length}`);
-      insert(_el$105, () => `targets=${props.renderState().locations.length}`);
-      insert(_el$106, () => `routes=${props.renderState().links.length}`);
-      insert(_el$107, () => `fragments=${props.renderState().fragment_terrain.length}`);
+      }), _el$104);
+      insert(_el$105, () => `agents=${props.renderState().agents.length}`);
+      insert(_el$106, () => `targets=${props.renderState().locations.length}`);
+      insert(_el$107, () => `routes=${props.renderState().links.length}`);
+      insert(_el$108, () => `fragments=${props.renderState().fragment_terrain.length}`);
       createRenderEffect((_p$) => {
-        var _v$22 = props.renderState().links.length, _v$23 = tr$1(props.locale(), "世界摘要", "World summary");
-        _v$22 !== _p$.e && setAttribute(_el$93, "data-routes", _p$.e = _v$22);
-        _v$23 !== _p$.t && setAttribute(_el$103, "aria-label", _p$.t = _v$23);
+        var _v$25 = props.renderState().links.length, _v$26 = tr$1(props.locale(), "世界摘要", "World summary");
+        _v$25 !== _p$.e && setAttribute(_el$94, "data-routes", _p$.e = _v$25);
+        _v$26 !== _p$.t && setAttribute(_el$104, "aria-label", _p$.t = _v$26);
         return _p$;
       }, {
         e: void 0,
         t: void 0
       });
-      return _el$89;
+      return _el$90;
     }
   });
 }
@@ -12184,20 +12427,20 @@ function PixelRawDiagnostics(props) {
   const [open, setOpen] = createSignal(false);
   const value2 = () => typeof props.value === "function" ? props.value() : props.value;
   return (() => {
-    var _el$108 = _tmpl$24$1(), _el$109 = _el$108.firstChild;
-    _el$108.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
-    insert(_el$109, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
-    insert(_el$108, createComponent(Show, {
+    var _el$109 = _tmpl$24$1(), _el$110 = _el$109.firstChild;
+    _el$109.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
+    insert(_el$110, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
+    insert(_el$109, createComponent(Show, {
       get when() {
         return open();
       },
       get children() {
-        var _el$110 = _tmpl$23$1();
-        insert(_el$110, () => JSON.stringify(value2(), null, 2));
-        return _el$110;
+        var _el$111 = _tmpl$23$1();
+        insert(_el$111, () => JSON.stringify(value2(), null, 2));
+        return _el$111;
       }
     }), null);
-    return _el$108;
+    return _el$109;
   })();
 }
 function PixelWorldFocusCommandSurface(props) {
@@ -12215,140 +12458,144 @@ function PixelWorldFocusCommandSurface(props) {
   const chatFeedbackDisplay = () => describeSemanticFeedback(chatFeedback(), locale());
   const chatControlsEnabled = () => chatCapability().enabled && !isAgentChatInFlight();
   const gameplaySummary = () => buildGameplaySummary(locale());
-  const blockerLabel = () => gameplaySummary()?.blockerLabel || gameplaySummary()?.blockerKind || tr$1(locale(), "无阻塞", "No blocker");
+  const blockerLabel = () => {
+    const kind = gameplaySummary()?.blockerKind;
+    if (!kind) return tr$1(locale(), "无阻塞", "No blocker");
+    return pixelWorldBlockerPresentation(kind, locale()).label;
+  };
   const receiptLabel = () => gameplaySummary()?.executionStateLabel || gameplaySummary()?.recentFeedback?.stage || tr$1(locale(), "等待回执", "Waiting");
   const chatHistory = () => state.chatHistory.filter((entry) => entry.agentId === agentId() || entry.targetAgentId === agentId()).slice(0, 12);
   return (() => {
-    var _el$111 = _tmpl$30$1();
-    insert(_el$111, createComponent(Show, {
+    var _el$112 = _tmpl$30$1();
+    insert(_el$112, createComponent(Show, {
       get when() {
         return agentId();
       },
       get fallback() {
         return (() => {
-          var _el$145 = _tmpl$28$1();
-          insert(_el$145, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
-          return _el$145;
+          var _el$146 = _tmpl$28$1();
+          insert(_el$146, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
+          return _el$146;
         })();
       },
       get children() {
         return [(() => {
-          var _el$112 = _tmpl$26$1(), _el$113 = _el$112.firstChild, _el$114 = _el$113.nextSibling, _el$116 = _el$114.nextSibling;
-          insert(_el$113, () => tr$1(locale(), "当前交互目标", "Current Target"));
-          insert(_el$114, agentName);
-          insert(_el$112, createComponent(Show, {
+          var _el$113 = _tmpl$26$1(), _el$114 = _el$113.firstChild, _el$115 = _el$114.nextSibling, _el$117 = _el$115.nextSibling;
+          insert(_el$114, () => tr$1(locale(), "当前交互目标", "Current Target"));
+          insert(_el$115, agentName);
+          insert(_el$113, createComponent(Show, {
             get when() {
               return binding()?.playerId;
             },
             get children() {
-              var _el$115 = _tmpl$25$1();
-              insert(_el$115, () => `boundPlayer=${binding().playerId}`);
-              return _el$115;
+              var _el$116 = _tmpl$25$1();
+              insert(_el$116, () => `boundPlayer=${binding().playerId}`);
+              return _el$116;
             }
-          }), _el$116);
-          insert(_el$116, (() => {
+          }), _el$117);
+          insert(_el$117, (() => {
             var _c$6 = memo(() => !!chatCapability().enabled);
             return () => _c$6() ? tr$1(locale(), "聊天可用", "Chat Ready") : tr$1(locale(), "聊天受限", "Chat Limited");
           })());
-          createRenderEffect(() => className(_el$116, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
-          return _el$112;
+          createRenderEffect(() => className(_el$117, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
+          return _el$113;
         })(), (() => {
-          var _el$117 = _tmpl$27$1(), _el$118 = _el$117.firstChild, _el$119 = _el$118.firstChild, _el$120 = _el$119.nextSibling, _el$121 = _el$120.nextSibling, _el$122 = _el$118.nextSibling, _el$123 = _el$122.firstChild, _el$124 = _el$123.nextSibling, _el$125 = _el$122.nextSibling, _el$126 = _el$125.firstChild, _el$127 = _el$126.nextSibling, _el$128 = _el$125.nextSibling;
-          insert(_el$119, () => tr$1(locale(), "目标", "Target"));
-          insert(_el$120, agentName);
-          insert(_el$121, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
-          insert(_el$123, () => tr$1(locale(), "阻塞", "Blocker"));
-          insert(_el$124, blockerLabel);
-          insert(_el$126, () => tr$1(locale(), "回执", "Receipt"));
-          insert(_el$127, receiptLabel);
-          _el$128.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$128, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          var _el$118 = _tmpl$27$1(), _el$119 = _el$118.firstChild, _el$120 = _el$119.firstChild, _el$121 = _el$120.nextSibling, _el$122 = _el$121.nextSibling, _el$123 = _el$119.nextSibling, _el$124 = _el$123.firstChild, _el$125 = _el$124.nextSibling, _el$126 = _el$123.nextSibling, _el$127 = _el$126.firstChild, _el$128 = _el$127.nextSibling, _el$129 = _el$126.nextSibling;
+          insert(_el$120, () => tr$1(locale(), "目标", "Target"));
+          insert(_el$121, agentName);
+          insert(_el$122, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
+          insert(_el$124, () => tr$1(locale(), "阻塞", "Blocker"));
+          insert(_el$125, blockerLabel);
+          insert(_el$127, () => tr$1(locale(), "回执", "Receipt"));
+          insert(_el$128, receiptLabel);
+          _el$129.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$129, () => tr$1(locale(), "发送聊天", "Send Chat"));
           createRenderEffect((_p$) => {
-            var _v$24 = chatControlsEnabled() ? "true" : "false", _v$25 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$26 = !chatControlsEnabled();
-            _v$24 !== _p$.e && setAttribute(_el$117, "data-chat-ready", _p$.e = _v$24);
-            _v$25 !== _p$.t && setAttribute(_el$122, "data-blocker-present", _p$.t = _v$25);
-            _v$26 !== _p$.a && (_el$128.disabled = _p$.a = _v$26);
+            var _v$27 = chatControlsEnabled() ? "true" : "false", _v$28 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$29 = !chatControlsEnabled();
+            _v$27 !== _p$.e && setAttribute(_el$118, "data-chat-ready", _p$.e = _v$27);
+            _v$28 !== _p$.t && setAttribute(_el$123, "data-blocker-present", _p$.t = _v$28);
+            _v$29 !== _p$.a && (_el$129.disabled = _p$.a = _v$29);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          return _el$117;
+          return _el$118;
         })(), createComponent(Show, {
           get when() {
             return !chatCapability().enabled;
           },
           get children() {
-            var _el$129 = _tmpl$28$1();
-            insert(_el$129, () => chatCapability().reason);
-            return _el$129;
+            var _el$130 = _tmpl$28$1();
+            insert(_el$130, () => chatCapability().reason);
+            return _el$130;
           }
         }), (() => {
-          var _el$130 = _tmpl$29$1(), _el$131 = _el$130.firstChild, _el$132 = _el$131.firstChild, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling, _el$135 = _el$134.nextSibling, _el$136 = _el$131.nextSibling, _el$137 = _el$136.firstChild, _el$138 = _el$137.firstChild, _el$139 = _el$138.nextSibling, _el$140 = _el$137.nextSibling, _el$141 = _el$140.firstChild, _el$142 = _el$140.nextSibling, _el$143 = _el$142.firstChild, _el$144 = _el$143.nextSibling;
-          insert(_el$133, () => tr$1(locale(), "指挥面板", "Command Surface"));
-          insert(_el$134, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
-          insert(_el$135, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
-          insert(_el$138, () => tr$1(locale(), "消息", "Message"));
-          _el$139.$$input = (event) => {
+          var _el$131 = _tmpl$29$1(), _el$132 = _el$131.firstChild, _el$133 = _el$132.firstChild, _el$134 = _el$133.firstChild, _el$135 = _el$134.nextSibling, _el$136 = _el$135.nextSibling, _el$137 = _el$132.nextSibling, _el$138 = _el$137.firstChild, _el$139 = _el$138.firstChild, _el$140 = _el$139.nextSibling, _el$141 = _el$138.nextSibling, _el$142 = _el$141.firstChild, _el$143 = _el$141.nextSibling, _el$144 = _el$143.firstChild, _el$145 = _el$144.nextSibling;
+          insert(_el$134, () => tr$1(locale(), "指挥面板", "Command Surface"));
+          insert(_el$135, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
+          insert(_el$136, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
+          insert(_el$139, () => tr$1(locale(), "消息", "Message"));
+          _el$140.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
-          _el$141.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$141, () => tr$1(locale(), "发送聊天", "Send Chat"));
-          insert(_el$136, createComponent(Show, {
+          _el$142.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$142, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          insert(_el$137, createComponent(Show, {
             get when() {
               return chatFeedback();
             },
             get fallback() {
               return (() => {
-                var _el$146 = _tmpl$28$1();
-                insert(_el$146, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
-                return _el$146;
+                var _el$147 = _tmpl$28$1();
+                insert(_el$147, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
+                return _el$147;
               })();
             },
             children: (feedback) => (() => {
-              var _el$147 = _tmpl$32$1(), _el$148 = _el$147.firstChild, _el$149 = _el$148.firstChild, _el$151 = _el$148.nextSibling;
-              insert(_el$149, () => chatFeedbackDisplay().label);
-              insert(_el$148, createComponent(Show, {
+              var _el$148 = _tmpl$32$1(), _el$149 = _el$148.firstChild, _el$150 = _el$149.firstChild, _el$152 = _el$149.nextSibling;
+              insert(_el$150, () => chatFeedbackDisplay().label);
+              insert(_el$149, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().code;
                 },
                 get children() {
-                  var _el$150 = _tmpl$25$1();
-                  insert(_el$150, () => `code=${chatFeedbackDisplay().code}`);
-                  return _el$150;
+                  var _el$151 = _tmpl$25$1();
+                  insert(_el$151, () => `code=${chatFeedbackDisplay().code}`);
+                  return _el$151;
                 }
               }), null);
-              insert(_el$151, () => chatFeedbackDisplay().summary);
-              insert(_el$147, createComponent(Show, {
+              insert(_el$152, () => chatFeedbackDisplay().summary);
+              insert(_el$148, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().detail;
                 },
                 get children() {
-                  var _el$152 = _tmpl$31$1();
-                  insert(_el$152, () => chatFeedbackDisplay().detail);
-                  return _el$152;
+                  var _el$153 = _tmpl$31$1();
+                  insert(_el$153, () => chatFeedbackDisplay().detail);
+                  return _el$153;
                 }
               }), null);
-              insert(_el$147, createComponent(PixelRawDiagnostics, {
+              insert(_el$148, createComponent(PixelRawDiagnostics, {
                 locale,
                 value: feedback
               }), null);
-              createRenderEffect(() => className(_el$149, chatFeedbackDisplay().badgeClass));
-              return _el$147;
+              createRenderEffect(() => className(_el$150, chatFeedbackDisplay().badgeClass));
+              return _el$148;
             })()
-          }), _el$142);
-          insert(_el$143, () => tr$1(locale(), "消息流", "Message Flow"));
-          insert(_el$144, createComponent(Show, {
+          }), _el$143);
+          insert(_el$144, () => tr$1(locale(), "消息流", "Message Flow"));
+          insert(_el$145, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
             get fallback() {
               return (() => {
-                var _el$153 = _tmpl$28$1();
-                insert(_el$153, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
-                return _el$153;
+                var _el$154 = _tmpl$28$1();
+                insert(_el$154, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
+                return _el$154;
               })();
             },
             get children() {
@@ -12357,37 +12604,37 @@ function PixelWorldFocusCommandSurface(props) {
                   return chatHistory();
                 },
                 children: (entry) => (() => {
-                  var _el$154 = _tmpl$33$1(), _el$155 = _el$154.firstChild, _el$156 = _el$155.firstChild, _el$157 = _el$155.nextSibling, _el$158 = _el$157.nextSibling;
-                  insert(_el$156, () => chatEntryTitle$1(entry, locale()));
-                  insert(_el$157, () => chatEntryMeta$1(entry, locale()));
-                  insert(_el$158, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
-                  insert(_el$154, createComponent(PixelRawDiagnostics, {
+                  var _el$155 = _tmpl$33$1(), _el$156 = _el$155.firstChild, _el$157 = _el$156.firstChild, _el$158 = _el$156.nextSibling, _el$159 = _el$158.nextSibling;
+                  insert(_el$157, () => chatEntryTitle$1(entry, locale()));
+                  insert(_el$158, () => chatEntryMeta$1(entry, locale()));
+                  insert(_el$159, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
+                  insert(_el$155, createComponent(PixelRawDiagnostics, {
                     locale,
                     value: entry
                   }), null);
-                  createRenderEffect(() => className(_el$154, chatEntryCardClass$1(entry)));
-                  return _el$154;
+                  createRenderEffect(() => className(_el$155, chatEntryCardClass$1(entry)));
+                  return _el$155;
                 })()
               });
             }
           }));
           createRenderEffect((_p$) => {
-            var _v$27 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$28 = !chatControlsEnabled(), _v$29 = !chatControlsEnabled();
-            _v$27 !== _p$.e && setAttribute(_el$139, "placeholder", _p$.e = _v$27);
-            _v$28 !== _p$.t && (_el$139.disabled = _p$.t = _v$28);
-            _v$29 !== _p$.a && (_el$141.disabled = _p$.a = _v$29);
+            var _v$30 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$31 = !chatControlsEnabled(), _v$32 = !chatControlsEnabled();
+            _v$30 !== _p$.e && setAttribute(_el$140, "placeholder", _p$.e = _v$30);
+            _v$31 !== _p$.t && (_el$140.disabled = _p$.t = _v$31);
+            _v$32 !== _p$.a && (_el$142.disabled = _p$.a = _v$32);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          createRenderEffect(() => _el$139.value = state.chatDraft.message);
-          return _el$130;
+          createRenderEffect(() => _el$140.value = state.chatDraft.message);
+          return _el$131;
         })()];
       }
     }));
-    return _el$111;
+    return _el$112;
   })();
 }
 function PixelWorldHost(props) {
@@ -12636,26 +12883,26 @@ function PixelWorldHost(props) {
     });
   });
   return (() => {
-    var _el$159 = _tmpl$42$1(), _el$164 = _el$159.firstChild, _el$165 = _el$164.firstChild, _el$166 = _el$165.nextSibling, _el$203 = _el$164.nextSibling, _el$204 = _el$203.firstChild;
-    setAttribute(_el$159, "data-visual-fixture", visualFixtureName || "");
-    insert(_el$159, createComponent(Show, {
+    var _el$160 = _tmpl$42$1(), _el$165 = _el$160.firstChild, _el$166 = _el$165.firstChild, _el$167 = _el$166.nextSibling, _el$204 = _el$165.nextSibling, _el$205 = _el$204.firstChild;
+    setAttribute(_el$160, "data-visual-fixture", visualFixtureName || "");
+    insert(_el$160, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$160 = _tmpl$34$1(), _el$161 = _el$160.firstChild, _el$162 = _el$161.firstChild, _el$163 = _el$162.nextSibling;
-        insert(_el$162, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
-        insert(_el$163, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
-        return _el$160;
+        var _el$161 = _tmpl$34$1(), _el$162 = _el$161.firstChild, _el$163 = _el$162.firstChild, _el$164 = _el$163.nextSibling;
+        insert(_el$163, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
+        insert(_el$164, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
+        return _el$161;
       }
-    }), _el$164);
-    insert(_el$165, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
-    addEventListener(_el$166, "click", focusController.enterFocusMode);
-    insert(_el$166, (() => {
+    }), _el$165);
+    insert(_el$166, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
+    addEventListener(_el$167, "click", focusController.enterFocusMode);
+    insert(_el$167, (() => {
       var _c$7 = memo(() => rendererStatus() === "unavailable");
       return () => _c$7() ? tr$1(locale(), "电影视图（当前不可用）", "Cinematic View (unavailable)") : tr$1(locale(), "电影视图", "Cinematic View");
     })());
-    insert(_el$159, createComponent(Show, {
+    insert(_el$160, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
@@ -12700,8 +12947,8 @@ function PixelWorldHost(props) {
           }
         })];
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return renderState();
       },
@@ -12712,8 +12959,8 @@ function PixelWorldHost(props) {
           focusMode
         });
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return memo(() => rendererStatus() !== "fallback")() && rendererStatus() !== "unavailable";
       },
@@ -12745,59 +12992,59 @@ function PixelWorldHost(props) {
           }
         });
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return !renderState();
       },
       get children() {
-        var _el$167 = _tmpl$35$1();
-        insert(_el$167, (() => {
+        var _el$168 = _tmpl$35$1();
+        insert(_el$168, (() => {
           var _c$8 = memo(() => rendererStatus() === "unavailable");
           return () => _c$8() ? [(() => {
-            var _el$207 = _tmpl$43$1();
-            insert(_el$207, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
-            return _el$207;
-          })(), (() => {
-            var _el$208 = _tmpl$44$1();
-            _el$208.$$click = requestReadyMode;
-            insert(_el$208, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
+            var _el$208 = _tmpl$43$1();
+            insert(_el$208, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
             return _el$208;
+          })(), (() => {
+            var _el$209 = _tmpl$44$1();
+            _el$209.$$click = requestReadyMode;
+            insert(_el$209, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
+            return _el$209;
           })()] : tr$1(locale(), "Rust bridge 正在生成世界显示状态。", "Rust bridge is deriving the world display state.");
         })());
         createRenderEffect((_p$) => {
-          var _v$30 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$31 = rendererStatus();
-          _v$30 !== _p$.e && setAttribute(_el$167, "id", _p$.e = _v$30);
-          _v$31 !== _p$.t && setAttribute(_el$167, "data-renderer-state", _p$.t = _v$31);
+          var _v$33 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$34 = rendererStatus();
+          _v$33 !== _p$.e && setAttribute(_el$168, "id", _p$.e = _v$33);
+          _v$34 !== _p$.t && setAttribute(_el$168, "data-renderer-state", _p$.t = _v$34);
           return _p$;
         }, {
           e: void 0,
           t: void 0
         });
-        return _el$167;
+        return _el$168;
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState()?.commercial_surface;
       },
       get children() {
-        var _el$168 = _tmpl$36$1();
-        insert(_el$168, createComponent(PixelWorldActionReceipt, {
+        var _el$169 = _tmpl$36$1();
+        insert(_el$169, createComponent(PixelWorldActionReceipt, {
           "class": "pixel-world-action-receipt--focus-compact",
           locale,
           surface: () => renderState().commercial_surface
         }));
-        return _el$168;
+        return _el$169;
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return focusMode();
       },
       get children() {
-        var _el$169 = _tmpl$37$1(), _el$170 = _el$169.firstChild, _el$171 = _el$170.nextSibling;
-        _el$169.addEventListener("toggle", (event) => {
+        var _el$170 = _tmpl$37$1(), _el$171 = _el$170.firstChild, _el$172 = _el$171.nextSibling;
+        _el$170.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentCommandDrawerOpen(true);
@@ -12807,97 +13054,97 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$170, () => tr$1(locale(), "命令与目标", "Command and Target"));
-        insert(_el$171, createComponent(PixelWorldFocusCommandSurface, {
+        insert(_el$171, () => tr$1(locale(), "命令与目标", "Command and Target"));
+        insert(_el$172, createComponent(PixelWorldFocusCommandSurface, {
           locale
         }));
-        createRenderEffect(() => _el$169.open = commandDrawerOpen());
-        return _el$169;
+        createRenderEffect(() => _el$170.open = commandDrawerOpen());
+        return _el$170;
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$172 = _tmpl$39$1(), _el$173 = _el$172.firstChild, _el$174 = _el$173.nextSibling, _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling, _el$177 = _el$176.nextSibling, _el$179 = _el$177.nextSibling, _el$180 = _el$179.nextSibling, _el$181 = _el$180.nextSibling, _el$182 = _el$181.nextSibling, _el$183 = _el$182.nextSibling, _el$184 = _el$183.nextSibling, _el$188 = _el$184.nextSibling, _el$189 = _el$188.nextSibling, _el$190 = _el$189.nextSibling;
-        insert(_el$173, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
-        insert(_el$175, () => `locations=${visualState().locations.length}`);
-        insert(_el$176, () => `fragments=${visualState().fragmentTerrain.length}`);
-        insert(_el$177, () => `agents=${visualState().agents.length}`);
-        insert(_el$174, createComponent(Show, {
+        var _el$173 = _tmpl$39$1(), _el$174 = _el$173.firstChild, _el$175 = _el$174.nextSibling, _el$176 = _el$175.firstChild, _el$177 = _el$176.nextSibling, _el$178 = _el$177.nextSibling, _el$180 = _el$178.nextSibling, _el$181 = _el$180.nextSibling, _el$182 = _el$181.nextSibling, _el$183 = _el$182.nextSibling, _el$184 = _el$183.nextSibling, _el$185 = _el$184.nextSibling, _el$189 = _el$185.nextSibling, _el$190 = _el$189.nextSibling, _el$191 = _el$190.nextSibling;
+        insert(_el$174, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
+        insert(_el$176, () => `locations=${visualState().locations.length}`);
+        insert(_el$177, () => `fragments=${visualState().fragmentTerrain.length}`);
+        insert(_el$178, () => `agents=${visualState().agents.length}`);
+        insert(_el$175, createComponent(Show, {
           get when() {
             return memo(() => renderState()?.world_tick !== null)() && renderState()?.world_tick !== void 0;
           },
           get children() {
-            var _el$178 = _tmpl$11$1();
-            insert(_el$178, () => `tick=${renderState()?.world_tick}`);
-            createRenderEffect(() => setAttribute(_el$178, "data-world-tick", String(renderState()?.world_tick)));
-            return _el$178;
+            var _el$179 = _tmpl$11$1();
+            insert(_el$179, () => `tick=${renderState()?.world_tick}`);
+            createRenderEffect(() => setAttribute(_el$179, "data-world-tick", String(renderState()?.world_tick)));
+            return _el$179;
           }
-        }), _el$179);
-        insert(_el$179, () => `links=${visualState().links.length}`);
-        insert(_el$180, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
-        insert(_el$181, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$182, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
-        insert(_el$183, () => `renderer=${rendererStatus()}`);
-        insert(_el$184, () => `runtime=${runtimeSource()}`);
-        insert(_el$174, createComponent(Show, {
-          get when() {
-            return cameraState();
-          },
-          get children() {
-            var _el$185 = _tmpl$25$1();
-            insert(_el$185, () => `zoom=${cameraState().zoom.toFixed(2)}`);
-            return _el$185;
-          }
-        }), _el$188);
-        insert(_el$174, createComponent(Show, {
+        }), _el$180);
+        insert(_el$180, () => `links=${visualState().links.length}`);
+        insert(_el$181, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
+        insert(_el$182, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$183, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
+        insert(_el$184, () => `renderer=${rendererStatus()}`);
+        insert(_el$185, () => `runtime=${runtimeSource()}`);
+        insert(_el$175, createComponent(Show, {
           get when() {
             return cameraState();
           },
           get children() {
             var _el$186 = _tmpl$25$1();
-            insert(_el$186, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
+            insert(_el$186, () => `zoom=${cameraState().zoom.toFixed(2)}`);
             return _el$186;
           }
-        }), _el$188);
-        insert(_el$174, createComponent(Show, {
+        }), _el$189);
+        insert(_el$175, createComponent(Show, {
+          get when() {
+            return cameraState();
+          },
+          get children() {
+            var _el$187 = _tmpl$25$1();
+            insert(_el$187, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
+            return _el$187;
+          }
+        }), _el$189);
+        insert(_el$175, createComponent(Show, {
           get when() {
             return hoverSelection();
           },
           get children() {
-            var _el$187 = _tmpl$25$1();
-            insert(_el$187, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
-            return _el$187;
+            var _el$188 = _tmpl$25$1();
+            insert(_el$188, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
+            return _el$188;
           }
-        }), _el$188);
-        _el$188.$$click = requestReadyMode;
-        insert(_el$188, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        _el$189.$$click = simulateFatal;
-        insert(_el$189, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
-        insert(_el$190, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
-        insert(_el$174, createComponent(Show, {
+        }), _el$189);
+        _el$189.$$click = requestReadyMode;
+        insert(_el$189, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        _el$190.$$click = simulateFatal;
+        insert(_el$190, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
+        insert(_el$191, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
+        insert(_el$175, createComponent(Show, {
           get when() {
             return memo(() => rendererStatus() === "unavailable")() && rendererFatal();
           },
           get children() {
-            var _el$191 = _tmpl$38$1();
-            insert(_el$191, () => `${rendererFatal().code}: ${rendererFatal().message}`);
-            return _el$191;
+            var _el$192 = _tmpl$38$1();
+            insert(_el$192, () => `${rendererFatal().code}: ${rendererFatal().message}`);
+            return _el$192;
           }
         }), null);
-        createRenderEffect(() => setAttribute(_el$172, "data-renderer-state", rendererStatus()));
-        return _el$172;
+        createRenderEffect(() => setAttribute(_el$173, "data-renderer-state", rendererStatus()));
+        return _el$173;
       }
-    }), _el$203);
-    insert(_el$159, createComponent(Show, {
+    }), _el$204);
+    insert(_el$160, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
       get children() {
-        var _el$192 = _tmpl$40$1(), _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling, _el$195 = _el$194.firstChild, _el$197 = _el$195.firstChild, _el$198 = _el$197.nextSibling, _el$199 = _el$198.nextSibling, _el$201 = _el$195.nextSibling, _el$202 = _el$201.firstChild;
-        _el$192.addEventListener("toggle", (event) => {
+        var _el$193 = _tmpl$40$1(), _el$194 = _el$193.firstChild, _el$195 = _el$194.nextSibling, _el$196 = _el$195.firstChild, _el$198 = _el$196.firstChild, _el$199 = _el$198.nextSibling, _el$200 = _el$199.nextSibling, _el$202 = _el$196.nextSibling, _el$203 = _el$202.firstChild;
+        _el$193.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentDiagnosticsDrawerOpen(true);
@@ -12907,58 +13154,58 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$193, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
-        insert(_el$195, createComponent(Show, {
+        insert(_el$194, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
+        insert(_el$196, createComponent(Show, {
           get when() {
             return memo(() => renderState().world_tick !== null)() && renderState().world_tick !== void 0;
           },
           get children() {
-            var _el$196 = _tmpl$11$1();
-            insert(_el$196, () => `tick=${renderState().world_tick}`);
-            createRenderEffect(() => setAttribute(_el$196, "data-world-tick", String(renderState().world_tick)));
-            return _el$196;
+            var _el$197 = _tmpl$11$1();
+            insert(_el$197, () => `tick=${renderState().world_tick}`);
+            createRenderEffect(() => setAttribute(_el$197, "data-world-tick", String(renderState().world_tick)));
+            return _el$197;
           }
-        }), _el$197);
-        insert(_el$197, () => `renderer=${rendererStatus()}`);
-        insert(_el$198, () => `runtime=${runtimeSource()}`);
-        insert(_el$199, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$195, createComponent(Show, {
+        }), _el$198);
+        insert(_el$198, () => `renderer=${rendererStatus()}`);
+        insert(_el$199, () => `runtime=${runtimeSource()}`);
+        insert(_el$200, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$196, createComponent(Show, {
           get when() {
             return rendererFatal();
           },
           get children() {
-            var _el$200 = _tmpl$15$1();
-            insert(_el$200, () => rendererFatal().code);
-            return _el$200;
+            var _el$201 = _tmpl$15$1();
+            insert(_el$201, () => rendererFatal().code);
+            return _el$201;
           }
         }), null);
-        _el$202.$$click = requestReadyMode;
-        insert(_el$202, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        createRenderEffect(() => _el$192.open = diagnosticsDrawerOpen());
-        return _el$192;
+        _el$203.$$click = requestReadyMode;
+        insert(_el$203, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        createRenderEffect(() => _el$193.open = diagnosticsDrawerOpen());
+        return _el$193;
       }
-    }), _el$203);
-    _el$203.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
-    insert(_el$204, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
-    insert(_el$203, createComponent(Show, {
+    }), _el$204);
+    _el$204.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
+    insert(_el$205, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
+    insert(_el$204, createComponent(Show, {
       get when() {
         return renderDtoOpen();
       },
       get children() {
-        var _el$205 = _tmpl$41$1(), _el$206 = _el$205.firstChild;
-        insert(_el$206, () => JSON.stringify(renderState(), null, 2));
-        return _el$205;
+        var _el$206 = _tmpl$41$1(), _el$207 = _el$206.firstChild;
+        insert(_el$207, () => JSON.stringify(renderState(), null, 2));
+        return _el$206;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$32 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$33 = focusMode() ? "true" : "false", _v$34 = focusMode() && maximized() ? "true" : "false", _v$35 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$36 = focusMode(), _v$37 = !renderState(), _v$38 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
-      _v$32 !== _p$.e && className(_el$159, _p$.e = _v$32);
-      _v$33 !== _p$.t && setAttribute(_el$159, "data-world-focus", _p$.t = _v$33);
-      _v$34 !== _p$.a && setAttribute(_el$159, "data-world-focus-maximized", _p$.a = _v$34);
-      _v$35 !== _p$.o && setAttribute(_el$159, "data-focus-comparable", _p$.o = _v$35);
-      _v$36 !== _p$.i && (_el$164.hidden = _p$.i = _v$36);
-      _v$37 !== _p$.n && (_el$166.disabled = _p$.n = _v$37);
-      _v$38 !== _p$.s && setAttribute(_el$166, "aria-describedby", _p$.s = _v$38);
+      var _v$35 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$36 = focusMode() ? "true" : "false", _v$37 = focusMode() && maximized() ? "true" : "false", _v$38 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$39 = focusMode(), _v$40 = !renderState(), _v$41 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
+      _v$35 !== _p$.e && className(_el$160, _p$.e = _v$35);
+      _v$36 !== _p$.t && setAttribute(_el$160, "data-world-focus", _p$.t = _v$36);
+      _v$37 !== _p$.a && setAttribute(_el$160, "data-world-focus-maximized", _p$.a = _v$37);
+      _v$38 !== _p$.o && setAttribute(_el$160, "data-focus-comparable", _p$.o = _v$38);
+      _v$39 !== _p$.i && (_el$165.hidden = _p$.i = _v$39);
+      _v$40 !== _p$.n && (_el$167.disabled = _p$.n = _v$40);
+      _v$41 !== _p$.s && setAttribute(_el$167, "aria-describedby", _p$.s = _v$41);
       return _p$;
     }, {
       e: void 0,
@@ -12969,11 +13216,11 @@ function PixelWorldHost(props) {
       n: void 0,
       s: void 0
     });
-    return _el$159;
+    return _el$160;
   })();
 }
 delegateEvents(["click", "input"]);
-var _tmpl$$o = /* @__PURE__ */ template(`<div class=world-feed__latest data-world-feed-latest=true><span class=world-feed__latest-copy>`), _tmpl$2$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$6$b = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$7$7 = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=world-feed__summary-line><div class=panel__title></div><span></span></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class="world-feed__latest world-feed__latest--empty"data-world-feed-latest-empty=true>`), _tmpl$9$3 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$0$3 = /* @__PURE__ */ template(`<div class=feedback-detail role=status aria-live=polite>`), _tmpl$1$1 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$10$1 = /* @__PURE__ */ template(`<article class="event-card world-feed__event"><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
+var _tmpl$$o = /* @__PURE__ */ template(`<div class=world-feed__latest data-world-feed-latest=true><span class=world-feed__latest-copy>`), _tmpl$2$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$6$b = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$7$7 = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=world-feed__summary-line><div class=panel__title></div><span></span></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class="world-feed__latest world-feed__latest--empty"data-world-feed-latest-empty=true>`), _tmpl$9$3 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$0$3 = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__major-event-status">`), _tmpl$1$1 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$10$1 = /* @__PURE__ */ template(`<article><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
 function readFeed(props) {
   return typeof props.feed === "function" ? props.feed() : props.feed || {};
 }
@@ -13042,13 +13289,8 @@ function eventKindLabel(event, locale, tr2) {
   return normalized2.replace(/\b\w/g, (character) => character.toUpperCase());
 }
 function majorEventStatusCopy(event, locale, tr2) {
-  const lifecycle = {
-    active: ["进行中", "active"],
-    resolved: ["已解决", "resolved"],
-    timed_out: ["已超时", "timed out"]
-  }[event?.major_event?.lifecycle];
-  if (!lifecycle) return null;
-  return tr2(locale, `危机${lifecycle[0]} · 严重度 ${event.major_event.severity}`, `Crisis ${lifecycle[1]} · severity ${event.major_event.severity}`);
+  const presentation = pixelWorldMajorEventPresentation(event?.major_event, locale);
+  return typeof tr2 === "function" ? presentation.label : presentation.label;
 }
 function WorldFeedPanel(props) {
   const locale = () => typeof props.locale === "function" ? props.locale() : props.locale || "en";
@@ -13166,11 +13408,22 @@ function WorldFeedPanel(props) {
             insert(_el$25, () => eventKindLabel(event, locale(), tr2));
             insert(_el$21, createComponent(Show, {
               get when() {
-                return memo(() => event.major_event?.freshness === "current")() && status() === "ready";
+                return event.major_event;
               },
               get children() {
                 var _el$26 = _tmpl$0$3();
                 insert(_el$26, () => majorEventStatusCopy(event, locale(), tr2));
+                createRenderEffect((_p$) => {
+                  var _v$6 = pixelWorldMajorEventPresentation(event.major_event, locale()).shape, _v$7 = event.major_event.freshness === "current" && status() === "ready" ? "status" : void 0, _v$8 = event.major_event.freshness === "current" && status() === "ready" ? "polite" : void 0;
+                  _v$6 !== _p$.e && setAttribute(_el$26, "data-major-event-status", _p$.e = _v$6);
+                  _v$7 !== _p$.t && setAttribute(_el$26, "role", _p$.t = _v$7);
+                  _v$8 !== _p$.a && setAttribute(_el$26, "aria-live", _p$.a = _v$8);
+                  return _p$;
+                }, {
+                  e: void 0,
+                  t: void 0,
+                  a: void 0
+                });
                 return _el$26;
               }
             }), null);
@@ -13186,19 +13439,21 @@ function WorldFeedPanel(props) {
               }
             }), null);
             createRenderEffect((_p$) => {
-              var _v$6 = event.event_seq, _v$7 = event.major_event ? event.event_seq : void 0, _v$8 = event.major_event?.category, _v$9 = event.major_event?.lifecycle, _v$0 = event.major_event?.severity;
-              _v$6 !== _p$.e && setAttribute(_el$21, "data-world-feed-event", _p$.e = _v$6);
-              _v$7 !== _p$.t && setAttribute(_el$21, "data-world-feed-major-event", _p$.t = _v$7);
-              _v$8 !== _p$.a && setAttribute(_el$21, "data-major-event-category", _p$.a = _v$8);
-              _v$9 !== _p$.o && setAttribute(_el$21, "data-major-event-lifecycle", _p$.o = _v$9);
-              _v$0 !== _p$.i && setAttribute(_el$21, "data-major-event-severity", _p$.i = _v$0);
+              var _v$9 = `event-card world-feed__event${event.major_event ? ` world-feed__event--major ${pixelWorldMajorEventPresentation(event.major_event, locale()).shape.split(" ").map((token) => `world-feed__event--${token}`).join(" ")}` : ""}`, _v$0 = event.event_seq, _v$1 = event.major_event ? event.event_seq : void 0, _v$10 = event.major_event?.category, _v$11 = event.major_event?.lifecycle, _v$12 = event.major_event?.severity;
+              _v$9 !== _p$.e && className(_el$21, _p$.e = _v$9);
+              _v$0 !== _p$.t && setAttribute(_el$21, "data-world-feed-event", _p$.t = _v$0);
+              _v$1 !== _p$.a && setAttribute(_el$21, "data-world-feed-major-event", _p$.a = _v$1);
+              _v$10 !== _p$.o && setAttribute(_el$21, "data-major-event-category", _p$.o = _v$10);
+              _v$11 !== _p$.i && setAttribute(_el$21, "data-major-event-lifecycle", _p$.i = _v$11);
+              _v$12 !== _p$.n && setAttribute(_el$21, "data-major-event-severity", _p$.n = _v$12);
               return _p$;
             }, {
               e: void 0,
               t: void 0,
               a: void 0,
               o: void 0,
-              i: void 0
+              i: void 0,
+              n: void 0
             });
             return _el$21;
           })()
@@ -19586,6 +19841,7 @@ function HostedLoginGate() {
 function EmptyEntityRecoveryCard(props) {
   const locale = () => props.locale ?? uiLocale();
   const gameplay = () => typeof props.gameplay === "function" ? props.gameplay() : props.gameplay;
+  const blockerPresentation = () => pixelWorldBlockerPresentation(gameplay()?.blockerKind, locale());
   const firstAgentClaimAction = () => (gameplay()?.availableActions || []).find((action2) => action2.actionId === "claim_first_agent");
   const firstAgentClaimDisabledReason = () => gameplayActionDisabledReason(firstAgentClaimAction(), gameplay(), locale());
   return createComponent(CalloutCard, {
@@ -19595,7 +19851,7 @@ function EmptyEntityRecoveryCard(props) {
       return props.title ?? tr(locale(), "认领第一个 Agent", "Claim Your First Agent");
     },
     get badge() {
-      return gameplay()?.blockerKind || "blocked";
+      return blockerPresentation().label;
     },
     get badgeClass() {
       return firstAgentClaimAction() && !firstAgentClaimDisabledReason() ? "badge badge--good" : "badge badge--warn";
@@ -19606,21 +19862,13 @@ function EmptyEntityRecoveryCard(props) {
     get children() {
       return [(() => {
         var _el$88 = _tmpl$9();
-        insert(_el$88, (() => {
-          var _c$4 = memo(() => !!firstAgentClaimDisabledReason());
-          return () => _c$4() ? firstAgentClaimDisabledReason() : memo(() => !!firstAgentClaimAction())() ? tr(locale(), "这是新用户入口：当前还没有可玩实体，先用正式玩法动作认领你的第一个 Agent。", "This is the new-user entry: there are no playable entities yet, so claim your first Agent through the canonical gameplay action.") : gameplay()?.blockerDetail || tr(locale(), "运行时已发布玩法摘要，但当前快照还没有可选行动体或地点。", "Runtime published gameplay summary, but the current snapshot still has no selectable agents or locations.");
-        })());
+        insert(_el$88, () => firstAgentClaimDisabledReason() || blockerPresentation().reason);
         return _el$88;
+      })(), (() => {
+        var _el$89 = _tmpl$6();
+        insert(_el$89, () => gameplay()?.nextStepHint || blockerPresentation().nextAction);
+        return _el$89;
       })(), createComponent(Show, {
-        get when() {
-          return gameplay()?.nextStepHint;
-        },
-        get children() {
-          var _el$89 = _tmpl$6();
-          insert(_el$89, () => gameplay().nextStepHint);
-          return _el$89;
-        }
-      }), createComponent(Show, {
         get when() {
           return gameplay()?.entityCounts;
         },
@@ -19641,8 +19889,8 @@ function EmptyEntityRecoveryCard(props) {
       }), (() => {
         var _el$91 = _tmpl$6();
         insert(_el$91, (() => {
-          var _c$5 = memo(() => !!firstAgentClaimAction());
-          return () => _c$5() ? tr(locale(), "认领提交后等待链上提交与快照同步；同步完成后第一个 Agent 会出现在世界里。", "After submitting the claim, wait for chain submission and snapshot sync; the first Agent appears once the committed world updates.") : tr(locale(), "如果页面仍提供“刷新快照”动作，先从当前入口重拉一次；如果数量仍然是 0，就需要修复或重启运行时世界引导流程。", "If the page still exposes a refresh action, pull a fresh snapshot from the current entry first. If the counts stay at 0, repair or restart the runtime world bootstrap.");
+          var _c$4 = memo(() => !!firstAgentClaimAction());
+          return () => _c$4() ? tr(locale(), "认领提交后等待链上提交与快照同步；同步完成后第一个 Agent 会出现在世界里。", "After submitting the claim, wait for chain submission and snapshot sync; the first Agent appears once the committed world updates.") : tr(locale(), "如果页面仍提供“刷新快照”动作，先从当前入口重拉一次；如果数量仍然是 0，就需要修复或重启运行时世界引导流程。", "If the page still exposes a refresh action, pull a fresh snapshot from the current entry first. If the counts stay at 0, repair or restart the runtime world bootstrap.");
         })());
         return _el$91;
       })()];
@@ -20071,8 +20319,8 @@ function StarterOcOnboardingPanel(props) {
             return (() => {
               var _el$117 = _tmpl$6();
               insert(_el$117, (() => {
-                var _c$7 = memo(() => !!waitingForFirstAgent());
-                return () => _c$7() ? tr(locale(), "当前还在等第一个 Agent 写入 committed 快照；OC 按钮会在 Agent 同步后自动出现。", "The first Agent is still waiting for the committed snapshot; the OC button appears automatically after the Agent syncs.") : tr(locale(), "如果聊天提示 OC 不足，回到这里领取初始 OC。", "If chat says OC is missing, return here to claim starter OC.");
+                var _c$6 = memo(() => !!waitingForFirstAgent());
+                return () => _c$6() ? tr(locale(), "当前还在等第一个 Agent 写入 committed 快照；OC 按钮会在 Agent 同步后自动出现。", "The first Agent is still waiting for the committed snapshot; the OC button appears automatically after the Agent syncs.") : tr(locale(), "如果聊天提示 OC 不足，回到这里领取初始 OC。", "If chat says OC is missing, return here to claim starter OC.");
               })());
               return _el$117;
             })();
@@ -20104,8 +20352,8 @@ function StarterOcOnboardingPanel(props) {
       get children() {
         var _el$116 = _tmpl$6();
         insert(_el$116, (() => {
-          var _c$6 = memo(() => !!waitingForFirstAgent());
-          return () => _c$6() ? tr(locale(), "当前还在等第一个 Agent 写入 committed 快照；OC 按钮会在 Agent 同步后自动出现。", "The first Agent is still waiting for the committed snapshot; the OC button appears automatically after the Agent syncs.") : tr(locale(), "如果聊天提示 OC 不足，回到这里领取初始 OC。", "If chat says OC is missing, return here to claim starter OC.");
+          var _c$5 = memo(() => !!waitingForFirstAgent());
+          return () => _c$5() ? tr(locale(), "当前还在等第一个 Agent 写入 committed 快照；OC 按钮会在 Agent 同步后自动出现。", "The first Agent is still waiting for the committed snapshot; the OC button appears automatically after the Agent syncs.") : tr(locale(), "如果聊天提示 OC 不足，回到这里领取初始 OC。", "If chat says OC is missing, return here to claim starter OC.");
         })());
         return _el$116;
       }
@@ -20235,8 +20483,8 @@ function StarterOcRequiredGate() {
       var _el$120 = _tmpl$33(), _el$121 = _el$120.firstChild, _el$122 = _el$121.firstChild, _el$123 = _el$122.firstChild, _el$124 = _el$123.firstChild, _el$125 = _el$124.nextSibling, _el$127 = _el$122.nextSibling;
       insert(_el$124, () => tr(locale(), "新手必经步骤", "Required Onboarding Step"));
       insert(_el$125, (() => {
-        var _c$8 = memo(() => !!creditConfirmed());
-        return () => _c$8() ? tr(locale(), "OC 已入账", "OC Credited") : memo(() => !!pendingCredit())() ? tr(locale(), "正在确认 OC 入账", "Confirming OC Credit") : tr(locale(), "领取第一笔 OC", "Claim Your First OC");
+        var _c$7 = memo(() => !!creditConfirmed());
+        return () => _c$7() ? tr(locale(), "OC 已入账", "OC Credited") : memo(() => !!pendingCredit())() ? tr(locale(), "正在确认 OC 入账", "Confirming OC Credit") : tr(locale(), "领取第一笔 OC", "Claim Your First OC");
       })());
       insert(_el$122, createComponent(Badge, {
         get ["class"]() {
@@ -20256,18 +20504,18 @@ function StarterOcRequiredGate() {
             insert(_el$130, confirmSummaryCopy);
             insert(_el$133, () => tr(locale(), "状态", "Status"));
             insert(_el$134, (() => {
-              var _c$0 = memo(() => !!creditConfirmed());
-              return () => _c$0() ? tr(locale(), "已入账", "Credited") : confirmStatusLabel();
+              var _c$9 = memo(() => !!creditConfirmed());
+              return () => _c$9() ? tr(locale(), "已入账", "Credited") : confirmStatusLabel();
             })());
             insert(_el$136, () => tr(locale(), "进度", "Progress"));
             insert(_el$137, (() => {
-              var _c$1 = memo(() => !!creditConfirmed());
-              return () => _c$1() ? tr(locale(), "完成", "Done") : confirmProgressLabel();
+              var _c$0 = memo(() => !!creditConfirmed());
+              return () => _c$0() ? tr(locale(), "完成", "Done") : confirmProgressLabel();
             })());
             insert(_el$139, () => tr(locale(), "你可以做什么", "What To Do"));
             insert(_el$140, (() => {
-              var _c$10 = memo(() => !!creditConfirmed());
-              return () => _c$10() ? tr(locale(), "开始聊天", "Start chat") : tr(locale(), "先看玩法说明", "Read the guide");
+              var _c$1 = memo(() => !!creditConfirmed());
+              return () => _c$1() ? tr(locale(), "开始聊天", "Start chat") : tr(locale(), "先看玩法说明", "Read the guide");
             })());
             insert(_el$129, createComponent(StarterOcGuide, {
               get locale() {
@@ -20329,8 +20577,8 @@ function StarterOcRequiredGate() {
         get children() {
           var _el$126 = _tmpl$6();
           insert(_el$126, (() => {
-            var _c$9 = memo(() => !!creditConfirmed());
-            return () => _c$9() ? tr(locale(), "OC 会作为第一次 LLM/Agent chat 的启动预算；用它向 Agent 发第一条指令，推动产线恢复。", "OC is the starter budget for the first LLM/Agent chat. Use it to send the first command and move production forward.") : memo(() => !!pendingCredit())() ? tr(locale(), "不用空等：系统会自动推进确认。若本地世界暂时没有回执，下面的按钮可以手动补一次确认。", "No need to idle: confirmation runs automatically. If the local world has not responded yet, the button below can retry one confirmation.") : tr(locale(), "这是进入 Agent 聊天和早期玩法动作前必须完成的一步。领取后会进入入账确认。", "This step is required before Agent chat and early gameplay actions. Claiming it moves you to credit confirmation.");
+            var _c$8 = memo(() => !!creditConfirmed());
+            return () => _c$8() ? tr(locale(), "OC 会作为第一次 LLM/Agent chat 的启动预算；用它向 Agent 发第一条指令，推动产线恢复。", "OC is the starter budget for the first LLM/Agent chat. Use it to send the first command and move production forward.") : memo(() => !!pendingCredit())() ? tr(locale(), "不用空等：系统会自动推进确认。若本地世界暂时没有回执，下面的按钮可以手动补一次确认。", "No need to idle: confirmation runs automatically. If the local world has not responded yet, the button below can retry one confirmation.") : tr(locale(), "这是进入 Agent 聊天和早期玩法动作前必须完成的一步。领取后会进入入账确认。", "This step is required before Agent chat and early gameplay actions. Claiming it moves you to credit confirmation.");
           })());
           return _el$126;
         }
@@ -20615,16 +20863,7 @@ function chatEntryMessage(entry, locale) {
   return message || tr(locale, "这条消息没有可读正文。", "This message has no readable text.");
 }
 function connectionStatusLabel(status, locale) {
-  if (status === "connected") {
-    return tr(locale, "世界在线", "World Live");
-  }
-  if (status === "connecting") {
-    return tr(locale, "正在连入世界", "Connecting to World");
-  }
-  if (status === "closed") {
-    return tr(locale, "连接已关闭", "Connection Closed");
-  }
-  return tr(locale, `连接异常：${status || "unknown"}`, `Connection Issue: ${status || "unknown"}`);
+  return pixelWorldConnectionPresentation(status, locale).label;
 }
 function renderResourceSummary(resources) {
   return resourceSummary$1(resources);
@@ -21619,7 +21858,7 @@ function WorldSummaryPanel(props = {}) {
                     insert(_el$269, createComponent(Badge, {
                       "class": "badge badge--warn",
                       get children() {
-                        return gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker");
+                        return pixelWorldBlockerPresentation(gameplay().blockerKind, locale()).label;
                       }
                     }));
                     return _el$269;
@@ -23081,8 +23320,8 @@ function InteractionPanel() {
       insert(_el$308, () => selectedAgentContextModel().freshness?.label || tr(locale(), "不可用", "Unavailable"), null);
       insert(_el$312, () => tr(locale(), "目标", "Objective"));
       insert(_el$311, (() => {
-        var _c$11 = memo(() => !!(selectedAgentContextModel().objective?.state === "published" && selectedAgentContextModel().objective.value));
-        return () => _c$11() ? selectedAgentContextModel().objective.value : tr(locale(), "目标不可用", "Objective unavailable");
+        var _c$10 = memo(() => !!(selectedAgentContextModel().objective?.state === "published" && selectedAgentContextModel().objective.value));
+        return () => _c$10() ? selectedAgentContextModel().objective.value : tr(locale(), "目标不可用", "Objective unavailable");
       })(), null);
       insert(_el$302, createComponent(AgentContextLite, {
         get model() {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -9562,7 +9562,7 @@ const core = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty
   toggleViewerLocale,
   updatePixelWorldRuntimeMeta
 }, Symbol.toStringTag, { value: "Module" }));
-var _tmpl$$s = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$s = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
+var _tmpl$$t = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$s = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
 const ZH_VALUE_MAP = {
   chat_purpose: {
     "Start a first conversation with your claimed Agent.": "与已认领的 Agent 开始第一次对话。"
@@ -9593,7 +9593,7 @@ function FirstChatUnlockPreview(props) {
   const fields = () => [["chat_purpose", tr2("目的", "Purpose")], ["immediate_playable_help", tr2("即时帮助", "Immediate help")], ["first_question_or_action_hint", tr2("先试试", "Try first")], ["resource_boundary", tr2("资源边界", "Resource boundary")], ["defer_effect", tr2("如果等待", "If you wait")], ["recommended_unlock_action", tr2("建议操作", "Recommended action")]];
   const value2 = (field) => field === "recommended_unlock_action" ? recommendedActionValue(props.preview[field], locale()) : previewValue(field, props.preview[field], locale());
   return (() => {
-    var _el$ = _tmpl$$s();
+    var _el$ = _tmpl$$t();
     insert(_el$, createComponent(For, {
       get each() {
         return fields();
@@ -10512,7 +10512,7 @@ function pixelWorldSparseScenePresentation(data = {}, locale) {
     hasSparseTopology: routeCount === 0 || terrainCount === 0
   };
 }
-var _tmpl$$r = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$3$n = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$4$k = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$5$j = /* @__PURE__ */ template(`<div>`), _tmpl$6$d = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span class=pixel-world-entity__code>`), _tmpl$7$9 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$8$6 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__legend data-pixel-world-legend=true><div class=pixel-world-canvas__legend-title></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class=pixel-world-canvas__legend-swatch aria-hidden=true></span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>◆</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>!</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>▪</span><span>`), _tmpl$9$5 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__sparse-guidance data-pixel-world-sparse-guidance=true><div class=pixel-world-canvas__sparse-title></div><div data-sparse-field=entities></div><div data-sparse-field=routes></div><div data-sparse-field=terrain></div><div data-sparse-field=bounds>`);
+var _tmpl$$s = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$3$n = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$4$k = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$5$j = /* @__PURE__ */ template(`<div>`), _tmpl$6$d = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span class=pixel-world-entity__code>`), _tmpl$7$9 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$8$6 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__legend data-pixel-world-legend=true><div class=pixel-world-canvas__legend-title></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class=pixel-world-canvas__legend-swatch aria-hidden=true></span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>◆</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>!</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>▪</span><span>`), _tmpl$9$5 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__sparse-guidance data-pixel-world-sparse-guidance=true><div class=pixel-world-canvas__sparse-title></div><div data-sparse-field=entities></div><div data-sparse-field=routes></div><div data-sparse-field=terrain></div><div data-sparse-field=bounds>`);
 const FRAGMENT_TERRAIN_PALETTE = {
   unknown: [148, 163, 184]
 };
@@ -10701,7 +10701,7 @@ function PixelWorldCanvasAgentHitTargets(props) {
     children: (agent, index) => {
       const label = pixelWorldReadableAgentLabel(agent, agent.id, isLocaleZh(props.locale()));
       return (() => {
-        var _el$ = _tmpl$$r(), _el$2 = _el$.firstChild;
+        var _el$ = _tmpl$$s(), _el$2 = _el$.firstChild;
         _el$.$$click = () => props.onSelect({
           kind: "agent",
           id: agent.id
@@ -10985,6 +10985,7 @@ function pixelWorldMarkerClearance(marker, panels, bounds) {
 }
 function applyPixelWorldMarkerClearance(canvasRoot) {
   if (!canvasRoot) return;
+  if (canvasRoot.dataset.rendererProjection === "true") return;
   const markers = [...canvasRoot.querySelectorAll("button.pixel-world-entity, button.pixel-world-hotspot")];
   for (const marker of markers) marker.style.translate = "";
   const visibleRect = (node) => {
@@ -11013,6 +11014,25 @@ function observePixelWorldMarkerPanels(sync) {
   for (const panel of document.querySelectorAll(PANELS)) observer.observe(panel);
   return () => observer.disconnect();
 }
+const CLEARANCE = 8;
+const MIN_PANEL_HEIGHT = 160;
+function rendererDecisionMaxHeight(panel, viewportHeight, hotspots) {
+  let height = Math.max(MIN_PANEL_HEIGHT, viewportHeight / 2 - 76);
+  for (const hotspot of hotspots) {
+    if (hotspot.right <= panel.left || hotspot.left >= panel.right || hotspot.bottom <= 0 || hotspot.top >= viewportHeight) continue;
+    height = Math.min(height, panel.bottom - hotspot.bottom - CLEARANCE);
+  }
+  return Math.max(MIN_PANEL_HEIGHT, Math.floor(height));
+}
+function applyRendererDecisionClearance(canvasRoot) {
+  if (canvasRoot?.dataset.rendererProjection !== "true") return;
+  const host = canvasRoot.closest(".pixel-world-host");
+  const panel = host?.querySelector(".pixel-world-decision-area");
+  if (!panel) return;
+  const hotspots = [...canvasRoot.querySelectorAll('.pixel-world-hotspot[data-renderer-target="true"]')].filter((node) => getComputedStyle(node).display !== "none").map((node) => node.getBoundingClientRect());
+  const height = rendererDecisionMaxHeight(panel.getBoundingClientRect(), window.innerHeight, hotspots);
+  panel.style.setProperty("--renderer-decision-max-height", `${height}px`);
+}
 const MOBILE_SHELL_MAX_WIDTH = 640;
 const SAFE_AREA_GAP_PX = 8;
 function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, commandTop, feedBottom = 0 }) {
@@ -11030,6 +11050,7 @@ function pixelWorldMobileFocusSelectionOffset({ markerLeft, hudRight }) {
   return hudRight + SAFE_AREA_GAP_PX - markerLeft;
 }
 function applyMobileSelectionSafeArea(canvasRoot) {
+  if (canvasRoot?.dataset.rendererProjection === "true") return;
   const marker = canvasRoot?.querySelector(".pixel-world-entity--canvas-hit-target[data-selected='true']");
   const selectionChip = canvasRoot?.querySelector(".pixel-world-canvas__selection");
   const feed = document.querySelector('[data-viewer-overlay="feed"]');
@@ -11071,6 +11092,7 @@ function applyMobileSelectionSafeArea(canvasRoot) {
   marker.style.translate = `0 ${Math.floor(offset)}px`;
 }
 function applyPixelWorldMobileSelectionSafeArea(canvasRoot) {
+  applyRendererDecisionClearance(canvasRoot);
   applyMobileSelectionSafeArea(canvasRoot);
   applyPixelWorldMarkerClearance(canvasRoot);
 }
@@ -11194,7 +11216,7 @@ function pixelWorldHotspotGlyphSize(hotspot) {
     Math.min(32, safeNumber(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
   );
 }
-function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
+function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState, stageSize = { width: PIXEL_WORLD_CANVAS_WIDTH, height: PIXEL_WORLD_CANVAS_HEIGHT }) {
   const fallback = {
     left: `${20 + index % 4 * 16}%`,
     top: `${22 + Math.floor(index / 4) * 16}%`
@@ -11208,16 +11230,16 @@ function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
       transform: "translate(-50%, -50%)"
     };
   }
-  const point = toCanvasPoint(position, worldBounds, PIXEL_WORLD_CANVAS_WIDTH, PIXEL_WORLD_CANVAS_HEIGHT, cameraState);
+  const point = toCanvasPoint(position, worldBounds, stageSize.width, stageSize.height, cameraState);
   return {
-    left: `${point.x / PIXEL_WORLD_CANVAS_WIDTH * 100}%`,
-    top: `${point.y / PIXEL_WORLD_CANVAS_HEIGHT * 100}%`,
+    left: `${point.x / stageSize.width * 100}%`,
+    top: `${point.y / stageSize.height * 100}%`,
     width: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
     height: `${PIXEL_WORLD_HOTSPOT_TOUCH_TARGET_PX}px`,
     transform: "translate(-50%, -50%)"
   };
 }
-var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span data-hotspot-tooltip-body></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
+var _tmpl$$r = /* @__PURE__ */ template(`<button type=button class=pixel-world-hotspot data-hotspot-hit-target=44><span class=pixel-world-hotspot__glyph aria-hidden=true style=pointer-events:none>`), _tmpl$2$q = /* @__PURE__ */ template(`<div class=pixel-world-canvas__hotspot-tooltip data-hotspot-tooltip role=status><span data-hotspot-tooltip-body></span><button type=button class=pixel-world-canvas__hotspot-tooltip-close>×`);
 function isZhLocale(locale) {
   return String(locale || "").trim().toLowerCase().startsWith("zh");
 }
@@ -11292,7 +11314,7 @@ function PixelWorldHotspot(props) {
     props.onHover?.(selection());
   };
   return (() => {
-    var _el$ = _tmpl$$q(), _el$2 = _el$.firstChild;
+    var _el$ = _tmpl$$r(), _el$2 = _el$.firstChild;
     _el$.$$click = (event) => {
       event.preventDefault();
       event.stopPropagation();
@@ -11341,25 +11363,26 @@ function PixelWorldHotspot(props) {
       return () => _c$() ? "!" : hotspot().kind === "goal" ? "G" : "i";
     })());
     createRenderEffect((_p$) => {
-      var _v$ = hotspot().kind, _v$2 = !visible(), _v$3 = visible() ? 0 : -1, _v$4 = !visible(), _v$5 = {
+      var _v$ = hotspot().kind, _v$2 = props.rendererProjection ? "true" : void 0, _v$3 = !visible(), _v$4 = visible() ? 0 : -1, _v$5 = !visible(), _v$6 = {
         ...props.style,
         display: visible() ? void 0 : "none",
         "--hotspot-projected-x": props.style?.left,
         "--hotspot-projected-y": props.style?.top,
-        left: `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
-        top: `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`
-      }, _v$6 = `${hotspot().kind}:${hotspot().label}`, _v$7 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$8 = pixelWorldHotspotTooltipId(hotspot()), _v$9 = `${Number(props.glyphSize) || 20}px`, _v$0 = `${Number(props.glyphSize) || 20}px`, _v$1 = `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`;
+        left: props.rendererProjection ? props.style?.left : `clamp(22px, ${props.style?.left || "50%"}, calc(100% - 22px))`,
+        top: props.rendererProjection ? props.style?.top : `clamp(22px, ${props.style?.top || "50%"}, calc(100% - 22px))`
+      }, _v$7 = `${hotspot().kind}:${hotspot().label}`, _v$8 = pixelWorldHotspotAccessibleLabel(props.locale, hotspot()), _v$9 = pixelWorldHotspotTooltipId(hotspot()), _v$0 = `${Number(props.glyphSize) || 20}px`, _v$1 = `${Number(props.glyphSize) || 20}px`, _v$10 = `translate(${glyphOffset("left", "width")}px, ${glyphOffset("top", "height")}px)`;
       _v$ !== _p$.e && setAttribute(_el$, "data-hotspot-kind", _p$.e = _v$);
-      _v$2 !== _p$.t && (_el$.disabled = _p$.t = _v$2);
-      _v$3 !== _p$.a && setAttribute(_el$, "tabindex", _p$.a = _v$3);
-      _v$4 !== _p$.o && setAttribute(_el$, "aria-hidden", _p$.o = _v$4);
-      _p$.i = style(_el$, _v$5, _p$.i);
-      _v$6 !== _p$.n && setAttribute(_el$, "title", _p$.n = _v$6);
-      _v$7 !== _p$.s && setAttribute(_el$, "aria-label", _p$.s = _v$7);
-      _v$8 !== _p$.h && setAttribute(_el$, "aria-describedby", _p$.h = _v$8);
-      _v$9 !== _p$.r && setStyleProperty(_el$2, "width", _p$.r = _v$9);
-      _v$0 !== _p$.d && setStyleProperty(_el$2, "height", _p$.d = _v$0);
-      _v$1 !== _p$.l && setStyleProperty(_el$2, "transform", _p$.l = _v$1);
+      _v$2 !== _p$.t && setAttribute(_el$, "data-renderer-target", _p$.t = _v$2);
+      _v$3 !== _p$.a && (_el$.disabled = _p$.a = _v$3);
+      _v$4 !== _p$.o && setAttribute(_el$, "tabindex", _p$.o = _v$4);
+      _v$5 !== _p$.i && setAttribute(_el$, "aria-hidden", _p$.i = _v$5);
+      _p$.n = style(_el$, _v$6, _p$.n);
+      _v$7 !== _p$.s && setAttribute(_el$, "title", _p$.s = _v$7);
+      _v$8 !== _p$.h && setAttribute(_el$, "aria-label", _p$.h = _v$8);
+      _v$9 !== _p$.r && setAttribute(_el$, "aria-describedby", _p$.r = _v$9);
+      _v$0 !== _p$.d && setStyleProperty(_el$2, "width", _p$.d = _v$0);
+      _v$1 !== _p$.l && setStyleProperty(_el$2, "height", _p$.l = _v$1);
+      _v$10 !== _p$.u && setStyleProperty(_el$2, "transform", _p$.u = _v$10);
       return _p$;
     }, {
       e: void 0,
@@ -11372,7 +11395,8 @@ function PixelWorldHotspot(props) {
       h: void 0,
       r: void 0,
       d: void 0,
-      l: void 0
+      l: void 0,
+      u: void 0
     });
     return _el$;
   })();
@@ -11405,9 +11429,9 @@ function PixelWorldHotspotTooltip(props) {
         }
       };
       createRenderEffect((_p$) => {
-        var _v$10 = pixelWorldHotspotTooltipId(hotspot()), _v$11 = tr$2(props.locale, "关闭热点说明", "Close hotspot explanation");
-        _v$10 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$10);
-        _v$11 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$11);
+        var _v$11 = pixelWorldHotspotTooltipId(hotspot()), _v$12 = tr$2(props.locale, "关闭热点说明", "Close hotspot explanation");
+        _v$11 !== _p$.e && setAttribute(_el$3, "id", _p$.e = _v$11);
+        _v$12 !== _p$.t && setAttribute(_el$5, "aria-label", _p$.t = _v$12);
         return _p$;
       }, {
         e: void 0,
@@ -11418,6 +11442,81 @@ function PixelWorldHotspotTooltip(props) {
   });
 }
 delegateEvents(["mousemove", "keydown", "click"]);
+var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-renderer-target"data-renderer-target=true>`);
+function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
+  const {
+    width,
+    height
+  } = size;
+  const idLength = new TextEncoder().encode(entity.id || "").length;
+  const point = toCanvasPoint(entity.pos, worldBounds, width, height, camera) || toCanvasPoint({
+    x_cm: 36 + idLength * 29 % Math.max(40, width - 72),
+    y_cm: 44 + idLength * 17 % Math.max(48, height - 88)
+  }, {
+    width_cm: width,
+    depth_cm: height
+  }, width, height, camera);
+  return {
+    left: `${point.x / width * 100}%`,
+    top: `${point.y / height * 100}%`,
+    width: "44px",
+    height: "44px",
+    transform: "translate(-50%, -50%)",
+    display: point.x < 0 || point.y < 0 || point.x > width || point.y > height ? "none" : void 0
+  };
+}
+function PixelWorldRendererTargets(props) {
+  const state2 = () => pixelWorldVisualState(props.renderState());
+  const isZh = () => isLocaleZh(props.locale());
+  const entities = () => [...state2().agents.map((entity) => ({
+    entity,
+    kind: "agent"
+  })), ...(state2().worldBounds ? state2().locations.filter((entity) => entity.pos) : []).map((entity) => ({
+    entity,
+    kind: "location"
+  }))];
+  return createComponent(For, {
+    get each() {
+      return entities();
+    },
+    children: ({
+      entity,
+      kind
+    }) => (() => {
+      var _el$ = _tmpl$$q();
+      _el$.addEventListener("mouseleave", () => props.onHover(null));
+      _el$.addEventListener("mouseenter", () => props.onHover({
+        kind,
+        id: entity.id
+      }));
+      _el$.$$click = () => props.onSelect({
+        kind,
+        id: entity.id
+      });
+      setAttribute(_el$, "data-pixel-world-agent-marker", kind === "agent" ? "true" : void 0);
+      setAttribute(_el$, "data-pixel-world-location-marker", kind === "location" ? "true" : void 0);
+      createRenderEffect((_p$) => {
+        var _v$ = kind === "agent" ? entity.id : void 0, _v$2 = kind === "location" ? entity.id : void 0, _v$3 = props.selection()?.kind === kind && props.selection()?.id === entity.id ? "true" : "false", _v$4 = props.selection()?.kind === kind && props.selection()?.id === entity.id, _v$5 = `${isZh() ? "选择" : "Select"} ${kind === "agent" ? pixelWorldReadableAgentLabel(entity, entity.id, isZh()) : entity.label || entity.id}`, _v$6 = rendererEntityTargetStyle(entity, state2().worldBounds, props.stageSize(), props.cameraState?.());
+        _v$ !== _p$.e && setAttribute(_el$, "data-agent-id", _p$.e = _v$);
+        _v$2 !== _p$.t && setAttribute(_el$, "data-location-id", _p$.t = _v$2);
+        _v$3 !== _p$.a && setAttribute(_el$, "data-selected", _p$.a = _v$3);
+        _v$4 !== _p$.o && setAttribute(_el$, "aria-pressed", _p$.o = _v$4);
+        _v$5 !== _p$.i && setAttribute(_el$, "aria-label", _p$.i = _v$5);
+        _p$.n = style(_el$, _v$6, _p$.n);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
+      });
+      return _el$;
+    })()
+  });
+}
+delegateEvents(["click"]);
 var _tmpl$$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$j = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__changes data-receipt-changes=true>`), _tmpl$7$8 = /* @__PURE__ */ template(`<span>`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$0$4 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$1$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$10$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__feedback data-primary-action-feedback=true aria-live=polite>`), _tmpl$11$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div id=viewer-decision-area class=pixel-world-decision-area data-viewer-decision-area=true><div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action data-primary-action=true aria-live=polite></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong></strong></div></div></div></div><div class="pixel-world-readout badge-row"><span></span><span></span><span class="badge badge--accent">`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$15$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$23$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$24$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$25$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$37$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$39$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$40$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div>`), _tmpl$44$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
@@ -11463,7 +11562,10 @@ function PixelWorldHostHotspotLayer(props) {
         return hotspot();
       },
       get style() {
-        return pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.());
+        return pixelWorldHotspotStyle(hotspot(), visualState().worldBounds, index, props.cameraState?.(), props.stageSize?.());
+      },
+      get rendererProjection() {
+        return props.rendererProjection?.();
       },
       get glyphSize() {
         return pixelWorldHotspotGlyphSize(hotspot());
@@ -11711,6 +11813,24 @@ function buildPixelWorldRenderInput(locale = state.uiLocale) {
 }
 function PixelWorldCanvasRenderer(props) {
   let canvasRef;
+  const [stageSize, setStageSize] = createSignal({
+    width: 960,
+    height: 540
+  });
+  onMount(() => {
+    const update = () => {
+      const rect = canvasRef?.getBoundingClientRect();
+      if (rect?.width && rect?.height) setStageSize({
+        width: rect.width,
+        height: rect.height
+      });
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(canvasRef);
+    onCleanup(() => observer.disconnect());
+  });
   const hotspotFocus = createHotspotFocusRestoration();
   const visualState = () => pixelWorldVisualState(props.renderState());
   const [inspectedHotspot, setInspectedHotspot] = createSignal(null);
@@ -11724,6 +11844,11 @@ function PixelWorldCanvasRenderer(props) {
   };
   const selectedEntityLabel = () => pixelWorldSelectedEntityLabel(visualState(), visualState().selection, isLocaleZh(props.locale()));
   onMount(() => onCleanup(installPixelWorldMobileSelectionSafeArea(() => canvasRef?.closest(".pixel-world-canvas"))));
+  createEffect(() => {
+    props.cameraState?.();
+    stageSize();
+    requestAnimationFrame(() => applyPixelWorldMobileSelectionSafeArea(canvasRef?.closest(".pixel-world-canvas")));
+  });
   createEffect(() => {
     if (!canvasRef) {
       return;
@@ -11743,47 +11868,76 @@ function PixelWorldCanvasRenderer(props) {
     var _ref$ = canvasRef;
     typeof _ref$ === "function" ? use(_ref$, _el$2) : canvasRef = _el$2;
     insert(_el$3, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
-    insert(_el$4, createComponent(PixelWorldCanvasAgentHitTargets, {
-      get locale() {
-        return props.locale;
+    insert(_el$4, createComponent(Show, {
+      get when() {
+        return props.rendererProjection?.();
       },
-      get renderState() {
-        return props.renderState;
+      get fallback() {
+        return [createComponent(PixelWorldCanvasAgentHitTargets, {
+          get locale() {
+            return props.locale;
+          },
+          get renderState() {
+            return props.renderState;
+          },
+          get selection() {
+            return props.selection;
+          },
+          get hovered() {
+            return props.hoveredEntity;
+          },
+          get onSelect() {
+            return props.onSelect;
+          },
+          get onHover() {
+            return props.onHover;
+          }
+        }), createComponent(PixelWorldHostVisualLayer, {
+          get enabled() {
+            return props.visualOverlayEnabled?.() ?? false;
+          },
+          get locale() {
+            return props.locale;
+          },
+          get renderState() {
+            return props.renderState;
+          },
+          get selection() {
+            return props.selection;
+          },
+          get hovered() {
+            return props.hoveredEntity;
+          },
+          get onSelect() {
+            return props.onSelect;
+          },
+          get onHover() {
+            return props.onHover;
+          }
+        })];
       },
-      get selection() {
-        return props.selection;
-      },
-      get hovered() {
-        return props.hoveredEntity;
-      },
-      get onSelect() {
-        return props.onSelect;
-      },
-      get onHover() {
-        return props.onHover;
-      }
-    }), null);
-    insert(_el$4, createComponent(PixelWorldHostVisualLayer, {
-      get enabled() {
-        return props.visualOverlayEnabled?.() ?? false;
-      },
-      get locale() {
-        return props.locale;
-      },
-      get renderState() {
-        return props.renderState;
-      },
-      get selection() {
-        return props.selection;
-      },
-      get hovered() {
-        return props.hoveredEntity;
-      },
-      get onSelect() {
-        return props.onSelect;
-      },
-      get onHover() {
-        return props.onHover;
+      get children() {
+        return createComponent(PixelWorldRendererTargets, {
+          get locale() {
+            return props.locale;
+          },
+          get renderState() {
+            return props.renderState;
+          },
+          get selection() {
+            return props.selection;
+          },
+          get cameraState() {
+            return props.cameraState;
+          },
+          stageSize,
+          get onSelect() {
+            return props.onSelect;
+          },
+          get onHover() {
+            return props.onHover;
+          }
+        });
       }
     }), null);
     insert(_el$4, createComponent(PixelWorldHostHotspotLayer, {
@@ -11796,6 +11950,10 @@ function PixelWorldCanvasRenderer(props) {
       get cameraState() {
         return props.cameraState;
       },
+      get rendererProjection() {
+        return props.rendererProjection;
+      },
+      stageSize: () => props.rendererProjection?.() ? stageSize() : void 0,
       get onHover() {
         return props.onHover;
       },
@@ -11868,13 +12026,15 @@ function PixelWorldCanvasRenderer(props) {
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$ = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$2 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
-      _v$ !== _p$.e && setAttribute(_el$, "data-renderer-ready", _p$.e = _v$);
-      _v$2 !== _p$.t && setAttribute(_el$2, "aria-label", _p$.t = _v$2);
+      var _v$ = props.rendererProjection?.() ? "true" : void 0, _v$2 = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$3 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
+      _v$ !== _p$.e && setAttribute(_el$, "data-renderer-projection", _p$.e = _v$);
+      _v$2 !== _p$.t && setAttribute(_el$, "data-renderer-ready", _p$.t = _v$2);
+      _v$3 !== _p$.a && setAttribute(_el$2, "aria-label", _p$.a = _v$3);
       return _p$;
     }, {
       e: void 0,
-      t: void 0
+      t: void 0,
+      a: void 0
     });
     return _el$;
   })();
@@ -11928,12 +12088,12 @@ function PixelWorldActionReceipt(props) {
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$3 = props.id, _v$4 = `pixel-world-action-receipt pixel-world-action-receipt--${receipt().state || "unknown"} pixel-world-action-receipt--${receipt().confidence || "none"} ${props.class ?? ""}`, _v$5 = receipt().present ? "true" : "false", _v$6 = receipt().state, _v$7 = receipt().confidence;
-      _v$3 !== _p$.e && setAttribute(_el$8, "id", _p$.e = _v$3);
-      _v$4 !== _p$.t && className(_el$8, _p$.t = _v$4);
-      _v$5 !== _p$.a && setAttribute(_el$8, "data-receipt-present", _p$.a = _v$5);
-      _v$6 !== _p$.o && setAttribute(_el$8, "data-receipt-state", _p$.o = _v$6);
-      _v$7 !== _p$.i && setAttribute(_el$8, "data-receipt-confidence", _p$.i = _v$7);
+      var _v$4 = props.id, _v$5 = `pixel-world-action-receipt pixel-world-action-receipt--${receipt().state || "unknown"} pixel-world-action-receipt--${receipt().confidence || "none"} ${props.class ?? ""}`, _v$6 = receipt().present ? "true" : "false", _v$7 = receipt().state, _v$8 = receipt().confidence;
+      _v$4 !== _p$.e && setAttribute(_el$8, "id", _p$.e = _v$4);
+      _v$5 !== _p$.t && className(_el$8, _p$.t = _v$5);
+      _v$6 !== _p$.a && setAttribute(_el$8, "data-receipt-present", _p$.a = _v$6);
+      _v$7 !== _p$.o && setAttribute(_el$8, "data-receipt-state", _p$.o = _v$7);
+      _v$8 !== _p$.i && setAttribute(_el$8, "data-receipt-confidence", _p$.i = _v$8);
       return _p$;
     }, {
       e: void 0,
@@ -12140,23 +12300,23 @@ function PixelWorldCommercialHud(props) {
         }
       }), null);
       createRenderEffect((_p$) => {
-        var _v$8 = activeAgentId(), _v$9 = surface().player_leverage.state, _v$0 = nextMoveRoute(), _v$1 = surface().next_action.execute_kind || "none", _v$10 = playerBlockerLabel() ? "true" : "false", _v$11 = nextMoveHref(), _v$12 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$13 = nextMoveDisabledReason() ? "true" : void 0, _v$14 = nextMovePending() ? "true" : "false", _v$15 = nextMoveDisabledReason() ? -1 : void 0, _v$16 = activeAgentLabel(), _v$17 = tr$1(props.locale(), "世界连接与动态新鲜度", "World connection and feed freshness"), _v$18 = worldConnection().className, _v$19 = worldConnection().state, _v$20 = feedFreshness().className, _v$21 = readoutFeedStatus();
-        _v$8 !== _p$.e && setAttribute(_el$17, "data-active-agent", _p$.e = _v$8);
-        _v$9 !== _p$.t && setAttribute(_el$17, "data-leverage-state", _p$.t = _v$9);
-        _v$0 !== _p$.a && setAttribute(_el$18, "data-next-move-route", _p$.a = _v$0);
-        _v$1 !== _p$.o && setAttribute(_el$18, "data-execute-kind", _p$.o = _v$1);
-        _v$10 !== _p$.i && setAttribute(_el$18, "data-blocker-present", _p$.i = _v$10);
-        _v$11 !== _p$.n && setAttribute(_el$24, "href", _p$.n = _v$11);
-        _v$12 !== _p$.s && setAttribute(_el$24, "aria-label", _p$.s = _v$12);
-        _v$13 !== _p$.h && setAttribute(_el$24, "aria-disabled", _p$.h = _v$13);
-        _v$14 !== _p$.r && setAttribute(_el$24, "aria-busy", _p$.r = _v$14);
-        _v$15 !== _p$.d && setAttribute(_el$24, "tabindex", _p$.d = _v$15);
-        _v$16 !== _p$.l && setAttribute(_el$35, "data-selected-agent-label", _p$.l = _v$16);
-        _v$17 !== _p$.u && setAttribute(_el$38, "aria-label", _p$.u = _v$17);
-        _v$18 !== _p$.c && className(_el$39, _p$.c = _v$18);
-        _v$19 !== _p$.w && setAttribute(_el$39, "data-world-connection-status", _p$.w = _v$19);
-        _v$20 !== _p$.m && className(_el$40, _p$.m = _v$20);
-        _v$21 !== _p$.f && setAttribute(_el$40, "data-world-feed-readout-status", _p$.f = _v$21);
+        var _v$9 = activeAgentId(), _v$0 = surface().player_leverage.state, _v$1 = nextMoveRoute(), _v$10 = surface().next_action.execute_kind || "none", _v$11 = playerBlockerLabel() ? "true" : "false", _v$12 = nextMoveHref(), _v$13 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$14 = nextMoveDisabledReason() ? "true" : void 0, _v$15 = nextMovePending() ? "true" : "false", _v$16 = nextMoveDisabledReason() ? -1 : void 0, _v$17 = activeAgentLabel(), _v$18 = tr$1(props.locale(), "世界连接与动态新鲜度", "World connection and feed freshness"), _v$19 = worldConnection().className, _v$20 = worldConnection().state, _v$21 = feedFreshness().className, _v$22 = readoutFeedStatus();
+        _v$9 !== _p$.e && setAttribute(_el$17, "data-active-agent", _p$.e = _v$9);
+        _v$0 !== _p$.t && setAttribute(_el$17, "data-leverage-state", _p$.t = _v$0);
+        _v$1 !== _p$.a && setAttribute(_el$18, "data-next-move-route", _p$.a = _v$1);
+        _v$10 !== _p$.o && setAttribute(_el$18, "data-execute-kind", _p$.o = _v$10);
+        _v$11 !== _p$.i && setAttribute(_el$18, "data-blocker-present", _p$.i = _v$11);
+        _v$12 !== _p$.n && setAttribute(_el$24, "href", _p$.n = _v$12);
+        _v$13 !== _p$.s && setAttribute(_el$24, "aria-label", _p$.s = _v$13);
+        _v$14 !== _p$.h && setAttribute(_el$24, "aria-disabled", _p$.h = _v$14);
+        _v$15 !== _p$.r && setAttribute(_el$24, "aria-busy", _p$.r = _v$15);
+        _v$16 !== _p$.d && setAttribute(_el$24, "tabindex", _p$.d = _v$16);
+        _v$17 !== _p$.l && setAttribute(_el$35, "data-selected-agent-label", _p$.l = _v$17);
+        _v$18 !== _p$.u && setAttribute(_el$38, "aria-label", _p$.u = _v$18);
+        _v$19 !== _p$.c && className(_el$39, _p$.c = _v$19);
+        _v$20 !== _p$.w && setAttribute(_el$39, "data-world-connection-status", _p$.w = _v$20);
+        _v$21 !== _p$.m && className(_el$40, _p$.m = _v$21);
+        _v$22 !== _p$.f && setAttribute(_el$40, "data-world-feed-readout-status", _p$.f = _v$22);
         return _p$;
       }, {
         e: void 0,
@@ -12227,10 +12387,10 @@ function PixelWorldFocusHud(props) {
         return () => _c$4() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
       })());
       createRenderEffect((_p$) => {
-        var _v$22 = surface().blocker.label ? "true" : "false", _v$23 = surface().blocker.label ? "critical" : "clear", _v$24 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
-        _v$22 !== _p$.e && setAttribute(_el$59, "data-blocker-present", _p$.e = _v$22);
-        _v$23 !== _p$.t && setAttribute(_el$59, "data-hud-priority", _p$.t = _v$23);
-        _v$24 !== _p$.a && setAttribute(_el$62, "aria-label", _p$.a = _v$24);
+        var _v$23 = surface().blocker.label ? "true" : "false", _v$24 = surface().blocker.label ? "critical" : "clear", _v$25 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
+        _v$23 !== _p$.e && setAttribute(_el$59, "data-blocker-present", _p$.e = _v$23);
+        _v$24 !== _p$.t && setAttribute(_el$59, "data-hud-priority", _p$.t = _v$24);
+        _v$25 !== _p$.a && setAttribute(_el$62, "aria-label", _p$.a = _v$25);
         return _p$;
       }, {
         e: void 0,
@@ -12387,9 +12547,9 @@ function PixelWorldFocusMinimapCard(props) {
       insert(_el$107, () => `routes=${props.renderState().links.length}`);
       insert(_el$108, () => `fragments=${props.renderState().fragment_terrain.length}`);
       createRenderEffect((_p$) => {
-        var _v$25 = props.renderState().links.length, _v$26 = tr$1(props.locale(), "世界摘要", "World summary");
-        _v$25 !== _p$.e && setAttribute(_el$94, "data-routes", _p$.e = _v$25);
-        _v$26 !== _p$.t && setAttribute(_el$104, "aria-label", _p$.t = _v$26);
+        var _v$26 = props.renderState().links.length, _v$27 = tr$1(props.locale(), "世界摘要", "World summary");
+        _v$26 !== _p$.e && setAttribute(_el$94, "data-routes", _p$.e = _v$26);
+        _v$27 !== _p$.t && setAttribute(_el$104, "aria-label", _p$.t = _v$27);
         return _p$;
       }, {
         e: void 0,
@@ -12511,10 +12671,10 @@ function PixelWorldFocusCommandSurface(props) {
           _el$129.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
           insert(_el$129, () => tr$1(locale(), "发送聊天", "Send Chat"));
           createRenderEffect((_p$) => {
-            var _v$27 = chatControlsEnabled() ? "true" : "false", _v$28 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$29 = !chatControlsEnabled();
-            _v$27 !== _p$.e && setAttribute(_el$118, "data-chat-ready", _p$.e = _v$27);
-            _v$28 !== _p$.t && setAttribute(_el$123, "data-blocker-present", _p$.t = _v$28);
-            _v$29 !== _p$.a && (_el$129.disabled = _p$.a = _v$29);
+            var _v$28 = chatControlsEnabled() ? "true" : "false", _v$29 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$30 = !chatControlsEnabled();
+            _v$28 !== _p$.e && setAttribute(_el$118, "data-chat-ready", _p$.e = _v$28);
+            _v$29 !== _p$.t && setAttribute(_el$123, "data-blocker-present", _p$.t = _v$29);
+            _v$30 !== _p$.a && (_el$129.disabled = _p$.a = _v$30);
             return _p$;
           }, {
             e: void 0,
@@ -12619,10 +12779,10 @@ function PixelWorldFocusCommandSurface(props) {
             }
           }));
           createRenderEffect((_p$) => {
-            var _v$30 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$31 = !chatControlsEnabled(), _v$32 = !chatControlsEnabled();
-            _v$30 !== _p$.e && setAttribute(_el$140, "placeholder", _p$.e = _v$30);
-            _v$31 !== _p$.t && (_el$140.disabled = _p$.t = _v$31);
-            _v$32 !== _p$.a && (_el$142.disabled = _p$.a = _v$32);
+            var _v$31 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$32 = !chatControlsEnabled(), _v$33 = !chatControlsEnabled();
+            _v$31 !== _p$.e && setAttribute(_el$140, "placeholder", _p$.e = _v$31);
+            _v$32 !== _p$.t && (_el$140.disabled = _p$.t = _v$32);
+            _v$33 !== _p$.a && (_el$142.disabled = _p$.a = _v$33);
             return _p$;
           }, {
             e: void 0,
@@ -12968,6 +13128,7 @@ function PixelWorldHost(props) {
         return createComponent(PixelWorldCanvasRenderer, {
           locale,
           rendererStatus,
+          rendererProjection: () => runtimeSource() === "wasm_bindgen_runtime" && cameraState() !== null,
           cameraState,
           renderInput,
           renderState,
@@ -13013,9 +13174,9 @@ function PixelWorldHost(props) {
           })()] : tr$1(locale(), "Rust bridge 正在生成世界显示状态。", "Rust bridge is deriving the world display state.");
         })());
         createRenderEffect((_p$) => {
-          var _v$33 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$34 = rendererStatus();
-          _v$33 !== _p$.e && setAttribute(_el$168, "id", _p$.e = _v$33);
-          _v$34 !== _p$.t && setAttribute(_el$168, "data-renderer-state", _p$.t = _v$34);
+          var _v$34 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$35 = rendererStatus();
+          _v$34 !== _p$.e && setAttribute(_el$168, "id", _p$.e = _v$34);
+          _v$35 !== _p$.t && setAttribute(_el$168, "data-renderer-state", _p$.t = _v$35);
           return _p$;
         }, {
           e: void 0,
@@ -13198,14 +13359,14 @@ function PixelWorldHost(props) {
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$35 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$36 = focusMode() ? "true" : "false", _v$37 = focusMode() && maximized() ? "true" : "false", _v$38 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$39 = focusMode(), _v$40 = !renderState(), _v$41 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
-      _v$35 !== _p$.e && className(_el$160, _p$.e = _v$35);
-      _v$36 !== _p$.t && setAttribute(_el$160, "data-world-focus", _p$.t = _v$36);
-      _v$37 !== _p$.a && setAttribute(_el$160, "data-world-focus-maximized", _p$.a = _v$37);
-      _v$38 !== _p$.o && setAttribute(_el$160, "data-focus-comparable", _p$.o = _v$38);
-      _v$39 !== _p$.i && (_el$165.hidden = _p$.i = _v$39);
-      _v$40 !== _p$.n && (_el$167.disabled = _p$.n = _v$40);
-      _v$41 !== _p$.s && setAttribute(_el$167, "aria-describedby", _p$.s = _v$41);
+      var _v$36 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$37 = focusMode() ? "true" : "false", _v$38 = focusMode() && maximized() ? "true" : "false", _v$39 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$40 = focusMode(), _v$41 = !renderState(), _v$42 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
+      _v$36 !== _p$.e && className(_el$160, _p$.e = _v$36);
+      _v$37 !== _p$.t && setAttribute(_el$160, "data-world-focus", _p$.t = _v$37);
+      _v$38 !== _p$.a && setAttribute(_el$160, "data-world-focus-maximized", _p$.a = _v$38);
+      _v$39 !== _p$.o && setAttribute(_el$160, "data-focus-comparable", _p$.o = _v$39);
+      _v$40 !== _p$.i && (_el$165.hidden = _p$.i = _v$40);
+      _v$41 !== _p$.n && (_el$167.disabled = _p$.n = _v$41);
+      _v$42 !== _p$.s && setAttribute(_el$167, "aria-describedby", _p$.s = _v$42);
       return _p$;
     }, {
       e: void 0,

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -2253,7 +2253,7 @@ function createViewerFeedbackModule({
         case "product_validation_rejected":
           return localeText2(locale, "产品验证失败", "Product validation failed");
         default:
-          return resolvedBlockerKind || null;
+          return resolvedBlockerKind ? localeText2(locale, "当前阻塞", "Current blocker") : null;
       }
     })();
     const factoryProductionFailureDisposition = normalizeFactoryProductionFailureDisposition(

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -11506,55 +11506,51 @@ function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
   };
 }
 function PixelWorldRendererTargets(props) {
-  const state2 = () => pixelWorldVisualState(props.renderState());
+  const state2 = createMemo(() => pixelWorldVisualState(props.renderState()));
   const isZh = () => isLocaleZh(props.locale());
-  const entities = () => [...state2().agents.map((entity) => ({
-    entity,
-    kind: "agent"
-  })), ...(state2().worldBounds ? state2().locations.filter((entity) => entity.pos) : []).map((entity) => ({
-    entity,
-    kind: "location"
-  }))];
+  const entities = createMemo(() => new Map([...state2().agents.map((entity) => [JSON.stringify(["agent", entity.id]), entity]), ...(state2().worldBounds ? state2().locations.filter((entity) => entity.pos) : []).map((entity) => [JSON.stringify(["location", entity.id]), entity])]));
+  const keys = createMemo(() => [...entities().keys()]);
   return createComponent(For, {
     get each() {
-      return entities();
+      return keys();
     },
-    children: ({
-      entity,
-      kind
-    }) => (() => {
-      var _el$ = _tmpl$$q();
-      _el$.addEventListener("mouseleave", () => props.onHover(null));
-      _el$.addEventListener("mouseenter", () => props.onHover({
-        kind,
-        id: entity.id
-      }));
-      addEventListener(_el$, "pointerdown", forwardRendererTargetPointer);
-      _el$.$$click = () => props.onSelect({
-        kind,
-        id: entity.id
-      });
-      setAttribute(_el$, "data-pixel-world-agent-marker", kind === "agent" ? "true" : void 0);
-      setAttribute(_el$, "data-pixel-world-location-marker", kind === "location" ? "true" : void 0);
-      createRenderEffect((_p$) => {
-        var _v$ = kind === "agent" ? entity.id : void 0, _v$2 = kind === "location" ? entity.id : void 0, _v$3 = props.selection()?.kind === kind && props.selection()?.id === entity.id ? "true" : "false", _v$4 = props.selection()?.kind === kind && props.selection()?.id === entity.id, _v$5 = `${isZh() ? "选择" : "Select"} ${kind === "agent" ? pixelWorldReadableAgentLabel(entity, entity.id, isZh()) : entity.label || entity.id}`, _v$6 = rendererEntityTargetStyle(entity, state2().worldBounds, props.stageSize(), props.cameraState?.());
-        _v$ !== _p$.e && setAttribute(_el$, "data-agent-id", _p$.e = _v$);
-        _v$2 !== _p$.t && setAttribute(_el$, "data-location-id", _p$.t = _v$2);
-        _v$3 !== _p$.a && setAttribute(_el$, "data-selected", _p$.a = _v$3);
-        _v$4 !== _p$.o && setAttribute(_el$, "aria-pressed", _p$.o = _v$4);
-        _v$5 !== _p$.i && setAttribute(_el$, "aria-label", _p$.i = _v$5);
-        _p$.n = style(_el$, _v$6, _p$.n);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0,
-        o: void 0,
-        i: void 0,
-        n: void 0
-      });
-      return _el$;
-    })()
+    children: (key) => {
+      const [kind] = JSON.parse(key);
+      const entity = createMemo((previous) => entities().get(key) || previous);
+      return (() => {
+        var _el$ = _tmpl$$q();
+        _el$.addEventListener("mouseleave", () => props.onHover(null));
+        _el$.addEventListener("mouseenter", () => props.onHover({
+          kind,
+          id: entity().id
+        }));
+        addEventListener(_el$, "pointerdown", forwardRendererTargetPointer);
+        _el$.$$click = () => props.onSelect({
+          kind,
+          id: entity().id
+        });
+        setAttribute(_el$, "data-pixel-world-agent-marker", kind === "agent" ? "true" : void 0);
+        setAttribute(_el$, "data-pixel-world-location-marker", kind === "location" ? "true" : void 0);
+        createRenderEffect((_p$) => {
+          var _v$ = kind === "agent" ? entity().id : void 0, _v$2 = kind === "location" ? entity().id : void 0, _v$3 = props.selection()?.kind === kind && props.selection()?.id === entity().id ? "true" : "false", _v$4 = props.selection()?.kind === kind && props.selection()?.id === entity().id, _v$5 = `${isZh() ? "选择" : "Select"} ${kind === "agent" ? pixelWorldReadableAgentLabel(entity(), entity().id, isZh()) : entity().label || entity().id}`, _v$6 = rendererEntityTargetStyle(entity(), state2().worldBounds, props.stageSize(), props.cameraState?.());
+          _v$ !== _p$.e && setAttribute(_el$, "data-agent-id", _p$.e = _v$);
+          _v$2 !== _p$.t && setAttribute(_el$, "data-location-id", _p$.t = _v$2);
+          _v$3 !== _p$.a && setAttribute(_el$, "data-selected", _p$.a = _v$3);
+          _v$4 !== _p$.o && setAttribute(_el$, "aria-pressed", _p$.o = _v$4);
+          _v$5 !== _p$.i && setAttribute(_el$, "aria-label", _p$.i = _v$5);
+          _p$.n = style(_el$, _v$6, _p$.n);
+          return _p$;
+        }, {
+          e: void 0,
+          t: void 0,
+          a: void 0,
+          o: void 0,
+          i: void 0,
+          n: void 0
+        });
+        return _el$;
+      })();
+    }
   });
 }
 delegateEvents(["click", "pointerdown"]);

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -128,23 +128,20 @@ function readSignal() {
     }
   }
   if (Listener) {
-    const observers = this.observers;
-    if (!observers || observers[observers.length - 1] !== Listener) {
-      const sSlot = observers ? observers.length : 0;
-      if (!Listener.sources) {
-        Listener.sources = [this];
-        Listener.sourceSlots = [sSlot];
-      } else {
-        Listener.sources.push(this);
-        Listener.sourceSlots.push(sSlot);
-      }
-      if (!observers) {
-        this.observers = [Listener];
-        this.observerSlots = [Listener.sources.length - 1];
-      } else {
-        observers.push(Listener);
-        this.observerSlots.push(Listener.sources.length - 1);
-      }
+    const sSlot = this.observers ? this.observers.length : 0;
+    if (!Listener.sources) {
+      Listener.sources = [this];
+      Listener.sourceSlots = [sSlot];
+    } else {
+      Listener.sources.push(this);
+      Listener.sourceSlots.push(sSlot);
+    }
+    if (!this.observers) {
+      this.observers = [Listener];
+      this.observerSlots = [Listener.sources.length - 1];
+    } else {
+      this.observers.push(Listener);
+      this.observerSlots.push(Listener.sources.length - 1);
     }
   }
   return this.value;
@@ -846,7 +843,7 @@ function Portal(props) {
       insert(renderRoot, content);
       el.appendChild(container);
       props.ref && props.ref(container);
-      onCleanup(() => el.contains(container) && el.removeChild(container));
+      onCleanup(() => el.removeChild(container));
     }
   }, void 0, {
     render: true
@@ -4559,9 +4556,6 @@ function ownKeys(target) {
   return Reflect.ownKeys(target);
 }
 function setProperty(state2, property, value2, deleting = false) {
-  if (property === "__proto__") {
-    return;
-  }
   if (!deleting && state2[property] === value2) return;
   const prev = state2[property], len = state2.length;
   if (value2 === void 0) {
@@ -4603,7 +4597,7 @@ const proxyTraps = {
     if (!tracked) {
       const desc = Object.getOwnPropertyDescriptor(target, property);
       const isFunction = typeof value2 === "function";
-      if (getListener() && (!isFunction || Object.prototype.hasOwnProperty.call(target, property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
+      if (getListener() && (!isFunction || target.hasOwnProperty(property)) && !(desc && desc.get)) value2 = getNode(nodes, property, value2)();
       else if (value2 != null && isFunction && value2 === Array.prototype[property]) {
         return (...args) => batch(() => Array.prototype[property].apply(receiver, args));
       }
@@ -9568,7 +9562,7 @@ const core = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty
   toggleViewerLocale,
   updatePixelWorldRuntimeMeta
 }, Symbol.toStringTag, { value: "Module" }));
-var _tmpl$$r = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
+var _tmpl$$s = /* @__PURE__ */ template(`<div class="stack stack--compact"data-testid=first-chat-unlock-preview>`), _tmpl$2$s = /* @__PURE__ */ template(`<div class=first-chat-unlock-preview__field><div class=metric__label></div><div>`);
 const ZH_VALUE_MAP = {
   chat_purpose: {
     "Start a first conversation with your claimed Agent.": "与已认领的 Agent 开始第一次对话。"
@@ -9599,13 +9593,13 @@ function FirstChatUnlockPreview(props) {
   const fields = () => [["chat_purpose", tr2("目的", "Purpose")], ["immediate_playable_help", tr2("即时帮助", "Immediate help")], ["first_question_or_action_hint", tr2("先试试", "Try first")], ["resource_boundary", tr2("资源边界", "Resource boundary")], ["defer_effect", tr2("如果等待", "If you wait")], ["recommended_unlock_action", tr2("建议操作", "Recommended action")]];
   const value2 = (field) => field === "recommended_unlock_action" ? recommendedActionValue(props.preview[field], locale()) : previewValue(field, props.preview[field], locale());
   return (() => {
-    var _el$ = _tmpl$$r();
+    var _el$ = _tmpl$$s();
     insert(_el$, createComponent(For, {
       get each() {
         return fields();
       },
       children: ([field, label]) => (() => {
-        var _el$2 = _tmpl$2$r(), _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling;
+        var _el$2 = _tmpl$2$s(), _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling;
         setAttribute(_el$2, "data-preview-field", field);
         insert(_el$3, label);
         className(_el$4, field === "chat_purpose" ? "feedback-summary" : "feedback-detail");
@@ -10304,6 +10298,24 @@ function humanizeAgentId(id) {
   const words = slug.replace(/[-_]+/g, " ").trim().split(/\s+/).filter(Boolean).map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`);
   return words.length > 0 ? `Agent ${words.join(" ")}` : "";
 }
+function stableMarkerHash(value2) {
+  let hash = 2166136261;
+  for (const character of String(value2)) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36).toUpperCase().padStart(4, "0").slice(-4);
+}
+function pixelWorldEntityMarkerCode(entity, fallbackId = "", kind = "agent") {
+  const id = String(entity?.id || fallbackId || "unknown").trim() || "unknown";
+  const prefix = kind === "location" ? "L" : "A";
+  const numericId = kind === "location" ? id.match(/^loc-(\d+)$/i)?.[1] : id.match(/^agent-(\d+)$/i)?.[1];
+  if (numericId) {
+    return `${prefix}${numericId}`;
+  }
+  const token = id.replace(/^(?:agent|location|loc)[-_]?/i, "").replace(/[^a-z0-9]+/gi, "").toUpperCase().slice(0, 4) || "X";
+  return `${prefix}${token}-${stableMarkerHash(`${kind}:${id}`)}`;
+}
 function pixelWorldReadableAgentLabel(agent, fallbackId = "", isLocaleZh2 = false) {
   const { id, explicitLabel, hasExplicitLabel } = agentIdentityParts(agent, fallbackId);
   const numericAgentId = id.match(/^agent[-_](\d+)$/i);
@@ -10340,6 +10352,426 @@ function pixelWorldSelectedEntityLabel(visualState, selection, isLocaleZh2 = fal
   const location = visualState.locations.find((candidate) => candidate.id === selection.id);
   return pixelWorldReadableLocationLabel(location, selection.id, isLocaleZh2);
 }
+var _tmpl$$r = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$2$r = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$3$n = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$4$k = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$5$j = /* @__PURE__ */ template(`<div>`), _tmpl$6$d = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span class=pixel-world-entity__code>`), _tmpl$7$9 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span class=pixel-world-entity__code>`), _tmpl$8$6 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__legend data-pixel-world-legend=true><div class=pixel-world-canvas__legend-title></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--route"><span class=pixel-world-canvas__legend-swatch aria-hidden=true></span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--goal"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>◆</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--blocker"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>!</span><span></span></div><div class="pixel-world-canvas__legend-item pixel-world-canvas__legend-item--resource"><span class=pixel-world-canvas__legend-swatch aria-hidden=true>▪</span><span>`);
+const FRAGMENT_TERRAIN_PALETTE = {
+  unknown: [148, 163, 184]
+};
+function tr$4(locale, zh, en) {
+  return isLocaleZh(locale) ? zh : en;
+}
+function safeNumber$1(value2, fallback = 0) {
+  const number = Number(value2);
+  return Number.isFinite(number) ? number : fallback;
+}
+function colorToCss(color, alpha = 0.36) {
+  const [red, green, blue] = Array.isArray(color) ? color : FRAGMENT_TERRAIN_PALETTE.unknown;
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
+function clampRatio$1(value2) {
+  return Math.min(1, Math.max(0, Number(value2) || 0));
+}
+function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
+  if (!pos || !worldBounds) return fallbackStyle;
+  const point = worldPercentPoint(pos, worldBounds, 8, 10);
+  return {
+    left: `${point.x.toFixed(1)}%`,
+    top: `${point.y.toFixed(1)}%`
+  };
+}
+function agentMarkerStyle(agent, index, worldBounds) {
+  const base = toWorldPercentStyle(agent.pos, worldBounds, {
+    left: `${18 + index % 5 * 15}%`,
+    top: `${14 + Math.floor(index / 5) * 22}%`
+  });
+  const offsets = [[-18, -18], [18, -18], [-18, 18], [18, 18], [0, -30], [0, 30], [-30, 0], [30, 0], [-28, -28], [28, 28]];
+  const [x, y] = offsets[index % offsets.length] || [0, 0];
+  return {
+    ...base,
+    transform: `translate(${x}px, ${y}px)`
+  };
+}
+function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
+  if (!pos || !worldBounds) return {
+    x: fallbackX,
+    y: fallbackY
+  };
+  return {
+    x: 8 + clampRatio$1(pos.x_cm / Math.max(1, worldBounds.width_cm)) * 84,
+    y: 10 + clampRatio$1(pos.y_cm / Math.max(1, worldBounds.depth_cm)) * 78
+  };
+}
+const FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO = 9 / 16;
+function routeStyle(link, worldBounds, index) {
+  const fallbackFrom = {
+    x: 14 + index % 5 * 15,
+    y: 18 + Math.floor(index / 5) * 14
+  };
+  const fallbackTo = {
+    x: fallbackFrom.x + 14,
+    y: fallbackFrom.y + 8
+  };
+  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
+  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
+  const deltaX = to.x - from.x;
+  const deltaY = to.y - from.y;
+  const scaledDeltaY = deltaY * FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO;
+  const length = Math.max(4, Math.hypot(deltaX, scaledDeltaY));
+  const angle = Math.atan2(scaledDeltaY, deltaX) * (180 / Math.PI);
+  return {
+    left: `${from.x.toFixed(1)}%`,
+    top: `${from.y.toFixed(1)}%`,
+    width: `${length.toFixed(1)}%`,
+    opacity: `${0.32 + clampRatio$1(link.emphasis ?? 0.72) * 0.38}`,
+    transform: `rotate(${angle.toFixed(1)}deg)`,
+    "transform-origin": "0 50%"
+  };
+}
+function fragmentTerrainStyle(patch, worldBounds, index) {
+  const sizePx = Math.max(12, Math.min(48, safeNumber$1(patch.footprint_cm, 1) / 840));
+  return {
+    ...toWorldPercentStyle(patch.pos, worldBounds, {
+      left: `${12 + index % 6 * 13}%`,
+      top: `${16 + Math.floor(index / 6) * 13}%`
+    }),
+    width: `${sizePx.toFixed(1)}px`,
+    height: `${sizePx.toFixed(1)}px`,
+    "background-color": colorToCss(patch.color),
+    transform: "translate(-50%, -50%)"
+  };
+}
+function routeWaypointStyle(link, worldBounds, index, stop) {
+  const fallbackFrom = {
+    x: 14 + index % 5 * 15,
+    y: 18 + Math.floor(index / 5) * 14
+  };
+  const fallbackTo = {
+    x: fallbackFrom.x + 14,
+    y: fallbackFrom.y + 8
+  };
+  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
+  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
+  const ratio = stop === "to" ? 1 : 0.52;
+  return {
+    left: `${(from.x + (to.x - from.x) * ratio).toFixed(1)}%`,
+    top: `${(from.y + (to.y - from.y) * ratio).toFixed(1)}%`
+  };
+}
+function fieldValue(value2, snakeName, camelName, fallback = void 0) {
+  if (!value2 || typeof value2 !== "object") return fallback;
+  if (value2[snakeName] !== void 0) return value2[snakeName];
+  if (camelName && value2[camelName] !== void 0) return value2[camelName];
+  return fallback;
+}
+function explicitLinkEndpointIds(link) {
+  if (!link || typeof link !== "object") return {
+    agent: [],
+    location: []
+  };
+  const endpoint = (names) => names.map((name) => fieldValue(link, name, name.replace(/_([a-z])/g, (_, character) => character.toUpperCase()), null)).filter((value2) => value2 != null && String(value2).trim()).map((value2) => String(value2).trim());
+  const explicit = {
+    agent: endpoint(["agent_id", "source_agent_id", "target_agent_id", "from_agent_id", "to_agent_id"]),
+    location: endpoint(["location_id", "source_location_id", "target_location_id", "from_location_id", "to_location_id"])
+  };
+  return explicit;
+}
+function hasAuthoritativeAssignment(agent) {
+  const envelope = [agent?.relation, agent?.assignment].find((candidate) => candidate && typeof candidate === "object");
+  return envelope?.kind === "agent_assignment" && envelope?.status === "active" && envelope?.source_class === "runtime_projection" && envelope?.freshness === "current";
+}
+function linkReferencesSelection(link, selection, agents) {
+  if (!selection?.id || !selection?.kind) return false;
+  const endpointIds = explicitLinkEndpointIds(link);
+  if ((selection.kind === "agent" ? endpointIds.agent : endpointIds.location).includes(String(selection.id))) {
+    return true;
+  }
+  if (link?.kind !== "agent_assignment" || link?.status !== "active" || link?.source_class !== "runtime_projection" || link?.freshness !== "current") {
+    return false;
+  }
+  return agents.some((agent) => {
+    const agentId = String(agent?.id || "").trim();
+    const locationId = String(fieldValue(agent, "location_id", "locationId", "")).trim();
+    if (!agentId || !locationId || !hasAuthoritativeAssignment(agent)) {
+      return false;
+    }
+    if (link.id !== `link:${agentId}:${locationId}`) {
+      return false;
+    }
+    return selection.kind === "agent" ? selection.id === agentId : selection.id === locationId;
+  });
+}
+function terrainReferencesSelection(patch, selection) {
+  return selection?.kind === "location" && String(fieldValue(patch, "location_id", "locationId", "")).trim() === String(selection.id);
+}
+function arrayField(value2, snakeName, camelName) {
+  const candidate = fieldValue(value2, snakeName, camelName, []);
+  return Array.isArray(candidate) ? candidate : [];
+}
+function normalizeVisualEntity(entry) {
+  if (!entry || typeof entry !== "object") return entry;
+  return {
+    ...entry,
+    location_id: fieldValue(entry, "location_id", "locationId", null),
+    marker_role: fieldValue(entry, "marker_role", "markerRole", null),
+    marker_alpha: fieldValue(entry, "marker_alpha", "markerAlpha", void 0),
+    position_source: fieldValue(entry, "position_source", "positionSource", null),
+    dominant_compound: fieldValue(entry, "dominant_compound", "dominantCompound", void 0),
+    footprint_cm: fieldValue(entry, "footprint_cm", "footprintCm", void 0)
+  };
+}
+function pixelWorldVisualState(renderState) {
+  const state2 = renderState || {};
+  return {
+    worldBounds: fieldValue(state2, "world_bounds", "worldBounds", null),
+    fragmentTerrain: arrayField(state2, "fragment_terrain", "fragmentTerrain").map(normalizeVisualEntity),
+    links: arrayField(state2, "links", "links"),
+    locations: arrayField(state2, "locations", "locations").map(normalizeVisualEntity),
+    agents: arrayField(state2, "agents", "agents").map(normalizeVisualEntity),
+    selection: fieldValue(state2, "selection", "selection", null),
+    goalHighlight: fieldValue(state2, "goal_highlight", "goalHighlight", null),
+    blockerHighlight: fieldValue(state2, "blocker_highlight", "blockerHighlight", null),
+    visualHotspots: arrayField(state2, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity)
+  };
+}
+function PixelWorldCanvasAgentHitTargets(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  return createComponent(For, {
+    get each() {
+      return visualState().agents.slice(0, 10);
+    },
+    children: (agent, index) => {
+      const label = pixelWorldReadableAgentLabel(agent, agent.id, isLocaleZh(props.locale()));
+      return (() => {
+        var _el$ = _tmpl$$r(), _el$2 = _el$.firstChild;
+        _el$.$$click = () => props.onSelect({
+          kind: "agent",
+          id: agent.id
+        });
+        _el$.addEventListener("mouseleave", () => props.onHover(null));
+        _el$.addEventListener("mouseenter", () => props.onHover({
+          kind: "agent",
+          id: agent.id
+        }));
+        setAttribute(_el$, "title", label);
+        insert(_el$2, () => pixelWorldEntityMarkerCode(agent, agent.id, "agent"));
+        createRenderEffect((_p$) => {
+          var _v$ = agent.id, _v$2 = pixelWorldEntityMarkerCode(agent, agent.id, "agent"), _v$3 = agent.position_source, _v$4 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$5 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$6 = `${tr$4(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$7 = agentMarkerStyle(agent, index(), visualState().worldBounds);
+          _v$ !== _p$.e && setAttribute(_el$, "data-agent-id", _p$.e = _v$);
+          _v$2 !== _p$.t && setAttribute(_el$, "data-marker-code", _p$.t = _v$2);
+          _v$3 !== _p$.a && setAttribute(_el$, "data-position-source", _p$.a = _v$3);
+          _v$4 !== _p$.o && setAttribute(_el$, "data-selected", _p$.o = _v$4);
+          _v$5 !== _p$.i && setAttribute(_el$, "aria-pressed", _p$.i = _v$5);
+          _v$6 !== _p$.n && setAttribute(_el$, "aria-label", _p$.n = _v$6);
+          _p$.s = style(_el$, _v$7, _p$.s);
+          return _p$;
+        }, {
+          e: void 0,
+          t: void 0,
+          a: void 0,
+          o: void 0,
+          i: void 0,
+          n: void 0,
+          s: void 0
+        });
+        return _el$;
+      })();
+    }
+  });
+}
+function PixelWorldHostVisualLayer(props) {
+  const visualState = () => pixelWorldVisualState(props.renderState());
+  const selection = () => props.selection?.() || visualState().selection;
+  const projectedAgents = () => visualState().agents;
+  if (!props.enabled) return [];
+  return [_tmpl$2$r(), _tmpl$3$n(), _tmpl$4$k(), createComponent(For, {
+    get each() {
+      return visualState().fragmentTerrain.slice(0, 96);
+    },
+    children: (patch, index) => (() => {
+      var _el$6 = _tmpl$5$j();
+      createRenderEffect((_p$) => {
+        var _v$8 = `pixel-world-fragment-terrain${terrainReferencesSelection(patch, selection()) ? " pixel-world-fragment-terrain--associated" : selection() ? " pixel-world-fragment-terrain--muted" : ""}`, _v$9 = patch.dominant_compound, _v$0 = terrainReferencesSelection(patch, selection()) ? "true" : "false", _v$1 = fragmentTerrainStyle(patch, visualState().worldBounds, index()), _v$10 = `${patch.location_id}:${patch.dominant_compound}`;
+        _v$8 !== _p$.e && className(_el$6, _p$.e = _v$8);
+        _v$9 !== _p$.t && setAttribute(_el$6, "data-compound", _p$.t = _v$9);
+        _v$0 !== _p$.a && setAttribute(_el$6, "data-associated", _p$.a = _v$0);
+        _p$.o = style(_el$6, _v$1, _p$.o);
+        _v$10 !== _p$.i && setAttribute(_el$6, "title", _p$.i = _v$10);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0
+      });
+      return _el$6;
+    })()
+  }), createComponent(For, {
+    get each() {
+      return visualState().links.slice(0, 10);
+    },
+    children: (link, index) => [(() => {
+      var _el$7 = _tmpl$5$j();
+      createRenderEffect((_p$) => {
+        var _v$11 = `pixel-world-route${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route--associated" : selection() ? " pixel-world-route--muted" : ""}`, _v$12 = link.id, _v$13 = link.kind, _v$14 = linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false", _v$15 = routeStyle(link, visualState().worldBounds, index()), _v$16 = `${link.kind}:${link.id}`;
+        _v$11 !== _p$.e && className(_el$7, _p$.e = _v$11);
+        _v$12 !== _p$.t && setAttribute(_el$7, "data-route-id", _p$.t = _v$12);
+        _v$13 !== _p$.a && setAttribute(_el$7, "data-route-kind", _p$.a = _v$13);
+        _v$14 !== _p$.o && setAttribute(_el$7, "data-associated", _p$.o = _v$14);
+        _p$.i = style(_el$7, _v$15, _p$.i);
+        _v$16 !== _p$.n && setAttribute(_el$7, "title", _p$.n = _v$16);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
+      });
+      return _el$7;
+    })(), (() => {
+      var _el$8 = _tmpl$5$j();
+      createRenderEffect((_p$) => {
+        var _v$17 = `pixel-world-route-waypoint pixel-world-route-waypoint--mid${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route-waypoint--associated" : selection() ? " pixel-world-route-waypoint--muted" : ""}`, _v$18 = link.id, _v$19 = link.kind, _v$20 = linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false", _v$21 = routeWaypointStyle(link, visualState().worldBounds, index(), "mid"), _v$22 = `${link.kind}:waypoint`;
+        _v$17 !== _p$.e && className(_el$8, _p$.e = _v$17);
+        _v$18 !== _p$.t && setAttribute(_el$8, "data-route-id", _p$.t = _v$18);
+        _v$19 !== _p$.a && setAttribute(_el$8, "data-route-kind", _p$.a = _v$19);
+        _v$20 !== _p$.o && setAttribute(_el$8, "data-associated", _p$.o = _v$20);
+        _p$.i = style(_el$8, _v$21, _p$.i);
+        _v$22 !== _p$.n && setAttribute(_el$8, "title", _p$.n = _v$22);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
+      });
+      return _el$8;
+    })(), (() => {
+      var _el$9 = _tmpl$5$j();
+      createRenderEffect((_p$) => {
+        var _v$23 = `pixel-world-route-waypoint pixel-world-route-waypoint--target${linkReferencesSelection(link, selection(), projectedAgents()) ? " pixel-world-route-waypoint--associated" : selection() ? " pixel-world-route-waypoint--muted" : ""}`, _v$24 = link.id, _v$25 = link.kind, _v$26 = linkReferencesSelection(link, selection(), projectedAgents()) ? "true" : "false", _v$27 = routeWaypointStyle(link, visualState().worldBounds, index(), "to"), _v$28 = `${link.kind}:target`;
+        _v$23 !== _p$.e && className(_el$9, _p$.e = _v$23);
+        _v$24 !== _p$.t && setAttribute(_el$9, "data-route-id", _p$.t = _v$24);
+        _v$25 !== _p$.a && setAttribute(_el$9, "data-route-kind", _p$.a = _v$25);
+        _v$26 !== _p$.o && setAttribute(_el$9, "data-associated", _p$.o = _v$26);
+        _p$.i = style(_el$9, _v$27, _p$.i);
+        _v$28 !== _p$.n && setAttribute(_el$9, "title", _p$.n = _v$28);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0
+      });
+      return _el$9;
+    })()]
+  }), createComponent(Index, {
+    get each() {
+      return visualState().locations.slice(0, 8);
+    },
+    children: (location, index) => (() => {
+      var _el$0 = _tmpl$6$d(), _el$1 = _el$0.firstChild;
+      _el$0.$$click = () => props.onSelect({
+        kind: "location",
+        id: location().id
+      });
+      _el$0.addEventListener("mouseleave", () => props.onHover(null));
+      _el$0.addEventListener("mouseenter", () => props.onHover({
+        kind: "location",
+        id: location().id
+      }));
+      insert(_el$1, () => pixelWorldEntityMarkerCode(location(), location().id, "location"));
+      createRenderEffect((_p$) => {
+        var _v$29 = location().id, _v$30 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$31 = pixelWorldEntityMarkerCode(location(), location().id, "location"), _v$32 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$33 = `${tr$4(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$34 = location().marker_role, _v$35 = {
+          ...toWorldPercentStyle(location().pos, visualState().worldBounds, {
+            left: `${12 + index % 4 * 21}%`,
+            top: `${18 + Math.floor(index / 4) * 26}%`
+          }),
+          opacity: location().marker_alpha
+        }, _v$36 = location().label;
+        _v$29 !== _p$.e && setAttribute(_el$0, "data-location-id", _p$.e = _v$29);
+        _v$30 !== _p$.t && setAttribute(_el$0, "data-selected", _p$.t = _v$30);
+        _v$31 !== _p$.a && setAttribute(_el$0, "data-marker-code", _p$.a = _v$31);
+        _v$32 !== _p$.o && setAttribute(_el$0, "aria-pressed", _p$.o = _v$32);
+        _v$33 !== _p$.i && setAttribute(_el$0, "aria-label", _p$.i = _v$33);
+        _v$34 !== _p$.n && setAttribute(_el$0, "data-marker-role", _p$.n = _v$34);
+        _p$.s = style(_el$0, _v$35, _p$.s);
+        _v$36 !== _p$.h && setAttribute(_el$0, "title", _p$.h = _v$36);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0,
+        s: void 0,
+        h: void 0
+      });
+      return _el$0;
+    })()
+  }), createComponent(Index, {
+    get each() {
+      return visualState().agents.slice(0, 10);
+    },
+    children: (agent, index) => {
+      const label = () => pixelWorldReadableAgentLabel(agent(), agent().id, isLocaleZh(props.locale()));
+      return (() => {
+        var _el$10 = _tmpl$7$9(), _el$11 = _el$10.firstChild;
+        _el$10.$$click = () => props.onSelect({
+          kind: "agent",
+          id: agent().id
+        });
+        _el$10.addEventListener("mouseleave", () => props.onHover(null));
+        _el$10.addEventListener("mouseenter", () => props.onHover({
+          kind: "agent",
+          id: agent().id
+        }));
+        insert(_el$11, () => pixelWorldEntityMarkerCode(agent(), agent().id, "agent"));
+        createRenderEffect((_p$) => {
+          var _v$37 = agent().id, _v$38 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$39 = pixelWorldEntityMarkerCode(agent(), agent().id, "agent"), _v$40 = agent().position_source, _v$41 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$42 = `${tr$4(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$43 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$44 = label();
+          _v$37 !== _p$.e && setAttribute(_el$10, "data-agent-id", _p$.e = _v$37);
+          _v$38 !== _p$.t && setAttribute(_el$10, "data-selected", _p$.t = _v$38);
+          _v$39 !== _p$.a && setAttribute(_el$10, "data-marker-code", _p$.a = _v$39);
+          _v$40 !== _p$.o && setAttribute(_el$10, "data-position-source", _p$.o = _v$40);
+          _v$41 !== _p$.i && setAttribute(_el$10, "aria-pressed", _p$.i = _v$41);
+          _v$42 !== _p$.n && setAttribute(_el$10, "aria-label", _p$.n = _v$42);
+          _p$.s = style(_el$10, _v$43, _p$.s);
+          _v$44 !== _p$.h && setAttribute(_el$10, "title", _p$.h = _v$44);
+          return _p$;
+        }, {
+          e: void 0,
+          t: void 0,
+          a: void 0,
+          o: void 0,
+          i: void 0,
+          n: void 0,
+          s: void 0,
+          h: void 0
+        });
+        return _el$10;
+      })();
+    }
+  })];
+}
+function PixelWorldCanvasLegend(props) {
+  return (() => {
+    var _el$12 = _tmpl$8$6(), _el$13 = _el$12.firstChild, _el$14 = _el$13.nextSibling, _el$15 = _el$14.firstChild, _el$16 = _el$15.nextSibling, _el$17 = _el$14.nextSibling, _el$18 = _el$17.firstChild, _el$19 = _el$18.nextSibling, _el$20 = _el$17.nextSibling, _el$21 = _el$20.firstChild, _el$22 = _el$21.nextSibling, _el$23 = _el$20.nextSibling, _el$24 = _el$23.firstChild, _el$25 = _el$24.nextSibling;
+    insert(_el$13, () => tr$4(props.locale(), "图例", "Legend"));
+    insert(_el$16, () => tr$4(props.locale(), "路线", "Route"));
+    insert(_el$19, () => tr$4(props.locale(), "目标", "Goal"));
+    insert(_el$22, () => tr$4(props.locale(), "阻塞", "Blocker"));
+    insert(_el$25, () => tr$4(props.locale(), "资源地形", "Resource terrain"));
+    createRenderEffect(() => setAttribute(_el$12, "aria-label", tr$4(props.locale(), "世界图例", "World legend")));
+    return _el$12;
+  })();
+}
+delegateEvents(["click"]);
 const MOBILE_SHELL_MAX_WIDTH = 640;
 const SAFE_AREA_GAP_PX = 8;
 function pixelWorldMobileSelectionOffset({ markerTop, markerBottom, commandTop, feedBottom = 0 }) {
@@ -10490,17 +10922,17 @@ function pixelWorldHotspotIntersectsStage(style2, stageSize, glyphSize = 20) {
   const radius = glyphSize / 2;
   return x + radius > 0 && y + radius > 0 && x - radius < stageSize.width && y - radius < stageSize.height;
 }
-function safeNumber$1(value2, fallback = 0) {
+function safeNumber(value2, fallback = 0) {
   const number = Number(value2);
   return Number.isFinite(number) ? number : fallback;
 }
-function clampRatio$1(value2) {
-  return Math.min(1, Math.max(0, safeNumber$1(value2)));
+function clampRatio(value2) {
+  return Math.min(1, Math.max(0, safeNumber(value2)));
 }
 function toCanvasPoint(position, worldBounds, width, height, cameraState) {
   if (!position || !worldBounds) return null;
-  const x = clampRatio$1(safeNumber$1(position.x_cm ?? position.xCm) / Math.max(1, safeNumber$1(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
-  const y = clampRatio$1(safeNumber$1(position.y_cm ?? position.yCm) / Math.max(1, safeNumber$1(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
+  const x = clampRatio(safeNumber(position.x_cm ?? position.xCm) / Math.max(1, safeNumber(worldBounds.width_cm ?? worldBounds.widthCm, 1)));
+  const y = clampRatio(safeNumber(position.y_cm ?? position.yCm) / Math.max(1, safeNumber(worldBounds.depth_cm ?? worldBounds.depthCm, 1)));
   const zoom = Math.max(0.5, Number(cameraState?.zoom) || 1);
   return {
     x: width / 2 + (20 + x * Math.max(1, width - 40) - width / 2) * zoom + (Number(cameraState?.pan_x_px ?? cameraState?.panX) || 0),
@@ -10510,7 +10942,7 @@ function toCanvasPoint(position, worldBounds, width, height, cameraState) {
 function pixelWorldHotspotGlyphSize(hotspot) {
   return Math.max(
     14,
-    Math.min(32, safeNumber$1(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
+    Math.min(32, safeNumber(hotspot?.size_hint_px ?? hotspot?.sizeHintPx, 16))
   );
 }
 function pixelWorldHotspotStyle(hotspot, worldBounds, index = 0, cameraState) {
@@ -10761,9 +11193,28 @@ function resolvePixelWorldReadoutStatus(locale, connectionStatus, worldFeed = {}
   if (status !== "connected") return warn(tr$2(locale, "离线", "OFFLINE"), "offline");
   return feedStatus === "ready" ? { label: tr$2(locale, "实时", "LIVE"), className: "badge badge--good pixel-world-readout__status pixel-world-readout__status--ready" } : warn(tr$2(locale, "同步中", "SYNCING"), "syncing");
 }
-var _tmpl$$p = /* @__PURE__ */ template(`<div class=pixel-world-canvas__grid>`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--one">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class="pixel-world-canvas__terrain-band pixel-world-canvas__terrain-band--two">`), _tmpl$4$j = /* @__PURE__ */ template(`<div class=pixel-world-fragment-terrain>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-route>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--mid">`), _tmpl$7$8 = /* @__PURE__ */ template(`<div class="pixel-world-route-waypoint pixel-world-route-waypoint--target">`), _tmpl$8$5 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--location"data-pixel-world-location-marker=true><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<button class="pixel-world-entity pixel-world-entity--agent"data-pixel-world-agent-marker=true><span>`), _tmpl$0$4 = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-entity--agent pixel-world-entity--canvas-hit-target"data-pixel-world-agent-marker=true><span>`), _tmpl$1$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$10$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$11$1 = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$12$1 = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$14$1 = /* @__PURE__ */ template(`<span>`), _tmpl$15$1 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$16$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$17$1 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$23$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$24$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$25$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$29$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$32$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$33$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$37$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$39$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$40$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$44$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$45$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$46$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$47$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$48$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$49$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$50$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$51$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$52$1 = /* @__PURE__ */ template(`<div>`), _tmpl$53$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
+var _tmpl$$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$j = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__changes data-receipt-changes=true>`), _tmpl$7$8 = /* @__PURE__ */ template(`<span>`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$0$4 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$1$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$10$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__feedback data-primary-action-feedback=true aria-live=polite>`), _tmpl$11$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div id=viewer-decision-area class=pixel-world-decision-area data-viewer-decision-area=true><div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action data-primary-action=true aria-live=polite></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong></strong></div></div></div></div><div class="pixel-world-readout badge-row"><span></span><span class="badge badge--accent">`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$15$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$23$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$24$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$25$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$37$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$39$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$40$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div>`), _tmpl$44$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;
+}
+async function waitForRuntimeCanvasAttachment(canvas) {
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    if (canvas?.isConnected && document.getElementById(PIXEL_WORLD_RUNTIME_CANVAS_ID) === canvas) {
+      return true;
+    }
+    await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  return false;
+}
+function snapshotTick(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return null;
+  }
+  const tick = Number(fieldValue(snapshot, "time", "time", null));
+  return Number.isFinite(tick) ? Math.max(0, Math.floor(tick)) : null;
+}
+function pixelWorldAgentIdentity(agent, fallbackId = "", isLocaleZh2 = false) {
+  return pixelWorldReadableAgentLabel(agent, fallbackId, isLocaleZh2) || "Agent";
 }
 const PIXEL_WORLD_RUNTIME_CANVAS_ID = "pixel-world-embedded-runtime-canvas";
 const PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID = "pixel-world-renderer-unavailable-message";
@@ -10773,178 +11224,6 @@ const pixelWorldFocusUiSessionState = {
   diagnosticsDrawerOpen: false,
   maximized: false
 };
-const FRAGMENT_TERRAIN_PALETTE = {
-  unknown: [148, 163, 184]
-};
-async function waitForRuntimeCanvasAttachment(canvas) {
-  for (let attempt = 0; attempt < 12; attempt += 1) {
-    if (canvas?.isConnected && document.getElementById(PIXEL_WORLD_RUNTIME_CANVAS_ID) === canvas) {
-      return true;
-    }
-    await new Promise((resolve) => {
-      requestAnimationFrame(() => resolve());
-    });
-  }
-  return false;
-}
-function safeNumber(value2, fallback = 0) {
-  const number = Number(value2);
-  return Number.isFinite(number) ? number : fallback;
-}
-function pixelWorldAgentIdentity(agent, fallbackId = "", isLocaleZh2 = false) {
-  return pixelWorldReadableAgentLabel(agent, fallbackId, isLocaleZh2) || "Agent";
-}
-function snapshotTick(snapshot) {
-  if (!snapshot || typeof snapshot !== "object") {
-    return null;
-  }
-  const tick = Number(fieldValue(snapshot, "time", "time", null));
-  if (!Number.isFinite(tick)) {
-    return null;
-  }
-  return Math.max(0, Math.floor(tick));
-}
-function colorToCss(color, alpha = 0.36) {
-  const [red, green, blue] = Array.isArray(color) ? color : FRAGMENT_TERRAIN_PALETTE.unknown;
-  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
-}
-function clampRatio(value2) {
-  return Math.min(1, Math.max(0, Number(value2) || 0));
-}
-function toWorldPercentStyle(pos, worldBounds, fallbackStyle) {
-  if (!pos || !worldBounds) {
-    return fallbackStyle;
-  }
-  const point = worldPercentPoint(pos, worldBounds, 8, 10);
-  return {
-    left: `${point.x.toFixed(1)}%`,
-    top: `${point.y.toFixed(1)}%`
-  };
-}
-function agentMarkerStyle(agent, index, worldBounds) {
-  const base = toWorldPercentStyle(agent.pos, worldBounds, {
-    left: `${18 + index % 5 * 15}%`,
-    top: `${14 + Math.floor(index / 5) * 22}%`
-  });
-  const offsets = [[-18, -18], [18, -18], [-18, 18], [18, 18], [0, -30], [0, 30], [-30, 0], [30, 0], [-28, -28], [28, 28]];
-  const [x, y] = offsets[index % offsets.length] || [0, 0];
-  return {
-    ...base,
-    transform: `translate(${x}px, ${y}px)`
-  };
-}
-function worldPercentPoint(pos, worldBounds, fallbackX = 50, fallbackY = 50) {
-  if (!pos || !worldBounds) {
-    return {
-      x: fallbackX,
-      y: fallbackY
-    };
-  }
-  return {
-    x: 8 + clampRatio(pos.x_cm / Math.max(1, worldBounds.width_cm)) * 84,
-    y: 10 + clampRatio(pos.y_cm / Math.max(1, worldBounds.depth_cm)) * 78
-  };
-}
-const FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO = 9 / 16;
-function routeStyle(link, worldBounds, index) {
-  const fallbackFrom = {
-    x: 14 + index % 5 * 15,
-    y: 18 + Math.floor(index / 5) * 14
-  };
-  const fallbackTo = {
-    x: fallbackFrom.x + 14,
-    y: fallbackFrom.y + 8
-  };
-  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
-  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
-  const deltaX = to.x - from.x;
-  const deltaY = to.y - from.y;
-  const scaledDeltaY = deltaY * FALLBACK_ROUTE_HEIGHT_TO_WIDTH_RATIO;
-  const length = Math.max(4, Math.hypot(deltaX, scaledDeltaY));
-  const angle = Math.atan2(scaledDeltaY, deltaX) * (180 / Math.PI);
-  return {
-    left: `${from.x.toFixed(1)}%`,
-    top: `${from.y.toFixed(1)}%`,
-    width: `${length.toFixed(1)}%`,
-    opacity: `${0.32 + clampRatio(link.emphasis ?? 0.72) * 0.38}`,
-    transform: `rotate(${angle.toFixed(1)}deg)`,
-    "transform-origin": "0 50%"
-  };
-}
-function fragmentTerrainStyle(patch, worldBounds, index) {
-  const sizePx = Math.max(12, Math.min(48, safeNumber(patch.footprint_cm, 1) / 840));
-  return {
-    ...toWorldPercentStyle(patch.pos, worldBounds, {
-      left: `${12 + index % 6 * 13}%`,
-      top: `${16 + Math.floor(index / 6) * 13}%`
-    }),
-    width: `${sizePx.toFixed(1)}px`,
-    height: `${sizePx.toFixed(1)}px`,
-    "background-color": colorToCss(patch.color),
-    transform: "translate(-50%, -50%)"
-  };
-}
-function routeWaypointStyle(link, worldBounds, index, stop) {
-  const fallbackFrom = {
-    x: 14 + index % 5 * 15,
-    y: 18 + Math.floor(index / 5) * 14
-  };
-  const fallbackTo = {
-    x: fallbackFrom.x + 14,
-    y: fallbackFrom.y + 8
-  };
-  const from = worldPercentPoint(link.from, worldBounds, fallbackFrom.x, fallbackFrom.y);
-  const to = worldPercentPoint(link.to, worldBounds, fallbackTo.x, fallbackTo.y);
-  const ratio = stop === "to" ? 1 : 0.52;
-  return {
-    left: `${(from.x + (to.x - from.x) * ratio).toFixed(1)}%`,
-    top: `${(from.y + (to.y - from.y) * ratio).toFixed(1)}%`
-  };
-}
-function fieldValue(value2, snakeName, camelName, fallback = void 0) {
-  if (!value2 || typeof value2 !== "object") {
-    return fallback;
-  }
-  if (value2[snakeName] !== void 0) {
-    return value2[snakeName];
-  }
-  if (camelName && value2[camelName] !== void 0) {
-    return value2[camelName];
-  }
-  return fallback;
-}
-function arrayField(value2, snakeName, camelName) {
-  const candidate = fieldValue(value2, snakeName, camelName, []);
-  return Array.isArray(candidate) ? candidate : [];
-}
-function normalizeVisualEntity(entry) {
-  if (!entry || typeof entry !== "object") {
-    return entry;
-  }
-  return {
-    ...entry,
-    location_id: fieldValue(entry, "location_id", "locationId", null),
-    marker_role: fieldValue(entry, "marker_role", "markerRole", null),
-    marker_alpha: fieldValue(entry, "marker_alpha", "markerAlpha", void 0),
-    position_source: fieldValue(entry, "position_source", "positionSource", null),
-    dominant_compound: fieldValue(entry, "dominant_compound", "dominantCompound", void 0),
-    footprint_cm: fieldValue(entry, "footprint_cm", "footprintCm", void 0)
-  };
-}
-function pixelWorldVisualState(renderState) {
-  const state2 = renderState || {};
-  return {
-    worldBounds: fieldValue(state2, "world_bounds", "worldBounds", null),
-    fragmentTerrain: arrayField(state2, "fragment_terrain", "fragmentTerrain").map(normalizeVisualEntity),
-    links: arrayField(state2, "links", "links"),
-    locations: arrayField(state2, "locations", "locations").map(normalizeVisualEntity),
-    agents: arrayField(state2, "agents", "agents").map(normalizeVisualEntity),
-    selection: fieldValue(state2, "selection", "selection", null),
-    goalHighlight: fieldValue(state2, "goal_highlight", "goalHighlight", null),
-    blockerHighlight: fieldValue(state2, "blocker_highlight", "blockerHighlight", null),
-    visualHotspots: arrayField(state2, "visual_hotspots", "visualHotspots").map(normalizeVisualEntity)
-  };
-}
 function PixelWorldHostHotspotLayer(props) {
   const visualState = () => pixelWorldVisualState(props.renderState());
   return createComponent(Index, {
@@ -10983,206 +11262,6 @@ function PixelWorldHostHotspotLayer(props) {
         return props.onHotspotRestoreFocus;
       }
     })
-  });
-}
-function PixelWorldHostVisualLayer(props) {
-  const visualState = () => pixelWorldVisualState(props.renderState());
-  const selection = () => props.selection?.() || visualState().selection;
-  if (!props.enabled) {
-    return [];
-  }
-  return [_tmpl$$p(), _tmpl$2$p(), _tmpl$3$m(), createComponent(For, {
-    get each() {
-      return visualState().fragmentTerrain.slice(0, 96);
-    },
-    children: (patch, index) => (() => {
-      var _el$4 = _tmpl$4$j();
-      createRenderEffect((_p$) => {
-        var _v$ = patch.dominant_compound, _v$2 = fragmentTerrainStyle(patch, visualState().worldBounds, index()), _v$3 = `${patch.location_id}:${patch.dominant_compound}`;
-        _v$ !== _p$.e && setAttribute(_el$4, "data-compound", _p$.e = _v$);
-        _p$.t = style(_el$4, _v$2, _p$.t);
-        _v$3 !== _p$.a && setAttribute(_el$4, "title", _p$.a = _v$3);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0
-      });
-      return _el$4;
-    })()
-  }), createComponent(For, {
-    get each() {
-      return visualState().links.slice(0, 10);
-    },
-    children: (link, index) => [(() => {
-      var _el$5 = _tmpl$5$i();
-      createRenderEffect((_p$) => {
-        var _v$4 = link.kind, _v$5 = routeStyle(link, visualState().worldBounds, index()), _v$6 = `${link.kind}:${link.id}`;
-        _v$4 !== _p$.e && setAttribute(_el$5, "data-route-kind", _p$.e = _v$4);
-        _p$.t = style(_el$5, _v$5, _p$.t);
-        _v$6 !== _p$.a && setAttribute(_el$5, "title", _p$.a = _v$6);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0
-      });
-      return _el$5;
-    })(), (() => {
-      var _el$6 = _tmpl$6$c();
-      createRenderEffect((_p$) => {
-        var _v$7 = link.kind, _v$8 = routeWaypointStyle(link, visualState().worldBounds, index(), "mid"), _v$9 = `${link.kind}:waypoint`;
-        _v$7 !== _p$.e && setAttribute(_el$6, "data-route-kind", _p$.e = _v$7);
-        _p$.t = style(_el$6, _v$8, _p$.t);
-        _v$9 !== _p$.a && setAttribute(_el$6, "title", _p$.a = _v$9);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0
-      });
-      return _el$6;
-    })(), (() => {
-      var _el$7 = _tmpl$7$8();
-      createRenderEffect((_p$) => {
-        var _v$0 = link.kind, _v$1 = routeWaypointStyle(link, visualState().worldBounds, index(), "to"), _v$10 = `${link.kind}:target`;
-        _v$0 !== _p$.e && setAttribute(_el$7, "data-route-kind", _p$.e = _v$0);
-        _p$.t = style(_el$7, _v$1, _p$.t);
-        _v$10 !== _p$.a && setAttribute(_el$7, "title", _p$.a = _v$10);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0
-      });
-      return _el$7;
-    })()]
-  }), createComponent(Index, {
-    get each() {
-      return visualState().locations.slice(0, 8);
-    },
-    children: (location, index) => (() => {
-      var _el$8 = _tmpl$8$5(), _el$9 = _el$8.firstChild;
-      _el$8.$$click = () => props.onSelect({
-        kind: "location",
-        id: location().id
-      });
-      _el$8.addEventListener("mouseleave", () => props.onHover(null));
-      _el$8.addEventListener("mouseenter", () => props.onHover({
-        kind: "location",
-        id: location().id
-      }));
-      insert(_el$9, () => location().label.slice(0, 2).toUpperCase());
-      createRenderEffect((_p$) => {
-        var _v$11 = location().id, _v$12 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$13 = selection()?.kind === "location" && selection()?.id === location().id ? "true" : "false", _v$14 = `${tr$1(props.locale(), "选择地点", "Select Location")} ${location().label || location().id}`, _v$15 = location().marker_role, _v$16 = {
-          ...toWorldPercentStyle(location().pos, visualState().worldBounds, {
-            left: `${12 + index % 4 * 21}%`,
-            top: `${18 + Math.floor(index / 4) * 26}%`
-          }),
-          opacity: location().marker_alpha
-        }, _v$17 = location().label;
-        _v$11 !== _p$.e && setAttribute(_el$8, "data-location-id", _p$.e = _v$11);
-        _v$12 !== _p$.t && setAttribute(_el$8, "data-selected", _p$.t = _v$12);
-        _v$13 !== _p$.a && setAttribute(_el$8, "aria-pressed", _p$.a = _v$13);
-        _v$14 !== _p$.o && setAttribute(_el$8, "aria-label", _p$.o = _v$14);
-        _v$15 !== _p$.i && setAttribute(_el$8, "data-marker-role", _p$.i = _v$15);
-        _p$.n = style(_el$8, _v$16, _p$.n);
-        _v$17 !== _p$.s && setAttribute(_el$8, "title", _p$.s = _v$17);
-        return _p$;
-      }, {
-        e: void 0,
-        t: void 0,
-        a: void 0,
-        o: void 0,
-        i: void 0,
-        n: void 0,
-        s: void 0
-      });
-      return _el$8;
-    })()
-  }), createComponent(Index, {
-    get each() {
-      return visualState().agents.slice(0, 10);
-    },
-    children: (agent, index) => {
-      const label = () => pixelWorldReadableAgentLabel(agent(), agent().id, isLocaleZh(props.locale()));
-      return (() => {
-        var _el$0 = _tmpl$9$4(), _el$1 = _el$0.firstChild;
-        _el$0.$$click = () => props.onSelect({
-          kind: "agent",
-          id: agent().id
-        });
-        _el$0.addEventListener("mouseleave", () => props.onHover(null));
-        _el$0.addEventListener("mouseenter", () => props.onHover({
-          kind: "agent",
-          id: agent().id
-        }));
-        insert(_el$1, () => label().slice(0, 1).toUpperCase());
-        createRenderEffect((_p$) => {
-          var _v$18 = agent().id, _v$19 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$20 = agent().position_source, _v$21 = selection()?.kind === "agent" && selection()?.id === agent().id ? "true" : "false", _v$22 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label()}`, _v$23 = agentMarkerStyle(agent(), index, visualState().worldBounds), _v$24 = label();
-          _v$18 !== _p$.e && setAttribute(_el$0, "data-agent-id", _p$.e = _v$18);
-          _v$19 !== _p$.t && setAttribute(_el$0, "data-selected", _p$.t = _v$19);
-          _v$20 !== _p$.a && setAttribute(_el$0, "data-position-source", _p$.a = _v$20);
-          _v$21 !== _p$.o && setAttribute(_el$0, "aria-pressed", _p$.o = _v$21);
-          _v$22 !== _p$.i && setAttribute(_el$0, "aria-label", _p$.i = _v$22);
-          _p$.n = style(_el$0, _v$23, _p$.n);
-          _v$24 !== _p$.s && setAttribute(_el$0, "title", _p$.s = _v$24);
-          return _p$;
-        }, {
-          e: void 0,
-          t: void 0,
-          a: void 0,
-          o: void 0,
-          i: void 0,
-          n: void 0,
-          s: void 0
-        });
-        return _el$0;
-      })();
-    }
-  })];
-}
-function PixelWorldCanvasAgentHitTargets(props) {
-  const visualState = () => pixelWorldVisualState(props.renderState());
-  return createComponent(For, {
-    get each() {
-      return visualState().agents.slice(0, 10);
-    },
-    children: (agent, index) => {
-      const label = pixelWorldReadableAgentLabel(agent, agent.id, isLocaleZh(props.locale()));
-      return (() => {
-        var _el$10 = _tmpl$0$4(), _el$11 = _el$10.firstChild;
-        _el$10.$$click = () => props.onSelect({
-          kind: "agent",
-          id: agent.id
-        });
-        _el$10.addEventListener("mouseleave", () => props.onHover(null));
-        _el$10.addEventListener("mouseenter", () => props.onHover({
-          kind: "agent",
-          id: agent.id
-        }));
-        setAttribute(_el$10, "title", label);
-        insert(_el$11, () => label.slice(0, 1).toUpperCase());
-        createRenderEffect((_p$) => {
-          var _v$25 = agent.id, _v$26 = agent.position_source, _v$27 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$28 = props.selection()?.kind === "agent" && props.selection()?.id === agent.id ? "true" : "false", _v$29 = `${tr$1(props.locale(), "选择 Agent", "Select Agent")} ${label}`, _v$30 = agentMarkerStyle(agent, index(), visualState().worldBounds);
-          _v$25 !== _p$.e && setAttribute(_el$10, "data-agent-id", _p$.e = _v$25);
-          _v$26 !== _p$.t && setAttribute(_el$10, "data-position-source", _p$.t = _v$26);
-          _v$27 !== _p$.a && setAttribute(_el$10, "data-selected", _p$.a = _v$27);
-          _v$28 !== _p$.o && setAttribute(_el$10, "aria-pressed", _p$.o = _v$28);
-          _v$29 !== _p$.i && setAttribute(_el$10, "aria-label", _p$.i = _v$29);
-          _p$.n = style(_el$10, _v$30, _p$.n);
-          return _p$;
-        }, {
-          e: void 0,
-          t: void 0,
-          a: void 0,
-          o: void 0,
-          i: void 0,
-          n: void 0
-        });
-        return _el$10;
-      })();
-    }
   });
 }
 function createPixelWorldHostAdapter({
@@ -11435,11 +11514,11 @@ function PixelWorldCanvasRenderer(props) {
     requestAnimationFrame(() => applyPixelWorldMobileSelectionSafeArea(canvasRef?.closest(".pixel-world-canvas")));
   });
   return (() => {
-    var _el$12 = _tmpl$12$1(), _el$13 = _el$12.firstChild, _el$14 = _el$13.nextSibling, _el$15 = _el$14.nextSibling;
+    var _el$ = _tmpl$4$j(), _el$2 = _el$.firstChild, _el$3 = _el$2.nextSibling, _el$4 = _el$3.nextSibling;
     var _ref$ = canvasRef;
-    typeof _ref$ === "function" ? use(_ref$, _el$13) : canvasRef = _el$13;
-    insert(_el$14, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
-    insert(_el$15, createComponent(PixelWorldCanvasAgentHitTargets, {
+    typeof _ref$ === "function" ? use(_ref$, _el$2) : canvasRef = _el$2;
+    insert(_el$3, () => tr$1(props.locale(), "Canvas 提供当前世界的只读概览；相邻 HUD、焦点栏和命令抽屉提供当前 Agent、阻塞、回执与命令路径。", "The canvas provides a read-only overview of the current world; adjacent HUD, focus rail, and command drawer expose the current agent, blocker, receipt, and command path."));
+    insert(_el$4, createComponent(PixelWorldCanvasAgentHitTargets, {
       get locale() {
         return props.locale;
       },
@@ -11449,6 +11528,9 @@ function PixelWorldCanvasRenderer(props) {
       get selection() {
         return props.selection;
       },
+      get hovered() {
+        return props.hoveredEntity;
+      },
       get onSelect() {
         return props.onSelect;
       },
@@ -11456,7 +11538,7 @@ function PixelWorldCanvasRenderer(props) {
         return props.onHover;
       }
     }), null);
-    insert(_el$15, createComponent(PixelWorldHostVisualLayer, {
+    insert(_el$4, createComponent(PixelWorldHostVisualLayer, {
       get enabled() {
         return props.visualOverlayEnabled?.() ?? false;
       },
@@ -11469,6 +11551,9 @@ function PixelWorldCanvasRenderer(props) {
       get selection() {
         return props.selection;
       },
+      get hovered() {
+        return props.hoveredEntity;
+      },
       get onSelect() {
         return props.onSelect;
       },
@@ -11476,7 +11561,7 @@ function PixelWorldCanvasRenderer(props) {
         return props.onHover;
       }
     }), null);
-    insert(_el$15, createComponent(PixelWorldHostHotspotLayer, {
+    insert(_el$4, createComponent(PixelWorldHostHotspotLayer, {
       get locale() {
         return props.locale;
       },
@@ -11505,27 +11590,27 @@ function PixelWorldCanvasRenderer(props) {
         return hotspotFocus.restore;
       }
     }), null);
-    insert(_el$15, createComponent(Show, {
+    insert(_el$4, createComponent(Show, {
       get when() {
         return visualState().goalHighlight;
       },
       get children() {
-        var _el$16 = _tmpl$1$1();
-        insert(_el$16, () => `${tr$1(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`);
-        return _el$16;
+        var _el$5 = _tmpl$$p();
+        insert(_el$5, () => `${tr$1(props.locale(), "目标", "Goal")}: ${visualState().goalHighlight.title}`);
+        return _el$5;
       }
     }), null);
-    insert(_el$15, createComponent(Show, {
+    insert(_el$4, createComponent(Show, {
       get when() {
         return visualState().blockerHighlight;
       },
       get children() {
-        var _el$17 = _tmpl$10$1();
-        insert(_el$17, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`);
-        return _el$17;
+        var _el$6 = _tmpl$2$p();
+        insert(_el$6, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${visualState().blockerHighlight.label || visualState().blockerHighlight.kind}`);
+        return _el$6;
       }
     }), null);
-    insert(_el$15, createComponent(Show, {
+    insert(_el$4, createComponent(Show, {
       get when() {
         return activeHotspot();
       },
@@ -11547,72 +11632,83 @@ function PixelWorldCanvasRenderer(props) {
         });
       }
     }), null);
-    insert(_el$12, createComponent(Show, {
+    insert(_el$, createComponent(Show, {
       get when() {
         return visualState().selection;
       },
       get children() {
-        var _el$18 = _tmpl$11$1();
-        insert(_el$18, () => `${tr$1(props.locale(), "已选中", "Selected")}: ${selectedEntityLabel()}`);
-        return _el$18;
+        var _el$7 = _tmpl$3$m();
+        insert(_el$7, () => `${tr$1(props.locale(), "已选中", "Selected")}: ${selectedEntityLabel()}`);
+        return _el$7;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$31 = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$32 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
-      _v$31 !== _p$.e && setAttribute(_el$12, "data-renderer-ready", _p$.e = _v$31);
-      _v$32 !== _p$.t && setAttribute(_el$13, "aria-label", _p$.t = _v$32);
+      var _v$ = props.rendererStatus?.() === "ready" ? "true" : void 0, _v$2 = tr$1(props.locale(), "世界 Canvas 概览", "World canvas overview");
+      _v$ !== _p$.e && setAttribute(_el$, "data-renderer-ready", _p$.e = _v$);
+      _v$2 !== _p$.t && setAttribute(_el$2, "aria-label", _p$.t = _v$2);
       return _p$;
     }, {
       e: void 0,
       t: void 0
     });
-    return _el$12;
+    return _el$;
   })();
 }
 function PixelWorldActionReceipt(props) {
   const receipt = () => props.surface().action_receipt;
+  const receiptChanges = () => [receipt().delta_logical_time == null ? null : `${tr$1(props.locale(), "世界 Tick 变化", "World tick change")} ${receipt().delta_logical_time}`, receipt().delta_event_seq == null ? null : `${tr$1(props.locale(), "事件序列变化", "Event sequence change")} ${receipt().delta_event_seq}`].filter(Boolean);
   return (() => {
-    var _el$19 = _tmpl$16$1(), _el$20 = _el$19.firstChild, _el$21 = _el$20.nextSibling, _el$22 = _el$21.firstChild, _el$23 = _el$22.nextSibling;
-    insert(_el$20, () => tr$1(props.locale(), "行动回执", "Action Receipt"));
-    insert(_el$22, () => receipt().title);
-    insert(_el$23, () => receipt().summary);
-    insert(_el$21, createComponent(Show, {
+    var _el$8 = _tmpl$9$4(), _el$9 = _el$8.firstChild, _el$0 = _el$9.nextSibling, _el$1 = _el$0.firstChild, _el$10 = _el$1.nextSibling;
+    insert(_el$9, () => tr$1(props.locale(), "行动回执", "Action Receipt"));
+    insert(_el$1, () => receipt().title);
+    insert(_el$10, () => receipt().summary);
+    insert(_el$0, createComponent(Show, {
       get when() {
         return receipt().detail;
       },
       get children() {
-        var _el$24 = _tmpl$13$1();
-        insert(_el$24, () => receipt().detail);
-        return _el$24;
+        var _el$11 = _tmpl$5$i();
+        insert(_el$11, () => receipt().detail);
+        return _el$11;
       }
     }), null);
-    insert(_el$19, createComponent(Show, {
+    insert(_el$0, createComponent(Show, {
+      get when() {
+        return receiptChanges().length > 0;
+      },
+      get children() {
+        var _el$12 = _tmpl$6$c();
+        insert(_el$12, () => receiptChanges().join(" · "));
+        return _el$12;
+      }
+    }), null);
+    insert(_el$8, createComponent(Show, {
       get when() {
         return receipt().present;
       },
       get children() {
-        var _el$25 = _tmpl$15$1(), _el$26 = _el$25.firstChild;
-        insert(_el$26, () => receiptConfidenceLabel(receipt().confidence, props.locale(), receipt().state));
-        insert(_el$25, createComponent(Show, {
+        var _el$13 = _tmpl$8$5(), _el$14 = _el$13.firstChild;
+        insert(_el$14, () => receiptConfidenceLabel(receipt().confidence, props.locale(), receipt().state));
+        insert(_el$13, createComponent(Show, {
           get when() {
             return receipt().target_agent_id;
           },
           get children() {
-            var _el$27 = _tmpl$14$1();
-            insert(_el$27, () => `${tr$1(props.locale(), "行动体", "Agent")} ${String(receipt().target_agent_id).replace(/^agent[-_]/i, "")}`);
-            return _el$27;
+            var _el$15 = _tmpl$7$8();
+            insert(_el$15, () => `${tr$1(props.locale(), "行动体", "Agent")} ${String(receipt().target_agent_id).replace(/^agent[-_]/i, "")}`);
+            return _el$15;
           }
         }), null);
-        return _el$25;
+        return _el$13;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$33 = props.id, _v$34 = `pixel-world-action-receipt ${props.class ?? ""}`, _v$35 = receipt().present ? "true" : "false", _v$36 = receipt().state, _v$37 = receipt().confidence;
-      _v$33 !== _p$.e && setAttribute(_el$19, "id", _p$.e = _v$33);
-      _v$34 !== _p$.t && className(_el$19, _p$.t = _v$34);
-      _v$35 !== _p$.a && setAttribute(_el$19, "data-receipt-present", _p$.a = _v$35);
-      _v$36 !== _p$.o && setAttribute(_el$19, "data-receipt-state", _p$.o = _v$36);
-      _v$37 !== _p$.i && setAttribute(_el$19, "data-receipt-confidence", _p$.i = _v$37);
+      var _v$3 = props.id, _v$4 = `pixel-world-action-receipt pixel-world-action-receipt--${receipt().state || "unknown"} pixel-world-action-receipt--${receipt().confidence || "none"} ${props.class ?? ""}`, _v$5 = receipt().present ? "true" : "false", _v$6 = receipt().state, _v$7 = receipt().confidence;
+      _v$3 !== _p$.e && setAttribute(_el$8, "id", _p$.e = _v$3);
+      _v$4 !== _p$.t && className(_el$8, _p$.t = _v$4);
+      _v$5 !== _p$.a && setAttribute(_el$8, "data-receipt-present", _p$.a = _v$5);
+      _v$6 !== _p$.o && setAttribute(_el$8, "data-receipt-state", _p$.o = _v$6);
+      _v$7 !== _p$.i && setAttribute(_el$8, "data-receipt-confidence", _p$.i = _v$7);
       return _p$;
     }, {
       e: void 0,
@@ -11621,12 +11717,13 @@ function PixelWorldActionReceipt(props) {
       o: void 0,
       i: void 0
     });
-    return _el$19;
+    return _el$8;
   })();
 }
 function receiptConfidenceLabel(confidence, locale, state2) {
   const value2 = String(confidence || "").trim().toLowerCase();
   const receiptState = String(state2 || "").trim().toLowerCase();
+  if (receiptState === "blocked") return tr$1(locale, "行动被阻塞", "Action blocked");
   if (receiptState === "rejected") return tr$1(locale, "行动已拒绝", "Action rejected");
   return value2 === "world_delta" ? tr$1(locale, "世界变化已确认", "World change confirmed") : value2 === "accepted_intent" ? tr$1(locale, "行动已接受", "Action accepted") : value2 === "none" ? tr$1(locale, "等待确认", "Waiting for confirmation") : tr$1(locale, "状态已记录", "Status recorded");
 }
@@ -11724,72 +11821,56 @@ function PixelWorldCommercialHud(props) {
       return surface();
     },
     get children() {
-      return [(() => {
-        var _el$28 = _tmpl$19$1(), _el$29 = _el$28.firstChild, _el$30 = _el$29.firstChild, _el$31 = _el$30.firstChild, _el$33 = _el$30.nextSibling, _el$35 = _el$33.nextSibling, _el$36 = _el$29.nextSibling, _el$37 = _el$36.firstChild, _el$38 = _el$37.firstChild, _el$39 = _el$38.nextSibling, _el$40 = _el$39.nextSibling, _el$41 = _el$37.nextSibling, _el$42 = _el$41.firstChild, _el$43 = _el$42.nextSibling, _el$44 = _el$43.nextSibling, _el$45 = _el$44.nextSibling, _el$46 = _el$45.firstChild, _el$47 = _el$46.nextSibling;
-        insert(_el$31, () => tr$1(props.locale(), "下一步", "Next Move"));
-        insert(_el$30, createComponent(Show, {
-          get when() {
-            return surface().blocker.label;
-          },
-          get children() {
-            var _el$32 = _tmpl$17$1();
-            insert(_el$32, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`);
-            return _el$32;
-          }
-        }), null);
-        insert(_el$33, () => surface().next_action.label);
-        insert(_el$29, createComponent(Show, {
-          get when() {
-            return surface().next_action.detail;
-          },
-          get children() {
-            var _el$34 = _tmpl$18$1();
-            insert(_el$34, () => surface().next_action.detail);
-            return _el$34;
-          }
-        }), _el$35);
-        _el$35.$$click = activateNextMove;
-        insert(_el$35, (() => {
-          var _c$ = memo(() => !!directNextMoveAction());
-          return () => _c$() ? surface().next_action.label : memo(() => !!nextMoveRoutesToGameplayDetails())() ? tr$1(props.locale(), "打开玩法明细", "Open Gameplay Details") : tr$1(props.locale(), "去指挥面板", "Go to Command");
-        })());
-        insert(_el$38, () => tr$1(props.locale(), "目标", "Objective"));
-        insert(_el$39, () => surface().objective.title);
-        insert(_el$40, () => surface().objective.detail);
-        insert(_el$42, () => tr$1(props.locale(), "玩家杠杆", "Player Leverage"));
-        insert(_el$43, () => pixelWorldReadableEntityText(surface().player_leverage.summary, props.renderState(), isLocaleZh(props.locale())));
-        insert(_el$44, () => surface().player_leverage.label);
-        insert(_el$46, () => tr$1(props.locale(), "当前 Agent", "Selected Agent"));
-        insert(_el$47, activeAgentLabel);
-        createRenderEffect((_p$) => {
-          var _v$38 = activeAgentId(), _v$39 = surface().player_leverage.state, _v$40 = nextMoveRoute(), _v$41 = surface().next_action.execute_kind || "none", _v$42 = surface().blocker.label ? "true" : "false", _v$43 = nextMoveHref(), _v$44 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$45 = nextMoveDisabledReason() ? "true" : void 0, _v$46 = nextMovePending() ? "true" : "false", _v$47 = nextMoveDisabledReason() ? -1 : void 0, _v$48 = activeAgentLabel();
-          _v$38 !== _p$.e && setAttribute(_el$28, "data-active-agent", _p$.e = _v$38);
-          _v$39 !== _p$.t && setAttribute(_el$28, "data-leverage-state", _p$.t = _v$39);
-          _v$40 !== _p$.a && setAttribute(_el$29, "data-next-move-route", _p$.a = _v$40);
-          _v$41 !== _p$.o && setAttribute(_el$29, "data-execute-kind", _p$.o = _v$41);
-          _v$42 !== _p$.i && setAttribute(_el$29, "data-blocker-present", _p$.i = _v$42);
-          _v$43 !== _p$.n && setAttribute(_el$35, "href", _p$.n = _v$43);
-          _v$44 !== _p$.s && setAttribute(_el$35, "aria-label", _p$.s = _v$44);
-          _v$45 !== _p$.h && setAttribute(_el$35, "aria-disabled", _p$.h = _v$45);
-          _v$46 !== _p$.r && setAttribute(_el$35, "aria-busy", _p$.r = _v$46);
-          _v$47 !== _p$.d && setAttribute(_el$35, "tabindex", _p$.d = _v$47);
-          _v$48 !== _p$.l && setAttribute(_el$45, "data-selected-agent-label", _p$.l = _v$48);
-          return _p$;
-        }, {
-          e: void 0,
-          t: void 0,
-          a: void 0,
-          o: void 0,
-          i: void 0,
-          n: void 0,
-          s: void 0,
-          h: void 0,
-          r: void 0,
-          d: void 0,
-          l: void 0
-        });
-        return _el$28;
-      })(), createComponent(Show, {
+      var _el$16 = _tmpl$12$1(), _el$17 = _el$16.firstChild, _el$18 = _el$17.firstChild, _el$19 = _el$18.firstChild, _el$20 = _el$19.firstChild, _el$22 = _el$19.nextSibling, _el$24 = _el$22.nextSibling, _el$26 = _el$18.nextSibling, _el$27 = _el$26.firstChild, _el$28 = _el$27.firstChild, _el$29 = _el$28.nextSibling, _el$30 = _el$29.nextSibling, _el$31 = _el$27.nextSibling, _el$32 = _el$31.firstChild, _el$33 = _el$32.nextSibling, _el$34 = _el$33.nextSibling, _el$35 = _el$34.nextSibling, _el$36 = _el$35.firstChild, _el$37 = _el$36.nextSibling, _el$38 = _el$17.nextSibling, _el$39 = _el$38.firstChild, _el$41 = _el$39.nextSibling;
+      insert(_el$20, () => tr$1(props.locale(), "下一步", "Next Move"));
+      insert(_el$19, createComponent(Show, {
+        get when() {
+          return surface().blocker.label;
+        },
+        get children() {
+          var _el$21 = _tmpl$0$4();
+          insert(_el$21, () => `${tr$1(props.locale(), "阻塞", "Blocker")}: ${surface().blocker.label}`);
+          return _el$21;
+        }
+      }), null);
+      insert(_el$22, () => surface().next_action.label);
+      insert(_el$18, createComponent(Show, {
+        get when() {
+          return surface().next_action.detail;
+        },
+        get children() {
+          var _el$23 = _tmpl$1$2();
+          insert(_el$23, () => surface().next_action.detail);
+          return _el$23;
+        }
+      }), _el$24);
+      _el$24.$$click = activateNextMove;
+      insert(_el$24, (() => {
+        var _c$ = memo(() => !!directNextMoveAction());
+        return () => _c$() ? surface().next_action.label : memo(() => !!nextMoveRoutesToGameplayDetails())() ? tr$1(props.locale(), "打开玩法明细", "Open Gameplay Details") : tr$1(props.locale(), "去指挥面板", "Go to Command");
+      })());
+      insert(_el$18, createComponent(Show, {
+        get when() {
+          return nextMovePending() || surface().action_receipt?.present;
+        },
+        get children() {
+          var _el$25 = _tmpl$10$2();
+          insert(_el$25, (() => {
+            var _c$2 = memo(() => !!nextMovePending());
+            return () => _c$2() ? tr$1(props.locale(), "动作已提交，等待世界确认。", "Action submitted; waiting for world confirmation.") : surface().action_receipt?.title;
+          })());
+          return _el$25;
+        }
+      }), null);
+      insert(_el$28, () => tr$1(props.locale(), "目标", "Objective"));
+      insert(_el$29, () => surface().objective.title);
+      insert(_el$30, () => surface().objective.detail);
+      insert(_el$32, () => tr$1(props.locale(), "玩家杠杆", "Player Leverage"));
+      insert(_el$33, () => pixelWorldReadableEntityText(surface().player_leverage.summary, props.renderState(), isLocaleZh(props.locale())));
+      insert(_el$34, () => surface().player_leverage.label);
+      insert(_el$36, () => tr$1(props.locale(), "当前 Agent", "Selected Agent"));
+      insert(_el$37, activeAgentLabel);
+      insert(_el$16, createComponent(Show, {
         get when() {
           return !props.focusMode?.();
         },
@@ -11802,32 +11883,57 @@ function PixelWorldCommercialHud(props) {
             surface
           });
         }
-      }), (() => {
-        var _el$48 = _tmpl$21$1(), _el$49 = _el$48.firstChild, _el$51 = _el$49.nextSibling;
-        insert(_el$49, () => readoutStatus().label);
-        insert(_el$48, createComponent(Show, {
-          get when() {
-            return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
-          },
-          get children() {
-            var _el$50 = _tmpl$20$1();
-            insert(_el$50, () => `tick=${surface().world_read.tick}`);
-            createRenderEffect(() => setAttribute(_el$50, "data-world-tick", String(surface().world_read.tick)));
-            return _el$50;
-          }
-        }), _el$51);
-        insert(_el$51, () => `agents=${surface().world_read.agents}`);
-        createRenderEffect((_p$) => {
-          var _v$49 = readoutStatus().className, _v$50 = readoutFeedStatus();
-          _v$49 !== _p$.e && className(_el$49, _p$.e = _v$49);
-          _v$50 !== _p$.t && setAttribute(_el$49, "data-world-feed-readout-status", _p$.t = _v$50);
-          return _p$;
-        }, {
-          e: void 0,
-          t: void 0
-        });
-        return _el$48;
-      })()];
+      }), _el$38);
+      insert(_el$39, () => readoutStatus().label);
+      insert(_el$38, createComponent(Show, {
+        get when() {
+          return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
+        },
+        get children() {
+          var _el$40 = _tmpl$11$1();
+          insert(_el$40, () => `tick=${surface().world_read.tick}`);
+          createRenderEffect(() => setAttribute(_el$40, "data-world-tick", String(surface().world_read.tick)));
+          return _el$40;
+        }
+      }), _el$41);
+      insert(_el$41, () => `agents=${surface().world_read.agents}`);
+      insert(_el$16, createComponent(PixelWorldCanvasLegend, {
+        get locale() {
+          return props.locale;
+        }
+      }), null);
+      createRenderEffect((_p$) => {
+        var _v$8 = activeAgentId(), _v$9 = surface().player_leverage.state, _v$0 = nextMoveRoute(), _v$1 = surface().next_action.execute_kind || "none", _v$10 = surface().blocker.label ? "true" : "false", _v$11 = nextMoveHref(), _v$12 = `${tr$1(props.locale(), "下一步", "Next Move")}: ${surface().next_action.label}`, _v$13 = nextMoveDisabledReason() ? "true" : void 0, _v$14 = nextMovePending() ? "true" : "false", _v$15 = nextMoveDisabledReason() ? -1 : void 0, _v$16 = activeAgentLabel(), _v$17 = readoutStatus().className, _v$18 = readoutFeedStatus();
+        _v$8 !== _p$.e && setAttribute(_el$17, "data-active-agent", _p$.e = _v$8);
+        _v$9 !== _p$.t && setAttribute(_el$17, "data-leverage-state", _p$.t = _v$9);
+        _v$0 !== _p$.a && setAttribute(_el$18, "data-next-move-route", _p$.a = _v$0);
+        _v$1 !== _p$.o && setAttribute(_el$18, "data-execute-kind", _p$.o = _v$1);
+        _v$10 !== _p$.i && setAttribute(_el$18, "data-blocker-present", _p$.i = _v$10);
+        _v$11 !== _p$.n && setAttribute(_el$24, "href", _p$.n = _v$11);
+        _v$12 !== _p$.s && setAttribute(_el$24, "aria-label", _p$.s = _v$12);
+        _v$13 !== _p$.h && setAttribute(_el$24, "aria-disabled", _p$.h = _v$13);
+        _v$14 !== _p$.r && setAttribute(_el$24, "aria-busy", _p$.r = _v$14);
+        _v$15 !== _p$.d && setAttribute(_el$24, "tabindex", _p$.d = _v$15);
+        _v$16 !== _p$.l && setAttribute(_el$35, "data-selected-agent-label", _p$.l = _v$16);
+        _v$17 !== _p$.u && className(_el$39, _p$.u = _v$17);
+        _v$18 !== _p$.c && setAttribute(_el$39, "data-world-feed-readout-status", _p$.c = _v$18);
+        return _p$;
+      }, {
+        e: void 0,
+        t: void 0,
+        a: void 0,
+        o: void 0,
+        i: void 0,
+        n: void 0,
+        s: void 0,
+        h: void 0,
+        r: void 0,
+        d: void 0,
+        l: void 0,
+        u: void 0,
+        c: void 0
+      });
+      return _el$16;
     }
   });
 }
@@ -11838,57 +11944,57 @@ function PixelWorldFocusHud(props) {
       return surface();
     },
     get children() {
-      var _el$52 = _tmpl$23$1(), _el$53 = _el$52.firstChild, _el$54 = _el$53.firstChild, _el$55 = _el$54.nextSibling, _el$56 = _el$53.nextSibling, _el$57 = _el$56.firstChild, _el$58 = _el$57.nextSibling, _el$59 = _el$58.nextSibling, _el$60 = _el$56.nextSibling, _el$61 = _el$60.firstChild, _el$62 = _el$61.nextSibling, _el$63 = _el$62.nextSibling, _el$68 = _el$60.nextSibling, _el$69 = _el$68.firstChild, _el$70 = _el$69.nextSibling, _el$71 = _el$68.nextSibling, _el$72 = _el$71.firstChild, _el$73 = _el$72.nextSibling, _el$74 = _el$73.nextSibling, _el$75 = _el$74.firstChild, _el$76 = _el$75.nextSibling, _el$77 = _el$76.nextSibling;
-      insert(_el$54, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
-      insert(_el$55, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
-      insert(_el$57, () => tr$1(props.locale(), "当前目标", "Current Objective"));
-      insert(_el$58, () => surface().objective.title);
-      insert(_el$59, () => surface().next_action.label);
-      insert(_el$61, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
-      insert(_el$62, (() => {
-        var _c$2 = memo(() => surface().objective.progress_percent == null);
-        return () => _c$2() ? tr$1(props.locale(), "进行中", "In Progress") : `${surface().objective.progress_percent}%`;
+      var _el$42 = _tmpl$14$1(), _el$43 = _el$42.firstChild, _el$44 = _el$43.firstChild, _el$45 = _el$44.nextSibling, _el$46 = _el$43.nextSibling, _el$47 = _el$46.firstChild, _el$48 = _el$47.nextSibling, _el$49 = _el$48.nextSibling, _el$50 = _el$46.nextSibling, _el$51 = _el$50.firstChild, _el$52 = _el$51.nextSibling, _el$53 = _el$52.nextSibling, _el$58 = _el$50.nextSibling, _el$59 = _el$58.firstChild, _el$60 = _el$59.nextSibling, _el$61 = _el$58.nextSibling, _el$62 = _el$61.firstChild, _el$63 = _el$62.nextSibling, _el$64 = _el$63.nextSibling, _el$65 = _el$64.firstChild, _el$66 = _el$65.nextSibling, _el$67 = _el$66.nextSibling;
+      insert(_el$44, () => tr$1(props.locale(), "电影视图", "Cinematic View"));
+      insert(_el$45, () => tr$1(props.locale(), "世界指挥棋盘", "World Command Board"));
+      insert(_el$47, () => tr$1(props.locale(), "当前目标", "Current Objective"));
+      insert(_el$48, () => surface().objective.title);
+      insert(_el$49, () => surface().next_action.label);
+      insert(_el$51, () => tr$1(props.locale(), "任务进度", "Mission Progress"));
+      insert(_el$52, (() => {
+        var _c$3 = memo(() => surface().objective.progress_percent == null);
+        return () => _c$3() ? tr$1(props.locale(), "进行中", "In Progress") : `${surface().objective.progress_percent}%`;
       })());
-      insert(_el$63, () => surface().next_action.detail || surface().objective.detail);
-      insert(_el$52, createComponent(Show, {
+      insert(_el$53, () => surface().next_action.detail || surface().objective.detail);
+      insert(_el$42, createComponent(Show, {
         get when() {
           return memo(() => surface().world_read.tick !== null)() && surface().world_read.tick !== void 0;
         },
         get children() {
-          var _el$64 = _tmpl$22$1(), _el$65 = _el$64.firstChild, _el$66 = _el$65.nextSibling, _el$67 = _el$66.nextSibling;
-          insert(_el$65, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
-          insert(_el$66, () => surface().world_read.tick);
-          insert(_el$67, () => `tick=${surface().world_read.tick}`);
-          createRenderEffect(() => setAttribute(_el$64, "data-world-tick", String(surface().world_read.tick)));
-          return _el$64;
+          var _el$54 = _tmpl$13$1(), _el$55 = _el$54.firstChild, _el$56 = _el$55.nextSibling, _el$57 = _el$56.nextSibling;
+          insert(_el$55, () => tr$1(props.locale(), "世界 Tick", "World Tick"));
+          insert(_el$56, () => surface().world_read.tick);
+          insert(_el$57, () => `tick=${surface().world_read.tick}`);
+          createRenderEffect(() => setAttribute(_el$54, "data-world-tick", String(surface().world_read.tick)));
+          return _el$54;
         }
-      }), _el$68);
-      insert(_el$69, () => tr$1(props.locale(), "阻塞", "Blocker"));
-      insert(_el$70, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
-      addEventListener(_el$72, "click", props.onOpenCommand);
-      insert(_el$72, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
-      addEventListener(_el$73, "click", props.onExit);
-      insert(_el$73, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
-      insert(_el$75, () => tr$1(props.locale(), "更多控制", "More controls"));
-      addEventListener(_el$76, "click", props.onOpenDiagnostics);
-      insert(_el$76, () => tr$1(props.locale(), "世界状态", "World Status"));
-      addEventListener(_el$77, "click", props.onToggleMaximized);
-      insert(_el$77, (() => {
-        var _c$3 = memo(() => !!props.maximized());
-        return () => _c$3() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
+      }), _el$58);
+      insert(_el$59, () => tr$1(props.locale(), "阻塞", "Blocker"));
+      insert(_el$60, () => surface().blocker.label || tr$1(props.locale(), "暂无阻塞", "No blocker"));
+      addEventListener(_el$62, "click", props.onOpenCommand);
+      insert(_el$62, () => tr$1(props.locale(), "命令与目标", "Command & Target"));
+      addEventListener(_el$63, "click", props.onExit);
+      insert(_el$63, () => tr$1(props.locale(), "退出电影视图", "Exit Cinematic"));
+      insert(_el$65, () => tr$1(props.locale(), "更多控制", "More controls"));
+      addEventListener(_el$66, "click", props.onOpenDiagnostics);
+      insert(_el$66, () => tr$1(props.locale(), "世界状态", "World Status"));
+      addEventListener(_el$67, "click", props.onToggleMaximized);
+      insert(_el$67, (() => {
+        var _c$4 = memo(() => !!props.maximized());
+        return () => _c$4() ? tr$1(props.locale(), "还原布局", "Restore Layout") : tr$1(props.locale(), "最大化", "Maximize");
       })());
       createRenderEffect((_p$) => {
-        var _v$51 = surface().blocker.label ? "true" : "false", _v$52 = surface().blocker.label ? "critical" : "clear", _v$53 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
-        _v$51 !== _p$.e && setAttribute(_el$68, "data-blocker-present", _p$.e = _v$51);
-        _v$52 !== _p$.t && setAttribute(_el$68, "data-hud-priority", _p$.t = _v$52);
-        _v$53 !== _p$.a && setAttribute(_el$71, "aria-label", _p$.a = _v$53);
+        var _v$19 = surface().blocker.label ? "true" : "false", _v$20 = surface().blocker.label ? "critical" : "clear", _v$21 = tr$1(props.locale(), "电影视图控制", "Cinematic controls");
+        _v$19 !== _p$.e && setAttribute(_el$58, "data-blocker-present", _p$.e = _v$19);
+        _v$20 !== _p$.t && setAttribute(_el$58, "data-hud-priority", _p$.t = _v$20);
+        _v$21 !== _p$.a && setAttribute(_el$61, "aria-label", _p$.a = _v$21);
         return _p$;
       }, {
         e: void 0,
         t: void 0,
         a: void 0
       });
-      return _el$52;
+      return _el$42;
     }
   });
 }
@@ -11899,22 +12005,22 @@ function PixelWorldFocusCinematicBanner(props) {
       return surface();
     },
     get children() {
-      var _el$78 = _tmpl$25$1(), _el$79 = _el$78.firstChild, _el$80 = _el$79.nextSibling, _el$81 = _el$80.nextSibling, _el$82 = _el$81.nextSibling, _el$83 = _el$82.firstChild;
-      insert(_el$79, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
-      insert(_el$80, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
-      insert(_el$81, () => surface().objective.detail);
-      insert(_el$83, () => surface().objective.title);
-      insert(_el$82, createComponent(Show, {
+      var _el$68 = _tmpl$16$1(), _el$69 = _el$68.firstChild, _el$70 = _el$69.nextSibling, _el$71 = _el$70.nextSibling, _el$72 = _el$71.nextSibling, _el$73 = _el$72.firstChild;
+      insert(_el$69, () => tr$1(props.locale(), "电影化首屏", "Cinematic Opening"));
+      insert(_el$70, () => tr$1(props.locale(), "工业世界指挥台", "Industrial World Command Board"));
+      insert(_el$71, () => surface().objective.detail);
+      insert(_el$73, () => surface().objective.title);
+      insert(_el$72, createComponent(Show, {
         get when() {
           return surface().blocker.label;
         },
         get children() {
-          var _el$84 = _tmpl$24$1();
-          insert(_el$84, () => surface().blocker.label);
-          return _el$84;
+          var _el$74 = _tmpl$15$1();
+          insert(_el$74, () => surface().blocker.label);
+          return _el$74;
         }
       }), null);
-      return _el$78;
+      return _el$68;
     }
   });
 }
@@ -11940,53 +12046,53 @@ function PixelWorldFocusRail(props) {
       return memo(() => !!surface())() && hasFocusItems();
     },
     get children() {
-      var _el$85 = _tmpl$28$1(), _el$86 = _el$85.firstChild;
-      insert(_el$86, () => tr$1(props.locale(), "焦点", "Focus"));
-      insert(_el$85, createComponent(Show, {
+      var _el$75 = _tmpl$19$1(), _el$76 = _el$75.firstChild;
+      insert(_el$76, () => tr$1(props.locale(), "焦点", "Focus"));
+      insert(_el$75, createComponent(Show, {
         get when() {
           return surface()?.blocker.label;
         },
         get children() {
-          var _el$87 = _tmpl$26$1(), _el$88 = _el$87.firstChild, _el$89 = _el$88.nextSibling;
-          insert(_el$88, () => tr$1(props.locale(), "阻塞", "Blocker"));
-          insert(_el$89, () => surface().blocker.label);
-          return _el$87;
+          var _el$77 = _tmpl$17$1(), _el$78 = _el$77.firstChild, _el$79 = _el$78.nextSibling;
+          insert(_el$78, () => tr$1(props.locale(), "阻塞", "Blocker"));
+          insert(_el$79, () => surface().blocker.label);
+          return _el$77;
         }
       }), null);
-      insert(_el$85, createComponent(Show, {
+      insert(_el$75, createComponent(Show, {
         get when() {
           return activeAgent();
         },
         get children() {
-          var _el$90 = _tmpl$27$1(), _el$91 = _el$90.firstChild, _el$92 = _el$91.nextSibling;
-          insert(_el$91, () => tr$1(props.locale(), "Agent", "Agent"));
-          insert(_el$92, activeAgentName);
-          return _el$90;
+          var _el$80 = _tmpl$18$1(), _el$81 = _el$80.firstChild, _el$82 = _el$81.nextSibling;
+          insert(_el$81, () => tr$1(props.locale(), "Agent", "Agent"));
+          insert(_el$82, activeAgentName);
+          return _el$80;
         }
       }), null);
-      insert(_el$85, createComponent(Show, {
+      insert(_el$75, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$93 = _tmpl$27$1(), _el$94 = _el$93.firstChild, _el$95 = _el$94.nextSibling;
-          insert(_el$94, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$95, selectedName);
-          return _el$93;
+          var _el$83 = _tmpl$18$1(), _el$84 = _el$83.firstChild, _el$85 = _el$84.nextSibling;
+          insert(_el$84, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$85, selectedName);
+          return _el$83;
         }
       }), null);
-      insert(_el$85, createComponent(Show, {
+      insert(_el$75, createComponent(Show, {
         get when() {
           return routeCount() > 0;
         },
         get children() {
-          var _el$96 = _tmpl$27$1(), _el$97 = _el$96.firstChild, _el$98 = _el$97.nextSibling;
-          insert(_el$97, () => tr$1(props.locale(), "路线", "Routes"));
-          insert(_el$98, routeCount);
-          return _el$96;
+          var _el$86 = _tmpl$18$1(), _el$87 = _el$86.firstChild, _el$88 = _el$87.nextSibling;
+          insert(_el$87, () => tr$1(props.locale(), "路线", "Routes"));
+          insert(_el$88, routeCount);
+          return _el$86;
         }
       }), null);
-      return _el$85;
+      return _el$75;
     }
   });
 }
@@ -12003,50 +12109,50 @@ function PixelWorldFocusMinimapCard(props) {
       return surface();
     },
     get children() {
-      var _el$99 = _tmpl$31$1(), _el$100 = _el$99.firstChild, _el$102 = _el$100.nextSibling, _el$103 = _el$102.nextSibling, _el$104 = _el$103.nextSibling, _el$105 = _el$104.firstChild, _el$106 = _el$105.nextSibling, _el$107 = _el$104.nextSibling, _el$108 = _el$107.firstChild, _el$109 = _el$108.nextSibling, _el$113 = _el$107.nextSibling, _el$114 = _el$113.firstChild, _el$115 = _el$114.nextSibling, _el$116 = _el$115.nextSibling, _el$117 = _el$116.nextSibling;
-      insert(_el$100, () => tr$1(props.locale(), "任务地图", "Mission Map"));
-      insert(_el$99, createComponent(Show, {
+      var _el$89 = _tmpl$22$1(), _el$90 = _el$89.firstChild, _el$92 = _el$90.nextSibling, _el$93 = _el$92.nextSibling, _el$94 = _el$93.nextSibling, _el$95 = _el$94.firstChild, _el$96 = _el$95.nextSibling, _el$97 = _el$94.nextSibling, _el$98 = _el$97.firstChild, _el$99 = _el$98.nextSibling, _el$103 = _el$97.nextSibling, _el$104 = _el$103.firstChild, _el$105 = _el$104.nextSibling, _el$106 = _el$105.nextSibling, _el$107 = _el$106.nextSibling;
+      insert(_el$90, () => tr$1(props.locale(), "任务地图", "Mission Map"));
+      insert(_el$89, createComponent(Show, {
         get when() {
           return primaryLocation();
         },
         get children() {
-          var _el$101 = _tmpl$29$1();
-          insert(_el$101, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
-          return _el$101;
+          var _el$91 = _tmpl$20$1();
+          insert(_el$91, () => `${tr$1(props.locale(), "参照", "Reference")}: ${primaryLocation().label || primaryLocation().id}`);
+          return _el$91;
         }
-      }), _el$102);
-      insert(_el$105, () => tr$1(props.locale(), "目标", "Target"));
-      insert(_el$106, () => surface().next_action.label);
-      insert(_el$108, () => tr$1(props.locale(), "Agent", "Agent"));
-      insert(_el$109, (() => {
-        var _c$4 = memo(() => !!activeAgent());
-        return () => _c$4() ? activeAgentName() : tr$1(props.locale(), "待分配", "Unassigned");
+      }), _el$92);
+      insert(_el$95, () => tr$1(props.locale(), "目标", "Target"));
+      insert(_el$96, () => surface().next_action.label);
+      insert(_el$98, () => tr$1(props.locale(), "Agent", "Agent"));
+      insert(_el$99, (() => {
+        var _c$5 = memo(() => !!activeAgent());
+        return () => _c$5() ? activeAgentName() : tr$1(props.locale(), "待分配", "Unassigned");
       })());
-      insert(_el$99, createComponent(Show, {
+      insert(_el$89, createComponent(Show, {
         get when() {
           return selected();
         },
         get children() {
-          var _el$110 = _tmpl$30$1(), _el$111 = _el$110.firstChild, _el$112 = _el$111.nextSibling;
-          insert(_el$111, () => tr$1(props.locale(), "选中", "Selected"));
-          insert(_el$112, selectedName);
-          return _el$110;
+          var _el$100 = _tmpl$21$1(), _el$101 = _el$100.firstChild, _el$102 = _el$101.nextSibling;
+          insert(_el$101, () => tr$1(props.locale(), "选中", "Selected"));
+          insert(_el$102, selectedName);
+          return _el$100;
         }
-      }), _el$113);
-      insert(_el$114, () => `agents=${props.renderState().agents.length}`);
-      insert(_el$115, () => `targets=${props.renderState().locations.length}`);
-      insert(_el$116, () => `routes=${props.renderState().links.length}`);
-      insert(_el$117, () => `fragments=${props.renderState().fragment_terrain.length}`);
+      }), _el$103);
+      insert(_el$104, () => `agents=${props.renderState().agents.length}`);
+      insert(_el$105, () => `targets=${props.renderState().locations.length}`);
+      insert(_el$106, () => `routes=${props.renderState().links.length}`);
+      insert(_el$107, () => `fragments=${props.renderState().fragment_terrain.length}`);
       createRenderEffect((_p$) => {
-        var _v$54 = props.renderState().links.length, _v$55 = tr$1(props.locale(), "世界摘要", "World summary");
-        _v$54 !== _p$.e && setAttribute(_el$103, "data-routes", _p$.e = _v$54);
-        _v$55 !== _p$.t && setAttribute(_el$113, "aria-label", _p$.t = _v$55);
+        var _v$22 = props.renderState().links.length, _v$23 = tr$1(props.locale(), "世界摘要", "World summary");
+        _v$22 !== _p$.e && setAttribute(_el$93, "data-routes", _p$.e = _v$22);
+        _v$23 !== _p$.t && setAttribute(_el$103, "aria-label", _p$.t = _v$23);
         return _p$;
       }, {
         e: void 0,
         t: void 0
       });
-      return _el$99;
+      return _el$89;
     }
   });
 }
@@ -12078,20 +12184,20 @@ function PixelRawDiagnostics(props) {
   const [open, setOpen] = createSignal(false);
   const value2 = () => typeof props.value === "function" ? props.value() : props.value;
   return (() => {
-    var _el$118 = _tmpl$33$1(), _el$119 = _el$118.firstChild;
-    _el$118.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
-    insert(_el$119, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
-    insert(_el$118, createComponent(Show, {
+    var _el$108 = _tmpl$24$1(), _el$109 = _el$108.firstChild;
+    _el$108.addEventListener("toggle", (event) => setOpen(event.currentTarget.open));
+    insert(_el$109, () => tr$1(locale(), "原始诊断", "Raw diagnostics"));
+    insert(_el$108, createComponent(Show, {
       get when() {
         return open();
       },
       get children() {
-        var _el$120 = _tmpl$32$1();
-        insert(_el$120, () => JSON.stringify(value2(), null, 2));
-        return _el$120;
+        var _el$110 = _tmpl$23$1();
+        insert(_el$110, () => JSON.stringify(value2(), null, 2));
+        return _el$110;
       }
     }), null);
-    return _el$118;
+    return _el$108;
   })();
 }
 function PixelWorldFocusCommandSurface(props) {
@@ -12113,136 +12219,136 @@ function PixelWorldFocusCommandSurface(props) {
   const receiptLabel = () => gameplaySummary()?.executionStateLabel || gameplaySummary()?.recentFeedback?.stage || tr$1(locale(), "等待回执", "Waiting");
   const chatHistory = () => state.chatHistory.filter((entry) => entry.agentId === agentId() || entry.targetAgentId === agentId()).slice(0, 12);
   return (() => {
-    var _el$121 = _tmpl$39$1();
-    insert(_el$121, createComponent(Show, {
+    var _el$111 = _tmpl$30$1();
+    insert(_el$111, createComponent(Show, {
       get when() {
         return agentId();
       },
       get fallback() {
         return (() => {
-          var _el$155 = _tmpl$37$1();
-          insert(_el$155, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
-          return _el$155;
+          var _el$145 = _tmpl$28$1();
+          insert(_el$145, () => tr$1(locale(), "先选中一个行动体，才能在电影视图里直接下指令。", "Select an agent to issue direct commands in Cinematic View."));
+          return _el$145;
         })();
       },
       get children() {
         return [(() => {
-          var _el$122 = _tmpl$35$1(), _el$123 = _el$122.firstChild, _el$124 = _el$123.nextSibling, _el$126 = _el$124.nextSibling;
-          insert(_el$123, () => tr$1(locale(), "当前交互目标", "Current Target"));
-          insert(_el$124, agentName);
-          insert(_el$122, createComponent(Show, {
+          var _el$112 = _tmpl$26$1(), _el$113 = _el$112.firstChild, _el$114 = _el$113.nextSibling, _el$116 = _el$114.nextSibling;
+          insert(_el$113, () => tr$1(locale(), "当前交互目标", "Current Target"));
+          insert(_el$114, agentName);
+          insert(_el$112, createComponent(Show, {
             get when() {
               return binding()?.playerId;
             },
             get children() {
-              var _el$125 = _tmpl$34$1();
-              insert(_el$125, () => `boundPlayer=${binding().playerId}`);
-              return _el$125;
+              var _el$115 = _tmpl$25$1();
+              insert(_el$115, () => `boundPlayer=${binding().playerId}`);
+              return _el$115;
             }
-          }), _el$126);
-          insert(_el$126, (() => {
-            var _c$5 = memo(() => !!chatCapability().enabled);
-            return () => _c$5() ? tr$1(locale(), "聊天可用", "Chat Ready") : tr$1(locale(), "聊天受限", "Chat Limited");
+          }), _el$116);
+          insert(_el$116, (() => {
+            var _c$6 = memo(() => !!chatCapability().enabled);
+            return () => _c$6() ? tr$1(locale(), "聊天可用", "Chat Ready") : tr$1(locale(), "聊天受限", "Chat Limited");
           })());
-          createRenderEffect(() => className(_el$126, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
-          return _el$122;
+          createRenderEffect(() => className(_el$116, chatCapability().enabled ? "badge badge--good" : "badge badge--warn"));
+          return _el$112;
         })(), (() => {
-          var _el$127 = _tmpl$36$1(), _el$128 = _el$127.firstChild, _el$129 = _el$128.firstChild, _el$130 = _el$129.nextSibling, _el$131 = _el$130.nextSibling, _el$132 = _el$128.nextSibling, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling, _el$135 = _el$132.nextSibling, _el$136 = _el$135.firstChild, _el$137 = _el$136.nextSibling, _el$138 = _el$135.nextSibling;
-          insert(_el$129, () => tr$1(locale(), "目标", "Target"));
-          insert(_el$130, agentName);
-          insert(_el$131, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
-          insert(_el$133, () => tr$1(locale(), "阻塞", "Blocker"));
-          insert(_el$134, blockerLabel);
-          insert(_el$136, () => tr$1(locale(), "回执", "Receipt"));
-          insert(_el$137, receiptLabel);
-          _el$138.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$138, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          var _el$117 = _tmpl$27$1(), _el$118 = _el$117.firstChild, _el$119 = _el$118.firstChild, _el$120 = _el$119.nextSibling, _el$121 = _el$120.nextSibling, _el$122 = _el$118.nextSibling, _el$123 = _el$122.firstChild, _el$124 = _el$123.nextSibling, _el$125 = _el$122.nextSibling, _el$126 = _el$125.firstChild, _el$127 = _el$126.nextSibling, _el$128 = _el$125.nextSibling;
+          insert(_el$119, () => tr$1(locale(), "目标", "Target"));
+          insert(_el$120, agentName);
+          insert(_el$121, () => tr$1(locale(), "可交互行动体", "Interactive agent"));
+          insert(_el$123, () => tr$1(locale(), "阻塞", "Blocker"));
+          insert(_el$124, blockerLabel);
+          insert(_el$126, () => tr$1(locale(), "回执", "Receipt"));
+          insert(_el$127, receiptLabel);
+          _el$128.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$128, () => tr$1(locale(), "发送聊天", "Send Chat"));
           createRenderEffect((_p$) => {
-            var _v$56 = chatControlsEnabled() ? "true" : "false", _v$57 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$58 = !chatControlsEnabled();
-            _v$56 !== _p$.e && setAttribute(_el$127, "data-chat-ready", _p$.e = _v$56);
-            _v$57 !== _p$.t && setAttribute(_el$132, "data-blocker-present", _p$.t = _v$57);
-            _v$58 !== _p$.a && (_el$138.disabled = _p$.a = _v$58);
+            var _v$24 = chatControlsEnabled() ? "true" : "false", _v$25 = blockerLabel() !== tr$1(locale(), "无阻塞", "No blocker") ? "true" : "false", _v$26 = !chatControlsEnabled();
+            _v$24 !== _p$.e && setAttribute(_el$117, "data-chat-ready", _p$.e = _v$24);
+            _v$25 !== _p$.t && setAttribute(_el$122, "data-blocker-present", _p$.t = _v$25);
+            _v$26 !== _p$.a && (_el$128.disabled = _p$.a = _v$26);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          return _el$127;
+          return _el$117;
         })(), createComponent(Show, {
           get when() {
             return !chatCapability().enabled;
           },
           get children() {
-            var _el$139 = _tmpl$37$1();
-            insert(_el$139, () => chatCapability().reason);
-            return _el$139;
+            var _el$129 = _tmpl$28$1();
+            insert(_el$129, () => chatCapability().reason);
+            return _el$129;
           }
         }), (() => {
-          var _el$140 = _tmpl$38$1(), _el$141 = _el$140.firstChild, _el$142 = _el$141.firstChild, _el$143 = _el$142.firstChild, _el$144 = _el$143.nextSibling, _el$145 = _el$144.nextSibling, _el$146 = _el$141.nextSibling, _el$147 = _el$146.firstChild, _el$148 = _el$147.firstChild, _el$149 = _el$148.nextSibling, _el$150 = _el$147.nextSibling, _el$151 = _el$150.firstChild, _el$152 = _el$150.nextSibling, _el$153 = _el$152.firstChild, _el$154 = _el$153.nextSibling;
-          insert(_el$143, () => tr$1(locale(), "指挥面板", "Command Surface"));
-          insert(_el$144, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
-          insert(_el$145, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
-          insert(_el$148, () => tr$1(locale(), "消息", "Message"));
-          _el$149.$$input = (event) => {
+          var _el$130 = _tmpl$29$1(), _el$131 = _el$130.firstChild, _el$132 = _el$131.firstChild, _el$133 = _el$132.firstChild, _el$134 = _el$133.nextSibling, _el$135 = _el$134.nextSibling, _el$136 = _el$131.nextSibling, _el$137 = _el$136.firstChild, _el$138 = _el$137.firstChild, _el$139 = _el$138.nextSibling, _el$140 = _el$137.nextSibling, _el$141 = _el$140.firstChild, _el$142 = _el$140.nextSibling, _el$143 = _el$142.firstChild, _el$144 = _el$143.nextSibling;
+          insert(_el$133, () => tr$1(locale(), "指挥面板", "Command Surface"));
+          insert(_el$134, () => tr$1(locale(), "行动体聊天", "Agent Chat"));
+          insert(_el$135, () => tr$1(locale(), "给当前目标发消息并读取反馈。", "Message the current target and read feedback."));
+          insert(_el$138, () => tr$1(locale(), "消息", "Message"));
+          _el$139.$$input = (event) => {
             state.chatDraft.message = String(event.currentTarget.value || "");
             state.chatDraft.dirty = true;
           };
-          _el$151.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-          insert(_el$151, () => tr$1(locale(), "发送聊天", "Send Chat"));
-          insert(_el$146, createComponent(Show, {
+          _el$141.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+          insert(_el$141, () => tr$1(locale(), "发送聊天", "Send Chat"));
+          insert(_el$136, createComponent(Show, {
             get when() {
               return chatFeedback();
             },
             get fallback() {
               return (() => {
-                var _el$156 = _tmpl$37$1();
-                insert(_el$156, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
-                return _el$156;
+                var _el$146 = _tmpl$28$1();
+                insert(_el$146, () => tr$1(locale(), "还没有聊天反馈。", "No chat feedback yet."));
+                return _el$146;
               })();
             },
             children: (feedback) => (() => {
-              var _el$157 = _tmpl$41$1(), _el$158 = _el$157.firstChild, _el$159 = _el$158.firstChild, _el$161 = _el$158.nextSibling;
-              insert(_el$159, () => chatFeedbackDisplay().label);
-              insert(_el$158, createComponent(Show, {
+              var _el$147 = _tmpl$32$1(), _el$148 = _el$147.firstChild, _el$149 = _el$148.firstChild, _el$151 = _el$148.nextSibling;
+              insert(_el$149, () => chatFeedbackDisplay().label);
+              insert(_el$148, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().code;
                 },
                 get children() {
-                  var _el$160 = _tmpl$34$1();
-                  insert(_el$160, () => `code=${chatFeedbackDisplay().code}`);
-                  return _el$160;
+                  var _el$150 = _tmpl$25$1();
+                  insert(_el$150, () => `code=${chatFeedbackDisplay().code}`);
+                  return _el$150;
                 }
               }), null);
-              insert(_el$161, () => chatFeedbackDisplay().summary);
-              insert(_el$157, createComponent(Show, {
+              insert(_el$151, () => chatFeedbackDisplay().summary);
+              insert(_el$147, createComponent(Show, {
                 get when() {
                   return chatFeedbackDisplay().detail;
                 },
                 get children() {
-                  var _el$162 = _tmpl$40$1();
-                  insert(_el$162, () => chatFeedbackDisplay().detail);
-                  return _el$162;
+                  var _el$152 = _tmpl$31$1();
+                  insert(_el$152, () => chatFeedbackDisplay().detail);
+                  return _el$152;
                 }
               }), null);
-              insert(_el$157, createComponent(PixelRawDiagnostics, {
+              insert(_el$147, createComponent(PixelRawDiagnostics, {
                 locale,
                 value: feedback
               }), null);
-              createRenderEffect(() => className(_el$159, chatFeedbackDisplay().badgeClass));
-              return _el$157;
+              createRenderEffect(() => className(_el$149, chatFeedbackDisplay().badgeClass));
+              return _el$147;
             })()
-          }), _el$152);
-          insert(_el$153, () => tr$1(locale(), "消息流", "Message Flow"));
-          insert(_el$154, createComponent(Show, {
+          }), _el$142);
+          insert(_el$143, () => tr$1(locale(), "消息流", "Message Flow"));
+          insert(_el$144, createComponent(Show, {
             get when() {
               return chatHistory().length > 0;
             },
             get fallback() {
               return (() => {
-                var _el$163 = _tmpl$37$1();
-                insert(_el$163, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
-                return _el$163;
+                var _el$153 = _tmpl$28$1();
+                insert(_el$153, () => tr$1(locale(), "这个行动体还没有聊天历史。", "No chat history for this agent yet."));
+                return _el$153;
               })();
             },
             get children() {
@@ -12251,37 +12357,37 @@ function PixelWorldFocusCommandSurface(props) {
                   return chatHistory();
                 },
                 children: (entry) => (() => {
-                  var _el$164 = _tmpl$42$1(), _el$165 = _el$164.firstChild, _el$166 = _el$165.firstChild, _el$167 = _el$165.nextSibling, _el$168 = _el$167.nextSibling;
-                  insert(_el$166, () => chatEntryTitle$1(entry, locale()));
-                  insert(_el$167, () => chatEntryMeta$1(entry, locale()));
-                  insert(_el$168, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
-                  insert(_el$164, createComponent(PixelRawDiagnostics, {
+                  var _el$154 = _tmpl$33$1(), _el$155 = _el$154.firstChild, _el$156 = _el$155.firstChild, _el$157 = _el$155.nextSibling, _el$158 = _el$157.nextSibling;
+                  insert(_el$156, () => chatEntryTitle$1(entry, locale()));
+                  insert(_el$157, () => chatEntryMeta$1(entry, locale()));
+                  insert(_el$158, () => entry.message || tr$1(locale(), "没有消息正文。", "No message body."));
+                  insert(_el$154, createComponent(PixelRawDiagnostics, {
                     locale,
                     value: entry
                   }), null);
-                  createRenderEffect(() => className(_el$164, chatEntryCardClass$1(entry)));
-                  return _el$164;
+                  createRenderEffect(() => className(_el$154, chatEntryCardClass$1(entry)));
+                  return _el$154;
                 })()
               });
             }
           }));
           createRenderEffect((_p$) => {
-            var _v$59 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$60 = !chatControlsEnabled(), _v$61 = !chatControlsEnabled();
-            _v$59 !== _p$.e && setAttribute(_el$149, "placeholder", _p$.e = _v$59);
-            _v$60 !== _p$.t && (_el$149.disabled = _p$.t = _v$60);
-            _v$61 !== _p$.a && (_el$151.disabled = _p$.a = _v$61);
+            var _v$27 = tr$1(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$28 = !chatControlsEnabled(), _v$29 = !chatControlsEnabled();
+            _v$27 !== _p$.e && setAttribute(_el$139, "placeholder", _p$.e = _v$27);
+            _v$28 !== _p$.t && (_el$139.disabled = _p$.t = _v$28);
+            _v$29 !== _p$.a && (_el$141.disabled = _p$.a = _v$29);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          createRenderEffect(() => _el$149.value = state.chatDraft.message);
-          return _el$140;
+          createRenderEffect(() => _el$139.value = state.chatDraft.message);
+          return _el$130;
         })()];
       }
     }));
-    return _el$121;
+    return _el$111;
   })();
 }
 function PixelWorldHost(props) {
@@ -12530,26 +12636,26 @@ function PixelWorldHost(props) {
     });
   });
   return (() => {
-    var _el$169 = _tmpl$51$1(), _el$174 = _el$169.firstChild, _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling, _el$213 = _el$174.nextSibling, _el$214 = _el$213.firstChild;
-    setAttribute(_el$169, "data-visual-fixture", visualFixtureName || "");
-    insert(_el$169, createComponent(Show, {
+    var _el$159 = _tmpl$42$1(), _el$164 = _el$159.firstChild, _el$165 = _el$164.firstChild, _el$166 = _el$165.nextSibling, _el$203 = _el$164.nextSibling, _el$204 = _el$203.firstChild;
+    setAttribute(_el$159, "data-visual-fixture", visualFixtureName || "");
+    insert(_el$159, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$170 = _tmpl$43$1(), _el$171 = _el$170.firstChild, _el$172 = _el$171.firstChild, _el$173 = _el$172.nextSibling;
-        insert(_el$172, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
-        insert(_el$173, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
-        return _el$170;
+        var _el$160 = _tmpl$34$1(), _el$161 = _el$160.firstChild, _el$162 = _el$161.firstChild, _el$163 = _el$162.nextSibling;
+        insert(_el$162, () => tr$1(locale(), "世界指挥棋盘", "World Command Board"));
+        insert(_el$163, () => renderState()?.commercial_surface?.objective?.detail || tr$1(locale(), "等待 Rust bridge 生成世界显示状态。", "Waiting for the Rust bridge to derive the world display state."));
+        return _el$160;
       }
-    }), _el$174);
-    insert(_el$175, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
-    addEventListener(_el$176, "click", focusController.enterFocusMode);
-    insert(_el$176, (() => {
-      var _c$6 = memo(() => rendererStatus() === "unavailable");
-      return () => _c$6() ? tr$1(locale(), "电影视图（当前不可用）", "Cinematic View (unavailable)") : tr$1(locale(), "电影视图", "Cinematic View");
+    }), _el$164);
+    insert(_el$165, () => tr$1(locale(), "拖动、缩放并检查世界", "Pan, zoom, and inspect the world"));
+    addEventListener(_el$166, "click", focusController.enterFocusMode);
+    insert(_el$166, (() => {
+      var _c$7 = memo(() => rendererStatus() === "unavailable");
+      return () => _c$7() ? tr$1(locale(), "电影视图（当前不可用）", "Cinematic View (unavailable)") : tr$1(locale(), "电影视图", "Cinematic View");
     })());
-    insert(_el$169, createComponent(Show, {
+    insert(_el$159, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
@@ -12594,8 +12700,8 @@ function PixelWorldHost(props) {
           }
         })];
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return renderState();
       },
@@ -12606,8 +12712,8 @@ function PixelWorldHost(props) {
           focusMode
         });
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return memo(() => rendererStatus() !== "fallback")() && rendererStatus() !== "unavailable";
       },
@@ -12619,6 +12725,7 @@ function PixelWorldHost(props) {
           renderInput,
           renderState,
           selection: selectedEntity,
+          hoveredEntity: hoverSelection,
           visualOverlayEnabled,
           onSelect: (selection) => adapter().simulateSelect(selection),
           onHover: (selection) => adapter().simulateHover(selection),
@@ -12638,59 +12745,59 @@ function PixelWorldHost(props) {
           }
         });
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return !renderState();
       },
       get children() {
-        var _el$177 = _tmpl$44$1();
-        insert(_el$177, (() => {
-          var _c$7 = memo(() => rendererStatus() === "unavailable");
-          return () => _c$7() ? [(() => {
-            var _el$217 = _tmpl$52$1();
-            insert(_el$217, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
-            return _el$217;
+        var _el$167 = _tmpl$35$1();
+        insert(_el$167, (() => {
+          var _c$8 = memo(() => rendererStatus() === "unavailable");
+          return () => _c$8() ? [(() => {
+            var _el$207 = _tmpl$43$1();
+            insert(_el$207, () => tr$1(locale(), "此浏览器中的图形不可用", "Graphics unavailable in this browser"));
+            return _el$207;
           })(), (() => {
-            var _el$218 = _tmpl$53$1();
-            _el$218.$$click = requestReadyMode;
-            insert(_el$218, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
-            return _el$218;
+            var _el$208 = _tmpl$44$1();
+            _el$208.$$click = requestReadyMode;
+            insert(_el$208, () => tr$1(locale(), "重试 Renderer", "Retry Renderer"));
+            return _el$208;
           })()] : tr$1(locale(), "Rust bridge 正在生成世界显示状态。", "Rust bridge is deriving the world display state.");
         })());
         createRenderEffect((_p$) => {
-          var _v$62 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$63 = rendererStatus();
-          _v$62 !== _p$.e && setAttribute(_el$177, "id", _p$.e = _v$62);
-          _v$63 !== _p$.t && setAttribute(_el$177, "data-renderer-state", _p$.t = _v$63);
+          var _v$30 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : void 0, _v$31 = rendererStatus();
+          _v$30 !== _p$.e && setAttribute(_el$167, "id", _p$.e = _v$30);
+          _v$31 !== _p$.t && setAttribute(_el$167, "data-renderer-state", _p$.t = _v$31);
           return _p$;
         }, {
           e: void 0,
           t: void 0
         });
-        return _el$177;
+        return _el$167;
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState()?.commercial_surface;
       },
       get children() {
-        var _el$178 = _tmpl$45$1();
-        insert(_el$178, createComponent(PixelWorldActionReceipt, {
+        var _el$168 = _tmpl$36$1();
+        insert(_el$168, createComponent(PixelWorldActionReceipt, {
           "class": "pixel-world-action-receipt--focus-compact",
           locale,
           surface: () => renderState().commercial_surface
         }));
-        return _el$178;
+        return _el$168;
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return focusMode();
       },
       get children() {
-        var _el$179 = _tmpl$46$1(), _el$180 = _el$179.firstChild, _el$181 = _el$180.nextSibling;
-        _el$179.addEventListener("toggle", (event) => {
+        var _el$169 = _tmpl$37$1(), _el$170 = _el$169.firstChild, _el$171 = _el$170.nextSibling;
+        _el$169.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentCommandDrawerOpen(true);
@@ -12700,97 +12807,97 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$180, () => tr$1(locale(), "命令与目标", "Command and Target"));
-        insert(_el$181, createComponent(PixelWorldFocusCommandSurface, {
+        insert(_el$170, () => tr$1(locale(), "命令与目标", "Command and Target"));
+        insert(_el$171, createComponent(PixelWorldFocusCommandSurface, {
           locale
         }));
-        createRenderEffect(() => _el$179.open = commandDrawerOpen());
-        return _el$179;
+        createRenderEffect(() => _el$169.open = commandDrawerOpen());
+        return _el$169;
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return !focusMode() || !maximized();
       },
       get children() {
-        var _el$182 = _tmpl$48$1(), _el$183 = _el$182.firstChild, _el$184 = _el$183.nextSibling, _el$185 = _el$184.firstChild, _el$186 = _el$185.nextSibling, _el$187 = _el$186.nextSibling, _el$189 = _el$187.nextSibling, _el$190 = _el$189.nextSibling, _el$191 = _el$190.nextSibling, _el$192 = _el$191.nextSibling, _el$193 = _el$192.nextSibling, _el$194 = _el$193.nextSibling, _el$198 = _el$194.nextSibling, _el$199 = _el$198.nextSibling, _el$200 = _el$199.nextSibling;
-        insert(_el$183, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
-        insert(_el$185, () => `locations=${visualState().locations.length}`);
-        insert(_el$186, () => `fragments=${visualState().fragmentTerrain.length}`);
-        insert(_el$187, () => `agents=${visualState().agents.length}`);
-        insert(_el$184, createComponent(Show, {
+        var _el$172 = _tmpl$39$1(), _el$173 = _el$172.firstChild, _el$174 = _el$173.nextSibling, _el$175 = _el$174.firstChild, _el$176 = _el$175.nextSibling, _el$177 = _el$176.nextSibling, _el$179 = _el$177.nextSibling, _el$180 = _el$179.nextSibling, _el$181 = _el$180.nextSibling, _el$182 = _el$181.nextSibling, _el$183 = _el$182.nextSibling, _el$184 = _el$183.nextSibling, _el$188 = _el$184.nextSibling, _el$189 = _el$188.nextSibling, _el$190 = _el$189.nextSibling;
+        insert(_el$173, () => tr$1(locale(), "Renderer 诊断", "Renderer Diagnostics"));
+        insert(_el$175, () => `locations=${visualState().locations.length}`);
+        insert(_el$176, () => `fragments=${visualState().fragmentTerrain.length}`);
+        insert(_el$177, () => `agents=${visualState().agents.length}`);
+        insert(_el$174, createComponent(Show, {
           get when() {
             return memo(() => renderState()?.world_tick !== null)() && renderState()?.world_tick !== void 0;
           },
           get children() {
-            var _el$188 = _tmpl$20$1();
-            insert(_el$188, () => `tick=${renderState()?.world_tick}`);
-            createRenderEffect(() => setAttribute(_el$188, "data-world-tick", String(renderState()?.world_tick)));
-            return _el$188;
+            var _el$178 = _tmpl$11$1();
+            insert(_el$178, () => `tick=${renderState()?.world_tick}`);
+            createRenderEffect(() => setAttribute(_el$178, "data-world-tick", String(renderState()?.world_tick)));
+            return _el$178;
           }
-        }), _el$189);
-        insert(_el$189, () => `links=${visualState().links.length}`);
-        insert(_el$190, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
-        insert(_el$191, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$192, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
-        insert(_el$193, () => `renderer=${rendererStatus()}`);
-        insert(_el$194, () => `runtime=${runtimeSource()}`);
-        insert(_el$184, createComponent(Show, {
+        }), _el$179);
+        insert(_el$179, () => `links=${visualState().links.length}`);
+        insert(_el$180, () => `hotspots=${arrayField(renderState(), "visual_hotspots", "visualHotspots").length}`);
+        insert(_el$181, () => `derived_positions=${visualState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$182, () => visualState().worldBounds ? "world_bounds=ready" : "world_bounds=missing");
+        insert(_el$183, () => `renderer=${rendererStatus()}`);
+        insert(_el$184, () => `runtime=${runtimeSource()}`);
+        insert(_el$174, createComponent(Show, {
           get when() {
             return cameraState();
           },
           get children() {
-            var _el$195 = _tmpl$34$1();
-            insert(_el$195, () => `zoom=${cameraState().zoom.toFixed(2)}`);
-            return _el$195;
+            var _el$185 = _tmpl$25$1();
+            insert(_el$185, () => `zoom=${cameraState().zoom.toFixed(2)}`);
+            return _el$185;
           }
-        }), _el$198);
-        insert(_el$184, createComponent(Show, {
+        }), _el$188);
+        insert(_el$174, createComponent(Show, {
           get when() {
             return cameraState();
           },
           get children() {
-            var _el$196 = _tmpl$34$1();
-            insert(_el$196, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
-            return _el$196;
+            var _el$186 = _tmpl$25$1();
+            insert(_el$186, () => `pan=${cameraState().pan_x_px},${cameraState().pan_y_px}`);
+            return _el$186;
           }
-        }), _el$198);
-        insert(_el$184, createComponent(Show, {
+        }), _el$188);
+        insert(_el$174, createComponent(Show, {
           get when() {
             return hoverSelection();
           },
           get children() {
-            var _el$197 = _tmpl$34$1();
-            insert(_el$197, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
-            return _el$197;
+            var _el$187 = _tmpl$25$1();
+            insert(_el$187, () => `hover=${hoverSelection().kind}/${hoverSelection().id}`);
+            return _el$187;
           }
-        }), _el$198);
-        _el$198.$$click = requestReadyMode;
-        insert(_el$198, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        _el$199.$$click = simulateFatal;
-        insert(_el$199, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
-        insert(_el$200, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
-        insert(_el$184, createComponent(Show, {
+        }), _el$188);
+        _el$188.$$click = requestReadyMode;
+        insert(_el$188, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        _el$189.$$click = simulateFatal;
+        insert(_el$189, () => tr$1(locale(), "模拟 Renderer Fatal", "Simulate Renderer Fatal"));
+        insert(_el$190, () => tr$1(locale(), "当前世界舞台只依赖 wasm/Rust bridge、嵌入式 canvas、轻量拖拽缩放和事件回传。", "The world stage depends only on the wasm/Rust bridge, embedded canvas, light pan-zoom interaction, and event callbacks."));
+        insert(_el$174, createComponent(Show, {
           get when() {
             return memo(() => rendererStatus() === "unavailable")() && rendererFatal();
           },
           get children() {
-            var _el$201 = _tmpl$47$1();
-            insert(_el$201, () => `${rendererFatal().code}: ${rendererFatal().message}`);
-            return _el$201;
+            var _el$191 = _tmpl$38$1();
+            insert(_el$191, () => `${rendererFatal().code}: ${rendererFatal().message}`);
+            return _el$191;
           }
         }), null);
-        createRenderEffect(() => setAttribute(_el$182, "data-renderer-state", rendererStatus()));
-        return _el$182;
+        createRenderEffect(() => setAttribute(_el$172, "data-renderer-state", rendererStatus()));
+        return _el$172;
       }
-    }), _el$213);
-    insert(_el$169, createComponent(Show, {
+    }), _el$203);
+    insert(_el$159, createComponent(Show, {
       get when() {
         return memo(() => !!focusMode())() && renderState();
       },
       get children() {
-        var _el$202 = _tmpl$49$1(), _el$203 = _el$202.firstChild, _el$204 = _el$203.nextSibling, _el$205 = _el$204.firstChild, _el$207 = _el$205.firstChild, _el$208 = _el$207.nextSibling, _el$209 = _el$208.nextSibling, _el$211 = _el$205.nextSibling, _el$212 = _el$211.firstChild;
-        _el$202.addEventListener("toggle", (event) => {
+        var _el$192 = _tmpl$40$1(), _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling, _el$195 = _el$194.firstChild, _el$197 = _el$195.firstChild, _el$198 = _el$197.nextSibling, _el$199 = _el$198.nextSibling, _el$201 = _el$195.nextSibling, _el$202 = _el$201.firstChild;
+        _el$192.addEventListener("toggle", (event) => {
           const open = event.currentTarget.open;
           if (open) {
             setPersistentDiagnosticsDrawerOpen(true);
@@ -12800,58 +12907,58 @@ function PixelWorldHost(props) {
             });
           }
         });
-        insert(_el$203, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
-        insert(_el$205, createComponent(Show, {
+        insert(_el$193, () => tr$1(locale(), "电影视图诊断", "Cinematic Diagnostics"));
+        insert(_el$195, createComponent(Show, {
           get when() {
             return memo(() => renderState().world_tick !== null)() && renderState().world_tick !== void 0;
           },
           get children() {
-            var _el$206 = _tmpl$20$1();
-            insert(_el$206, () => `tick=${renderState().world_tick}`);
-            createRenderEffect(() => setAttribute(_el$206, "data-world-tick", String(renderState().world_tick)));
-            return _el$206;
+            var _el$196 = _tmpl$11$1();
+            insert(_el$196, () => `tick=${renderState().world_tick}`);
+            createRenderEffect(() => setAttribute(_el$196, "data-world-tick", String(renderState().world_tick)));
+            return _el$196;
           }
-        }), _el$207);
-        insert(_el$207, () => `renderer=${rendererStatus()}`);
-        insert(_el$208, () => `runtime=${runtimeSource()}`);
-        insert(_el$209, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
-        insert(_el$205, createComponent(Show, {
+        }), _el$197);
+        insert(_el$197, () => `renderer=${rendererStatus()}`);
+        insert(_el$198, () => `runtime=${runtimeSource()}`);
+        insert(_el$199, () => `derived_positions=${renderState().agents.filter((agent) => agent.position_source === "location_derived").length}`);
+        insert(_el$195, createComponent(Show, {
           get when() {
             return rendererFatal();
           },
           get children() {
-            var _el$210 = _tmpl$24$1();
-            insert(_el$210, () => rendererFatal().code);
-            return _el$210;
+            var _el$200 = _tmpl$15$1();
+            insert(_el$200, () => rendererFatal().code);
+            return _el$200;
           }
         }), null);
-        _el$212.$$click = requestReadyMode;
-        insert(_el$212, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
-        createRenderEffect(() => _el$202.open = diagnosticsDrawerOpen());
-        return _el$202;
+        _el$202.$$click = requestReadyMode;
+        insert(_el$202, () => tr$1(locale(), "重新挂载嵌入式 Renderer", "Reattach Embedded Renderer"));
+        createRenderEffect(() => _el$192.open = diagnosticsDrawerOpen());
+        return _el$192;
       }
-    }), _el$213);
-    _el$213.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
-    insert(_el$214, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
-    insert(_el$213, createComponent(Show, {
+    }), _el$203);
+    _el$203.addEventListener("toggle", (event) => setRenderDtoOpen(event.currentTarget.open));
+    insert(_el$204, () => tr$1(locale(), "展开 Render DTO", "Expand Render DTO"));
+    insert(_el$203, createComponent(Show, {
       get when() {
         return renderDtoOpen();
       },
       get children() {
-        var _el$215 = _tmpl$50$1(), _el$216 = _el$215.firstChild;
-        insert(_el$216, () => JSON.stringify(renderState(), null, 2));
-        return _el$215;
+        var _el$205 = _tmpl$41$1(), _el$206 = _el$205.firstChild;
+        insert(_el$206, () => JSON.stringify(renderState(), null, 2));
+        return _el$205;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$64 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$65 = focusMode() ? "true" : "false", _v$66 = focusMode() && maximized() ? "true" : "false", _v$67 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$68 = focusMode(), _v$69 = !renderState(), _v$70 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
-      _v$64 !== _p$.e && className(_el$169, _p$.e = _v$64);
-      _v$65 !== _p$.t && setAttribute(_el$169, "data-world-focus", _p$.t = _v$65);
-      _v$66 !== _p$.a && setAttribute(_el$169, "data-world-focus-maximized", _p$.a = _v$66);
-      _v$67 !== _p$.o && setAttribute(_el$169, "data-focus-comparable", _p$.o = _v$67);
-      _v$68 !== _p$.i && (_el$174.hidden = _p$.i = _v$68);
-      _v$69 !== _p$.n && (_el$176.disabled = _p$.n = _v$69);
-      _v$70 !== _p$.s && setAttribute(_el$176, "aria-describedby", _p$.s = _v$70);
+      var _v$32 = `pixel-world-host stack ${focusMode() ? "pixel-world-host--focus" : ""} ${focusMode() && maximized() ? "pixel-world-host--focus-maximized" : ""}`, _v$33 = focusMode() ? "true" : "false", _v$34 = focusMode() && maximized() ? "true" : "false", _v$35 = shouldShowFocusCinematic(renderState()) ? "false" : "true", _v$36 = focusMode(), _v$37 = !renderState(), _v$38 = rendererStatus() === "unavailable" ? PIXEL_WORLD_RENDERER_UNAVAILABLE_MESSAGE_ID : "pixel-world-focus-entry-hint";
+      _v$32 !== _p$.e && className(_el$159, _p$.e = _v$32);
+      _v$33 !== _p$.t && setAttribute(_el$159, "data-world-focus", _p$.t = _v$33);
+      _v$34 !== _p$.a && setAttribute(_el$159, "data-world-focus-maximized", _p$.a = _v$34);
+      _v$35 !== _p$.o && setAttribute(_el$159, "data-focus-comparable", _p$.o = _v$35);
+      _v$36 !== _p$.i && (_el$164.hidden = _p$.i = _v$36);
+      _v$37 !== _p$.n && (_el$166.disabled = _p$.n = _v$37);
+      _v$38 !== _p$.s && setAttribute(_el$166, "aria-describedby", _p$.s = _v$38);
       return _p$;
     }, {
       e: void 0,
@@ -12862,11 +12969,11 @@ function PixelWorldHost(props) {
       n: void 0,
       s: void 0
     });
-    return _el$169;
+    return _el$159;
   })();
 }
 delegateEvents(["click", "input"]);
-var _tmpl$$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$2$o = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$6$b = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=world-feed__summary-line><div class=panel__title></div><span></span></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$7$7 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class=feedback-detail role=status aria-live=polite>`), _tmpl$9$3 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$0$3 = /* @__PURE__ */ template(`<article class="event-card world-feed__event"><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
+var _tmpl$$o = /* @__PURE__ */ template(`<div class=world-feed__latest data-world-feed-latest=true><span class=world-feed__latest-copy>`), _tmpl$2$o = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$3$l = /* @__PURE__ */ template(`<div class="feedback-detail world-feed__notice">`), _tmpl$4$i = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=reload-authoritative-snapshot>`), _tmpl$5$h = /* @__PURE__ */ template(`<div class="toolbar world-feed__recovery"><button type=button data-world-feed-action=retry-world-feed>`), _tmpl$6$b = /* @__PURE__ */ template(`<div class="event-list world-feed__events"data-world-feed-events=true>`), _tmpl$7$7 = /* @__PURE__ */ template(`<details id=viewer-world-feed class="panel panel--world-feed"data-viewer-overlay=feed data-viewer-surface=world-feed aria-live=polite><summary class="panel__header panel__header--stack world-feed__summary"><div class=panel__eyebrow></div><div class=world-feed__summary-line><div class=panel__title></div><span></span></div><div class=panel__meta-copy></div></summary><div class="panel__body world-feed__body"><div class=world-feed__status-row><span>`), _tmpl$8$4 = /* @__PURE__ */ template(`<div class="world-feed__latest world-feed__latest--empty"data-world-feed-latest-empty=true>`), _tmpl$9$3 = /* @__PURE__ */ template(`<div class=world-feed__empty data-world-feed-empty=true>`), _tmpl$0$3 = /* @__PURE__ */ template(`<div class=feedback-detail role=status aria-live=polite>`), _tmpl$1$1 = /* @__PURE__ */ template(`<a class=world-feed__receipt-link href=#viewer-action-receipt>`), _tmpl$10$1 = /* @__PURE__ */ template(`<article class="event-card world-feed__event"><div class=event-card__header><div class=event-card__title></div><span class=badge></span></div><div class=event-card__meta>`);
 function readFeed(props) {
   return typeof props.feed === "function" ? props.feed() : props.feed || {};
 }
@@ -12951,119 +13058,140 @@ function WorldFeedPanel(props) {
   const status = () => String(feed().status || "unavailable");
   const statusLabel2 = () => statusCopy(locale(), tr2, status());
   const summaryStatusLabel = () => statusBadgeLabel(locale(), tr2, status());
+  const latestEvent = () => presentationEvents().at(-1) || null;
   const shouldReload = () => status() !== "unavailable" && Boolean(feed().snapshotReloadRequired || status() === "gap");
   return (() => {
-    var _el$ = _tmpl$6$b(), _el$2 = _el$.firstChild, _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling, _el$5 = _el$4.firstChild, _el$6 = _el$5.nextSibling, _el$7 = _el$4.nextSibling, _el$8 = _el$2.nextSibling, _el$9 = _el$8.firstChild, _el$0 = _el$9.firstChild;
+    var _el$ = _tmpl$7$7(), _el$2 = _el$.firstChild, _el$3 = _el$2.firstChild, _el$4 = _el$3.nextSibling, _el$5 = _el$4.firstChild, _el$6 = _el$5.nextSibling, _el$7 = _el$4.nextSibling, _el$0 = _el$2.nextSibling, _el$1 = _el$0.firstChild, _el$10 = _el$1.firstChild;
     insert(_el$3, () => tr2(locale(), "环境上下文", "Ambient Context"));
     insert(_el$5, () => tr2(locale(), "World Feed", "World Feed"));
     insert(_el$6, summaryStatusLabel);
     insert(_el$7, () => tr2(locale(), "只读的运行时环境投影；不会替代 Action Receipt，也不会证明玩家动作成功。", "Read-only runtime context; it never replaces Action Receipt or proves a player action succeeded."));
-    insert(_el$0, statusLabel2);
-    insert(_el$9, createComponent(Show, {
+    insert(_el$2, createComponent(Show, {
+      get when() {
+        return latestEvent();
+      },
+      get fallback() {
+        return (() => {
+          var _el$19 = _tmpl$8$4();
+          insert(_el$19, (() => {
+            var _c$ = memo(() => status() === "loading");
+            return () => _c$() ? tr2(locale(), "等待最新环境动态。", "Waiting for the latest ambient activity.") : memo(() => status() === "unavailable")() ? tr2(locale(), "最新环境动态不可用。", "The latest ambient activity is unavailable.") : tr2(locale(), "暂无最新环境动态。", "No latest ambient activity is available.");
+          })());
+          return _el$19;
+        })();
+      },
+      get children() {
+        var _el$8 = _tmpl$$o(), _el$9 = _el$8.firstChild;
+        insert(_el$9, () => `${tr2(locale(), "最新", "Latest")}: ${latestEvent().summary} · ${eventKindLabel(latestEvent(), locale(), tr2)}`);
+        return _el$8;
+      }
+    }), null);
+    insert(_el$10, statusLabel2);
+    insert(_el$1, createComponent(Show, {
       get when() {
         return feed().worldId;
       },
       get children() {
-        var _el$1 = _tmpl$$o();
-        insert(_el$1, () => `world=${feed().worldId}`);
-        return _el$1;
+        var _el$11 = _tmpl$2$o();
+        insert(_el$11, () => `world=${feed().worldId}`);
+        return _el$11;
       }
     }), null);
-    insert(_el$9, createComponent(Show, {
+    insert(_el$1, createComponent(Show, {
       get when() {
         return feed().reorgEpoch != null;
       },
       get children() {
-        var _el$10 = _tmpl$$o();
-        insert(_el$10, () => `epoch=${feed().reorgEpoch}`);
-        return _el$10;
+        var _el$12 = _tmpl$2$o();
+        insert(_el$12, () => `epoch=${feed().reorgEpoch}`);
+        return _el$12;
       }
     }), null);
-    insert(_el$8, createComponent(Show, {
+    insert(_el$0, createComponent(Show, {
       get when() {
         return reasonCopy(locale(), tr2, feed());
       },
       get children() {
-        var _el$11 = _tmpl$2$o();
-        insert(_el$11, () => reasonCopy(locale(), tr2, feed()));
-        return _el$11;
+        var _el$13 = _tmpl$3$l();
+        insert(_el$13, () => reasonCopy(locale(), tr2, feed()));
+        return _el$13;
       }
     }), null);
-    insert(_el$8, createComponent(Show, {
+    insert(_el$0, createComponent(Show, {
       get when() {
         return shouldReload();
       },
       get children() {
-        var _el$12 = _tmpl$3$l(), _el$13 = _el$12.firstChild;
-        _el$13.$$click = () => props.onReloadSnapshot?.();
-        insert(_el$13, () => tr2(locale(), "重新加载权威快照", "Reload authoritative snapshot"));
-        return _el$12;
+        var _el$14 = _tmpl$4$i(), _el$15 = _el$14.firstChild;
+        _el$15.$$click = () => props.onReloadSnapshot?.();
+        insert(_el$15, () => tr2(locale(), "重新加载权威快照", "Reload authoritative snapshot"));
+        return _el$14;
       }
     }), null);
-    insert(_el$8, createComponent(Show, {
+    insert(_el$0, createComponent(Show, {
       get when() {
         return status() === "unavailable";
       },
       get children() {
-        var _el$14 = _tmpl$4$i(), _el$15 = _el$14.firstChild;
-        _el$15.$$click = () => props.onRetryFeed?.();
-        insert(_el$15, () => tr2(locale(), "重试 World Feed", "Retry World Feed"));
-        return _el$14;
+        var _el$16 = _tmpl$5$h(), _el$17 = _el$16.firstChild;
+        _el$17.$$click = () => props.onRetryFeed?.();
+        insert(_el$17, () => tr2(locale(), "重试 World Feed", "Retry World Feed"));
+        return _el$16;
       }
     }), null);
-    insert(_el$8, createComponent(Show, {
+    insert(_el$0, createComponent(Show, {
       get when() {
         return presentationEvents().length > 0;
       },
       get fallback() {
         return (() => {
-          var _el$17 = _tmpl$7$7();
-          insert(_el$17, (() => {
-            var _c$ = memo(() => status() === "loading");
-            return () => _c$() ? tr2(locale(), "正在等待 world_feed/v1 响应…", "Waiting for a world_feed/v1 response…") : memo(() => status() === "empty")() ? tr2(locale(), "权威运行时尚未发布世界更新中的事件。此动态仅作上下文；请继续当前玩家目标，下一次权威世界更新后动态会刷新。", "No authoritative world update has published events yet. This feed is context only—continue your Player goal; the feed will update after the next authoritative world update.") : memo(() => status() === "unavailable")() ? tr2(locale(), "重试 World Feed 以检查最新环境动态。", "Retry World Feed to check for the latest ambient activity.") : tr2(locale(), "没有可显示的环境事件。", "No ambient events are available to display.");
+          var _el$20 = _tmpl$9$3();
+          insert(_el$20, (() => {
+            var _c$2 = memo(() => status() === "loading");
+            return () => _c$2() ? tr2(locale(), "正在等待 world_feed/v1 响应…", "Waiting for a world_feed/v1 response…") : memo(() => status() === "empty")() ? tr2(locale(), "权威运行时尚未发布世界更新中的事件。此动态仅作上下文；请继续当前玩家目标，下一次权威世界更新后动态会刷新。", "No authoritative world update has published events yet. This feed is context only—continue your Player goal; the feed will update after the next authoritative world update.") : memo(() => status() === "unavailable")() ? tr2(locale(), "重试 World Feed 以检查最新环境动态。", "Retry World Feed to check for the latest ambient activity.") : tr2(locale(), "没有可显示的环境事件。", "No ambient events are available to display.");
           })());
-          return _el$17;
+          return _el$20;
         })();
       },
       get children() {
-        var _el$16 = _tmpl$5$h();
-        insert(_el$16, createComponent(For, {
+        var _el$18 = _tmpl$6$b();
+        insert(_el$18, createComponent(For, {
           get each() {
             return presentationEvents();
           },
           children: (event) => (() => {
-            var _el$18 = _tmpl$0$3(), _el$19 = _el$18.firstChild, _el$20 = _el$19.firstChild, _el$21 = _el$20.nextSibling, _el$22 = _el$19.nextSibling;
-            insert(_el$20, () => event.summary);
-            insert(_el$21, () => `#${event.event_seq}`);
-            insert(_el$22, () => eventKindLabel(event, locale(), tr2));
-            insert(_el$18, createComponent(Show, {
+            var _el$21 = _tmpl$10$1(), _el$22 = _el$21.firstChild, _el$23 = _el$22.firstChild, _el$24 = _el$23.nextSibling, _el$25 = _el$22.nextSibling;
+            insert(_el$23, () => event.summary);
+            insert(_el$24, () => `#${event.event_seq}`);
+            insert(_el$25, () => eventKindLabel(event, locale(), tr2));
+            insert(_el$21, createComponent(Show, {
               get when() {
                 return memo(() => event.major_event?.freshness === "current")() && status() === "ready";
               },
               get children() {
-                var _el$23 = _tmpl$8$4();
-                insert(_el$23, () => majorEventStatusCopy(event, locale(), tr2));
-                return _el$23;
+                var _el$26 = _tmpl$0$3();
+                insert(_el$26, () => majorEventStatusCopy(event, locale(), tr2));
+                return _el$26;
               }
             }), null);
-            insert(_el$18, createComponent(Show, {
+            insert(_el$21, createComponent(Show, {
               get when() {
                 return event.receipt_ref != null;
               },
               get children() {
-                var _el$24 = _tmpl$9$3();
-                insert(_el$24, () => tr2(locale(), `查看明确回执 ${event.receipt_ref}`, `View explicit receipt ${event.receipt_ref}`));
-                createRenderEffect(() => setAttribute(_el$24, "data-world-feed-receipt-ref", event.receipt_ref));
-                return _el$24;
+                var _el$27 = _tmpl$1$1();
+                insert(_el$27, () => tr2(locale(), `查看明确回执 ${event.receipt_ref}`, `View explicit receipt ${event.receipt_ref}`));
+                createRenderEffect(() => setAttribute(_el$27, "data-world-feed-receipt-ref", event.receipt_ref));
+                return _el$27;
               }
             }), null);
             createRenderEffect((_p$) => {
-              var _v$5 = event.event_seq, _v$6 = event.major_event ? event.event_seq : void 0, _v$7 = event.major_event?.category, _v$8 = event.major_event?.lifecycle, _v$9 = event.major_event?.severity;
-              _v$5 !== _p$.e && setAttribute(_el$18, "data-world-feed-event", _p$.e = _v$5);
-              _v$6 !== _p$.t && setAttribute(_el$18, "data-world-feed-major-event", _p$.t = _v$6);
-              _v$7 !== _p$.a && setAttribute(_el$18, "data-major-event-category", _p$.a = _v$7);
-              _v$8 !== _p$.o && setAttribute(_el$18, "data-major-event-lifecycle", _p$.o = _v$8);
-              _v$9 !== _p$.i && setAttribute(_el$18, "data-major-event-severity", _p$.i = _v$9);
+              var _v$6 = event.event_seq, _v$7 = event.major_event ? event.event_seq : void 0, _v$8 = event.major_event?.category, _v$9 = event.major_event?.lifecycle, _v$0 = event.major_event?.severity;
+              _v$6 !== _p$.e && setAttribute(_el$21, "data-world-feed-event", _p$.e = _v$6);
+              _v$7 !== _p$.t && setAttribute(_el$21, "data-world-feed-major-event", _p$.t = _v$7);
+              _v$8 !== _p$.a && setAttribute(_el$21, "data-major-event-category", _p$.a = _v$8);
+              _v$9 !== _p$.o && setAttribute(_el$21, "data-major-event-lifecycle", _p$.o = _v$9);
+              _v$0 !== _p$.i && setAttribute(_el$21, "data-major-event-severity", _p$.i = _v$0);
               return _p$;
             }, {
               e: void 0,
@@ -13072,24 +13200,26 @@ function WorldFeedPanel(props) {
               o: void 0,
               i: void 0
             });
-            return _el$18;
+            return _el$21;
           })()
         }));
-        return _el$16;
+        return _el$18;
       }
     }), null);
     createRenderEffect((_p$) => {
-      var _v$ = status(), _v$2 = statusBadgeClass(status()), _v$3 = status(), _v$4 = statusBadgeClass(status());
+      var _v$ = status(), _v$2 = latestEvent()?.event_seq == null ? void 0 : String(latestEvent().event_seq), _v$3 = statusBadgeClass(status()), _v$4 = status(), _v$5 = statusBadgeClass(status());
       _v$ !== _p$.e && setAttribute(_el$, "data-world-feed-status", _p$.e = _v$);
-      _v$2 !== _p$.t && className(_el$6, _p$.t = _v$2);
-      _v$3 !== _p$.a && setAttribute(_el$6, "data-world-feed-summary-status", _p$.a = _v$3);
-      _v$4 !== _p$.o && className(_el$0, _p$.o = _v$4);
+      _v$2 !== _p$.t && setAttribute(_el$2, "data-world-feed-latest", _p$.t = _v$2);
+      _v$3 !== _p$.a && className(_el$6, _p$.a = _v$3);
+      _v$4 !== _p$.o && setAttribute(_el$6, "data-world-feed-summary-status", _p$.o = _v$4);
+      _v$5 !== _p$.i && className(_el$10, _p$.i = _v$5);
       return _p$;
     }, {
       e: void 0,
       t: void 0,
       a: void 0,
-      o: void 0
+      o: void 0,
+      i: void 0
     });
     return _el$;
   })();
@@ -18491,7 +18621,7 @@ function buildAgentContextDisplayModel(input = {}) {
     control: firstValue(input.controlState, candidateIntent?.control_state, candidateIntent?.controlState) || "unknown"
   };
 }
-var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div>`), _tmpl$3 = /* @__PURE__ */ template(`<div class=entity-list-pending__progress>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=entity-list-pending aria-live=polite aria-busy=true><div class=entity-list-pending__row><span class=entity-list-pending__spinner aria-hidden=true></span><span></span></div><div class=entity-list-pending__skeleton aria-hidden=true><span></span><span></span><span>`), _tmpl$5 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$7 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class="stack flow-top">`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=action-grid>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=feedback-detail><div class=metric__label>`), _tmpl$12 = /* @__PURE__ */ template(`<div class=inline-help-tip><button type=button class=inline-help-tip__button>?</button><div class=inline-help-tip__panel><div class=inline-help-tip__title></div><div class=inline-help-tip__body>`), _tmpl$13 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$14 = /* @__PURE__ */ template(`<div class="feedback-detail flow-top--tight">`), _tmpl$15 = /* @__PURE__ */ template(`<div class="badge-row badge-row--tight">`), _tmpl$16 = /* @__PURE__ */ template(`<div><div class=metric__label></div><div class=metric__value>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$18 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$20 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$21 = /* @__PURE__ */ template(`<div><div class=panel__header><div class="stack stack--compact"><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$22 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$23 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$25 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$26 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=auth-gate data-viewer-fixture-state=hosted_login_gate role=dialog aria-modal=true aria-labelledby=hosted-login-gate-title tabindex=-1><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=hosted-login-gate-title class=auth-gate__title></h1></div></div><div class=feedback-summary>`), _tmpl$28 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class="panel__title panel__title--spaced"></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$29 = /* @__PURE__ */ template(`<div class="stack stack--compact"><div class=feedback-summary></div><div class=summary-grid><div class=metric><div class=metric__label></div><div class=metric__value></div></div><div class=metric><div class=metric__label></div><div class=metric__value></div></div><div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$30 = /* @__PURE__ */ template(`<div class="stack stack--compact">`), _tmpl$31 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$32 = /* @__PURE__ */ template(`<button>`), _tmpl$33 = /* @__PURE__ */ template(`<div class=auth-gate role=dialog aria-modal=true aria-labelledby=starter-oc-gate-title data-viewer-fixture-state=starter_oc_required_gate><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=starter-oc-gate-title class=auth-gate__title></h1></div></div><div class=toolbar>`), _tmpl$34 = /* @__PURE__ */ template(`<button data-testid=viewer-playthrough-action-claim-starter-oc>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=control-grid><div class=field><label for=agent-claim-target></label><select id=agent-claim-target>`), _tmpl$36 = /* @__PURE__ */ template(`<option>`), _tmpl$37 = /* @__PURE__ */ template(`<div class="stage-hero stage-hero--compact"><div class=stage-hero__topline><div class="stack stack--hero"><div class=stage-hero__eyebrow-row><div class=stage-hero__eyebrow></div></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class="hero-focus-grid hero-focus-grid--compact"><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class="hero-focus-card hero-focus-card--next-step"data-testid=viewer-next-step-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div></div><div class=hero-focus-card data-testid=viewer-identity-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div><div class=hero-focus-card__detail></div></div></div><div class=stage-hero__mobile-shortcuts><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$38 = /* @__PURE__ */ template(`<div class="badge-row stage-hero__selection">`), _tmpl$39 = /* @__PURE__ */ template(`<div class=toolbar><button type=button>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class="panel__title panel__title--spaced"></div><div class=list></div></div><div><div class="panel__title panel__title--spaced"></div><div class=list>`), _tmpl$41 = /* @__PURE__ */ template(`<span class=list-item__selected-label>`), _tmpl$42 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__header><div class=list-item__title></div></div><div class=list-item__meta><span class=entity-id></span></div><div class=badge-row></div><div class=list-item__meta></div><div class=list-item__meta>`), _tmpl$43 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__header><div class=list-item__title></div></div><div class=list-item__meta>`), _tmpl$44 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$45 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$46 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$47 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-summary><details class=gameplay-details-surface id=viewer-gameplay-details><summary class=gameplay-details-surface__summary><div class=diagnostic-surface__title><span></span><span class=diagnostic-surface__meta></span></div></summary><div class="stack flow-top"><details id=viewer-diagnostics-panel class="panel diagnostic-surface"data-viewer-surface=diagnostics><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$48 = /* @__PURE__ */ template(`<div class="badge-row badge-row--spaced">`), _tmpl$49 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced"></div><div class=action-grid>`), _tmpl$50 = /* @__PURE__ */ template(`<div class=feedback-summary data-testid=validation-unlock-preview>`), _tmpl$51 = /* @__PURE__ */ template(`<div class=feedback-summary><a href=#viewer-details-panel>`), _tmpl$52 = /* @__PURE__ */ template(`<div class="badge-row command-surface__auth-boundary">`), _tmpl$53 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$54 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$55 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$56 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$57 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$58 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$59 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$60 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$61 = /* @__PURE__ */ template(`<div class=toolbar><div class="field field--inline-flex"><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$62 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$63 = /* @__PURE__ */ template(`<div class="stack command-surface"><div class="badge-row command-surface__target-row"data-command-continuity=target><div class=command-surface__continuity-summary data-command-continuity=summary role=group><span><span class=metric__label></span> </span><span><span class=metric__label></span> </span><span class=command-surface__continuity-objective><span class=metric__label></span> </span></div></div><details class="diagnostic command-surface__capability-details"><summary></summary><div class="badge-row command-surface__capability-row command-surface__diagnostic-strip"></div></details><details class="diagnostic command-surface__advanced-details"><summary></summary></details><details class="diagnostic command-surface__asset-details"><summary>`), _tmpl$64 = /* @__PURE__ */ template(`<div class="stack command-surface command-surface--non-agent"data-command-target-kind=location><div class="badge-row command-surface__target-row"data-command-continuity=target>`), _tmpl$65 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced panel__title--danger"></div><pre class=json>`), _tmpl$66 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class="panel__title panel__title--spaced"></div><div class=badge-row></div><div class="feedback-detail flow-top">`), _tmpl$67 = /* @__PURE__ */ template(`<div class=viewer-shell data-viewer-shell=player-fullscreen><section class="panel panel--targets"id=viewer-targets-panel data-viewer-route-panel=targets data-viewer-overlay=targets tabindex=-1 data-viewer-surface=targets><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div><a class=panel__route-close href=#viewer-stage-panel></a></div><div class=panel__body></div></section><section class="panel panel--stage"id=viewer-stage-panel tabindex=-1 data-viewer-map-layer=base data-viewer-surface=stage><div class="panel__body panel__body--stage"><div class=stack></div></div></section><section class="panel panel--details"id=viewer-details-panel data-viewer-route-panel=command data-viewer-overlay=command tabindex=-1 data-viewer-surface=command><div class="panel__header panel__header--stack command-route-chrome"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div><a class=panel__route-close href=#viewer-stage-panel></a></div><div class=panel__body>`);
+var _tmpl$ = /* @__PURE__ */ template(`<span>`), _tmpl$2 = /* @__PURE__ */ template(`<div>`), _tmpl$3 = /* @__PURE__ */ template(`<div class=entity-list-pending__progress>`), _tmpl$4 = /* @__PURE__ */ template(`<div class=entity-list-pending aria-live=polite aria-busy=true><div class=entity-list-pending__row><span class=entity-list-pending__spinner aria-hidden=true></span><span></span></div><div class=entity-list-pending__skeleton aria-hidden=true><span></span><span></span><span>`), _tmpl$5 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$6 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$7 = /* @__PURE__ */ template(`<details class=diagnostic><summary></summary><div class="stack flow-top">`), _tmpl$8 = /* @__PURE__ */ template(`<div class=badge-row>`), _tmpl$9 = /* @__PURE__ */ template(`<div class=feedback-summary>`), _tmpl$0 = /* @__PURE__ */ template(`<div class=summary-grid>`), _tmpl$1 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$10 = /* @__PURE__ */ template(`<div class=action-grid>`), _tmpl$11 = /* @__PURE__ */ template(`<div class=feedback-detail><div class=metric__label>`), _tmpl$12 = /* @__PURE__ */ template(`<div class=inline-help-tip><button type=button class=inline-help-tip__button>?</button><div class=inline-help-tip__panel><div class=inline-help-tip__title></div><div class=inline-help-tip__body>`), _tmpl$13 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row></div><div class=feedback-summary>`), _tmpl$14 = /* @__PURE__ */ template(`<div class="feedback-detail flow-top--tight">`), _tmpl$15 = /* @__PURE__ */ template(`<div class="badge-row badge-row--tight">`), _tmpl$16 = /* @__PURE__ */ template(`<div><div class=metric__label></div><div class=metric__value>`), _tmpl$17 = /* @__PURE__ */ template(`<div class=event-card__meta>`), _tmpl$18 = /* @__PURE__ */ template(`<div><div class=event-card__title><span>`), _tmpl$19 = /* @__PURE__ */ template(`<div class=panel__eyebrow>`), _tmpl$20 = /* @__PURE__ */ template(`<div class=panel__meta-copy>`), _tmpl$21 = /* @__PURE__ */ template(`<div><div class=panel__header><div class="stack stack--compact"><div class=panel__title></div></div></div><div class="panel__body stack">`), _tmpl$22 = /* @__PURE__ */ template(`<div><div class=callout__header><div class=callout__title></div></div><div class=callout__body>`), _tmpl$23 = /* @__PURE__ */ template(`<div class=field><label></label><input type=text autocomplete=off>`), _tmpl$24 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=complete-login>`), _tmpl$25 = /* @__PURE__ */ template(`<div class=stack>`), _tmpl$26 = /* @__PURE__ */ template(`<div class=stack><div class=control-grid><div class=field><label></label><input type=email autocomplete=email></div></div><div class=toolbar><button data-auth-action=start-login>`), _tmpl$27 = /* @__PURE__ */ template(`<div class=auth-gate data-viewer-fixture-state=hosted_login_gate role=dialog aria-modal=true aria-labelledby=hosted-login-gate-title tabindex=-1><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=hosted-login-gate-title class=auth-gate__title></h1></div></div><div class=feedback-summary>`), _tmpl$28 = /* @__PURE__ */ template(`<details class=entry-menu><summary class=entry-menu__toggle></summary><div class="entry-menu__panel stack"><div><div class="panel__title panel__title--spaced"></div><div class=feedback-detail></div></div><div class=toolbar><button data-locale=zh>中文</button><button data-locale=en>English</button></div><div class=badge-row></div><div class=feedback-detail>`), _tmpl$29 = /* @__PURE__ */ template(`<div class="stack stack--compact"><div class=feedback-summary></div><div class=summary-grid><div class=metric><div class=metric__label></div><div class=metric__value></div></div><div class=metric><div class=metric__label></div><div class=metric__value></div></div><div class=metric><div class=metric__label></div><div class=metric__value>`), _tmpl$30 = /* @__PURE__ */ template(`<div class="stack stack--compact">`), _tmpl$31 = /* @__PURE__ */ template(`<div class=toolbar><button>`), _tmpl$32 = /* @__PURE__ */ template(`<button>`), _tmpl$33 = /* @__PURE__ */ template(`<div class=auth-gate role=dialog aria-modal=true aria-labelledby=starter-oc-gate-title data-viewer-fixture-state=starter_oc_required_gate><div class=auth-gate__dialog><div class=auth-gate__header><div><div class=panel__eyebrow></div><h1 id=starter-oc-gate-title class=auth-gate__title></h1></div></div><div class=toolbar>`), _tmpl$34 = /* @__PURE__ */ template(`<button data-testid=viewer-playthrough-action-claim-starter-oc>`), _tmpl$35 = /* @__PURE__ */ template(`<div class=control-grid><div class=field><label for=agent-claim-target></label><select id=agent-claim-target>`), _tmpl$36 = /* @__PURE__ */ template(`<option>`), _tmpl$37 = /* @__PURE__ */ template(`<div class="stage-hero stage-hero--compact"><div class=stage-hero__topline><div class="stack stack--hero"><div class=stage-hero__eyebrow-row><div class=stage-hero__eyebrow></div></div><div class=stage-hero__title></div><div class=stage-hero__lede></div></div></div><div class="hero-focus-grid hero-focus-grid--compact"><div class=hero-focus-card><div class=hero-focus-card__label></div><div></div><div class=hero-focus-card__detail></div></div><div class=hero-focus-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div></div><div class="hero-focus-card hero-focus-card--next-step"data-testid=viewer-next-step-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div></div><div class=hero-focus-card data-testid=viewer-identity-card><div class=hero-focus-card__label></div><div class="hero-focus-card__value hero-focus-card__value--body"></div><div class=hero-focus-card__detail></div><div class=hero-focus-card__detail></div></div></div><div class=stage-hero__mobile-shortcuts><a class=mobile-rail__link href=#viewer-targets-panel></a><a class=mobile-rail__link href=#viewer-details-panel>`), _tmpl$38 = /* @__PURE__ */ template(`<div class="badge-row stage-hero__selection">`), _tmpl$39 = /* @__PURE__ */ template(`<div class=toolbar><button type=button>`), _tmpl$40 = /* @__PURE__ */ template(`<div class=stage-hero__secondary-action data-hero-secondary-action=true>`), _tmpl$41 = /* @__PURE__ */ template(`<div class=stack><div class=field><label for=entity-search></label><input id=entity-search type=search></div><div><div class="panel__title panel__title--spaced"></div><div class=list></div></div><div><div class="panel__title panel__title--spaced"></div><div class=list>`), _tmpl$42 = /* @__PURE__ */ template(`<span class=list-item__selected-label>`), _tmpl$43 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=agent><div class=list-item__header><div class=list-item__title></div></div><div class=list-item__meta><span class=entity-id></span></div><div class=badge-row></div><div class=list-item__meta></div><div class=list-item__meta>`), _tmpl$44 = /* @__PURE__ */ template(`<button class=list-item data-select-kind=location><div class=list-item__header><div class=list-item__title></div></div><div class=list-item__meta>`), _tmpl$45 = /* @__PURE__ */ template(`<div class=toolbar><button data-auth-action=logout>`), _tmpl$46 = /* @__PURE__ */ template(`<button data-auth-action=logout>`), _tmpl$47 = /* @__PURE__ */ template(`<div class=event-list>`), _tmpl$48 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-summary><details class=gameplay-details-surface id=viewer-gameplay-details><summary class=gameplay-details-surface__summary><div class=diagnostic-surface__title><span></span><span class=diagnostic-surface__meta></span></div></summary><div class="stack flow-top"><details id=viewer-diagnostics-panel class="panel diagnostic-surface"data-viewer-surface=diagnostics><summary class="panel__header diagnostic-surface__summary"><div class=diagnostic-surface__title><div class=panel__title></div><div class=diagnostic-surface__meta></div></div><div class=badge-row></div></summary><div class="panel__body stack"><div class=badge-row></div><div class=badge-row></div><div class=toolbar></div><div class=summary-grid></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$49 = /* @__PURE__ */ template(`<div class="badge-row badge-row--spaced">`), _tmpl$50 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced"></div><div class=action-grid>`), _tmpl$51 = /* @__PURE__ */ template(`<div class=feedback-summary data-testid=validation-unlock-preview>`), _tmpl$52 = /* @__PURE__ */ template(`<div class=feedback-summary><a href=#viewer-details-panel>`), _tmpl$53 = /* @__PURE__ */ template(`<div class="badge-row command-surface__auth-boundary">`), _tmpl$54 = /* @__PURE__ */ template(`<div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=4>`), _tmpl$55 = /* @__PURE__ */ template(`<div class=toolbar><button data-chat-send=1>`), _tmpl$56 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-visibility-toggle=1>`), _tmpl$57 = /* @__PURE__ */ template(`<div class=field><label for=strong-auth-approval-code></label><input id=strong-auth-approval-code type=password autocomplete=off>`), _tmpl$58 = /* @__PURE__ */ template(`<div class=field><label for=prompt-system></label><textarea id=prompt-system rows=4>`), _tmpl$59 = /* @__PURE__ */ template(`<div class=field><label for=prompt-short></label><textarea id=prompt-short rows=3>`), _tmpl$60 = /* @__PURE__ */ template(`<div class=field><label for=prompt-long></label><textarea id=prompt-long rows=3>`), _tmpl$61 = /* @__PURE__ */ template(`<div class=toolbar><button data-prompt-action=preview></button><button data-prompt-action=apply>`), _tmpl$62 = /* @__PURE__ */ template(`<div class=toolbar><div class="field field--inline-flex"><label for=prompt-rollback-version></label><input id=prompt-rollback-version type=number min=0 step=1></div><button data-prompt-action=rollback>`), _tmpl$63 = /* @__PURE__ */ template(`<div class=toolbar><button disabled>`), _tmpl$64 = /* @__PURE__ */ template(`<div class="stack command-surface"><div class="badge-row command-surface__target-row"data-command-continuity=target><div class=command-surface__continuity-summary data-command-continuity=summary role=group><span><span class=metric__label></span> </span><span><span class=metric__label></span> </span><span class=command-surface__continuity-objective><span class=metric__label></span> </span></div></div><details class="diagnostic command-surface__capability-details"><summary></summary><div class="badge-row command-surface__capability-row command-surface__diagnostic-strip"></div></details><details class="diagnostic command-surface__advanced-details"><summary></summary></details><details class="diagnostic command-surface__asset-details"><summary>`), _tmpl$65 = /* @__PURE__ */ template(`<div class="stack command-surface command-surface--non-agent"data-command-target-kind=location><div class="badge-row command-surface__target-row"data-command-continuity=target>`), _tmpl$66 = /* @__PURE__ */ template(`<div><div class="panel__title panel__title--spaced panel__title--danger"></div><pre class=json>`), _tmpl$67 = /* @__PURE__ */ template(`<div class=stack><div class=badge-row></div><div><div class="panel__title panel__title--spaced"></div><div class=badge-row></div><div class="feedback-detail flow-top">`), _tmpl$68 = /* @__PURE__ */ template(`<div class=viewer-shell data-viewer-shell=player-fullscreen><section class="panel panel--targets"id=viewer-targets-panel data-viewer-route-panel=targets data-viewer-overlay=targets tabindex=-1 data-viewer-surface=targets><div class="panel__header panel__header--stack"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div><a class=panel__route-close href=#viewer-stage-panel></a></div><div class=panel__body></div></section><section class="panel panel--stage"id=viewer-stage-panel tabindex=-1 data-viewer-map-layer=base data-viewer-surface=stage><div class="panel__body panel__body--stage"><div class=stack></div></div></section><section class="panel panel--details"id=viewer-details-panel data-viewer-route-panel=command data-viewer-overlay=command tabindex=-1 data-viewer-surface=command><div class="panel__header panel__header--stack command-route-chrome"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div><a class=panel__route-close href=#viewer-stage-panel></a></div><div class=panel__body>`);
 const VIEWER_VISUAL_FIXTURE_GLOBAL = "__OASIS7_VIEWER_VISUAL_FIXTURES__";
 const [viewerStateRevision, setViewerStateRevision] = createSignal(0);
 function observeViewerStateRevision() {
@@ -20597,49 +20727,53 @@ function WorldStageHero() {
       get when() {
         return recommendedAction();
       },
-      children: (action2) => createComponent(CalloutCard, {
-        get title() {
-          return tr(locale(), "推荐动作", "Recommended Action");
-        },
-        get badge() {
-          return action2().executeKind || "ready";
-        },
-        badgeClass: "badge badge--good",
-        get children() {
-          return [(() => {
-            var _el$184 = _tmpl$9();
-            insert(_el$184, () => action2().label || action2().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
-            return _el$184;
-          })(), (() => {
-            var _el$185 = _tmpl$6();
-            insert(_el$185, () => gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) || gameplayActionDetail(action2(), gameplaySummary(), locale()));
-            createRenderEffect(() => setAttribute(_el$185, "id", gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action2()) : void 0));
-            return _el$185;
-          })(), (() => {
-            var _el$186 = _tmpl$39(), _el$187 = _el$186.firstChild;
-            _el$187.$$click = () => renderGameplayAction(action2());
-            insert(_el$187, () => gameplayActionDisplayLabel(action2(), locale()));
-            createRenderEffect((_p$) => {
-              var _v$37 = tr(locale(), "下一步动作", "Next Move action"), _v$38 = gameplayActionTestId(action2(), "recommended"), _v$39 = gameplayActionButtonClass(action2()), _v$40 = gameplayActionButtonBusyAttrs(action2()), _v$41 = gameplayActionButtonDisabled(action2(), gameplaySummary(), locale()), _v$42 = gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action2()) : void 0;
-              _v$37 !== _p$.e && setAttribute(_el$186, "aria-label", _p$.e = _v$37);
-              _v$38 !== _p$.t && setAttribute(_el$187, "data-testid", _p$.t = _v$38);
-              _v$39 !== _p$.a && className(_el$187, _p$.a = _v$39);
-              _v$40 !== _p$.o && setAttribute(_el$187, "aria-busy", _p$.o = _v$40);
-              _v$41 !== _p$.i && (_el$187.disabled = _p$.i = _v$41);
-              _v$42 !== _p$.n && setAttribute(_el$187, "aria-describedby", _p$.n = _v$42);
-              return _p$;
-            }, {
-              e: void 0,
-              t: void 0,
-              a: void 0,
-              o: void 0,
-              i: void 0,
-              n: void 0
-            });
-            return _el$186;
-          })()];
-        }
-      })
+      children: (action2) => (() => {
+        var _el$184 = _tmpl$40();
+        insert(_el$184, createComponent(CalloutCard, {
+          get title() {
+            return tr(locale(), "推荐动作", "Recommended Action");
+          },
+          get badge() {
+            return action2().executeKind || "ready";
+          },
+          badgeClass: "badge badge--good",
+          get children() {
+            return [(() => {
+              var _el$185 = _tmpl$9();
+              insert(_el$185, () => action2().label || action2().actionId || tr(locale(), "当前存在一条更合适的推进动作。", "One action is currently the best next move."));
+              return _el$185;
+            })(), (() => {
+              var _el$186 = _tmpl$6();
+              insert(_el$186, () => gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) || gameplayActionDetail(action2(), gameplaySummary(), locale()));
+              createRenderEffect(() => setAttribute(_el$186, "id", gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action2()) : void 0));
+              return _el$186;
+            })(), (() => {
+              var _el$187 = _tmpl$39(), _el$188 = _el$187.firstChild;
+              _el$188.$$click = () => renderGameplayAction(action2());
+              insert(_el$188, () => gameplayActionDisplayLabel(action2(), locale()));
+              createRenderEffect((_p$) => {
+                var _v$37 = tr(locale(), "下一步动作", "Next Move action"), _v$38 = gameplayActionTestId(action2(), "recommended"), _v$39 = gameplayActionButtonClass(action2()), _v$40 = gameplayActionButtonBusyAttrs(action2()), _v$41 = gameplayActionButtonDisabled(action2(), gameplaySummary(), locale()), _v$42 = gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) ? gameplayActionBlockedReasonId(action2()) : void 0;
+                _v$37 !== _p$.e && setAttribute(_el$187, "aria-label", _p$.e = _v$37);
+                _v$38 !== _p$.t && setAttribute(_el$188, "data-testid", _p$.t = _v$38);
+                _v$39 !== _p$.a && className(_el$188, _p$.a = _v$39);
+                _v$40 !== _p$.o && setAttribute(_el$188, "aria-busy", _p$.o = _v$40);
+                _v$41 !== _p$.i && (_el$188.disabled = _p$.i = _v$41);
+                _v$42 !== _p$.n && setAttribute(_el$188, "aria-describedby", _p$.n = _v$42);
+                return _p$;
+              }, {
+                e: void 0,
+                t: void 0,
+                a: void 0,
+                o: void 0,
+                i: void 0,
+                n: void 0
+              });
+              return _el$187;
+            })()];
+          }
+        }));
+        return _el$184;
+      })()
     }), _el$179);
     insert(_el$155, createComponent(Show, {
       get when() {
@@ -20722,33 +20856,33 @@ function TargetsPanel() {
     return state.selectedKind === kind && state.selectedId === id;
   };
   return (() => {
-    var _el$188 = _tmpl$40(), _el$189 = _el$188.firstChild, _el$190 = _el$189.firstChild, _el$191 = _el$190.nextSibling, _el$192 = _el$189.nextSibling, _el$193 = _el$192.firstChild, _el$194 = _el$193.nextSibling, _el$195 = _el$192.nextSibling, _el$196 = _el$195.firstChild, _el$197 = _el$196.nextSibling;
-    insert(_el$188, createComponent(Show, {
+    var _el$189 = _tmpl$41(), _el$190 = _el$189.firstChild, _el$191 = _el$190.firstChild, _el$192 = _el$191.nextSibling, _el$193 = _el$190.nextSibling, _el$194 = _el$193.firstChild, _el$195 = _el$194.nextSibling, _el$196 = _el$193.nextSibling, _el$197 = _el$196.firstChild, _el$198 = _el$197.nextSibling;
+    insert(_el$189, createComponent(Show, {
       get when() {
         return selectedLabel();
       },
       children: (selected) => (() => {
-        var _el$198 = _tmpl$8();
-        insert(_el$198, createComponent(Badge, {
+        var _el$199 = _tmpl$8();
+        insert(_el$199, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "已锁定目标", "Locked Target");
           }
         }), null);
-        insert(_el$198, createComponent(Badge, {
+        insert(_el$199, createComponent(Badge, {
           get children() {
             return selected();
           }
         }), null);
-        return _el$198;
+        return _el$199;
       })()
-    }), _el$189);
-    insert(_el$188, createComponent(EmptyState, {
+    }), _el$190);
+    insert(_el$189, createComponent(EmptyState, {
       get children() {
         return tr(locale(), "先在 Targets 中锁定一个行动体或地点，再回到世界查看局势；指挥面板只处理当前选中的目标。", "Lock onto an agent or location in Targets first, then read the world; the command surface handles only the selected target.");
       }
-    }), _el$189);
-    insert(_el$188, createComponent(Show, {
+    }), _el$190);
+    insert(_el$189, createComponent(Show, {
       get when() {
         return firstAgentClaimAction();
       },
@@ -20767,9 +20901,9 @@ function TargetsPanel() {
         },
         get children() {
           return [(() => {
-            var _el$199 = _tmpl$9();
-            insert(_el$199, () => gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) || tr(locale(), "当前是新用户空世界：先认领第一个 Agent，它会在链上提交并同步后出现在行动体列表。", "This is a new-user empty world: claim the first Agent first, then it will appear in the agent list after chain submission and sync."));
-            return _el$199;
+            var _el$200 = _tmpl$9();
+            insert(_el$200, () => gameplayActionDisabledReason(action2(), gameplaySummary(), locale()) || tr(locale(), "当前是新用户空世界：先认领第一个 Agent，它会在链上提交并同步后出现在行动体列表。", "This is a new-user empty world: claim the first Agent first, then it will appear in the agent list after chain submission and sync."));
+            return _el$200;
           })(), createComponent(Show, {
             get when() {
               return firstAgentClaimWaiting();
@@ -20786,29 +20920,29 @@ function TargetsPanel() {
               });
             }
           }), (() => {
-            var _el$200 = _tmpl$31(), _el$201 = _el$200.firstChild;
-            _el$201.$$click = () => renderGameplayAction(action2());
-            insert(_el$201, () => gameplayActionDisplayLabel(action2(), locale()));
+            var _el$201 = _tmpl$31(), _el$202 = _el$201.firstChild;
+            _el$202.$$click = () => renderGameplayAction(action2());
+            insert(_el$202, () => gameplayActionDisplayLabel(action2(), locale()));
             createRenderEffect((_p$) => {
               var _v$43 = gameplayActionButtonClass(action2()), _v$44 = gameplayActionButtonBusyAttrs(action2()), _v$45 = gameplayActionButtonDisabled(action2(), gameplaySummary(), locale());
-              _v$43 !== _p$.e && className(_el$201, _p$.e = _v$43);
-              _v$44 !== _p$.t && setAttribute(_el$201, "aria-busy", _p$.t = _v$44);
-              _v$45 !== _p$.a && (_el$201.disabled = _p$.a = _v$45);
+              _v$43 !== _p$.e && className(_el$202, _p$.e = _v$43);
+              _v$44 !== _p$.t && setAttribute(_el$202, "aria-busy", _p$.t = _v$44);
+              _v$45 !== _p$.a && (_el$202.disabled = _p$.a = _v$45);
               return _p$;
             }, {
               e: void 0,
               t: void 0,
               a: void 0
             });
-            return _el$200;
+            return _el$201;
           })()];
         }
       })
-    }), _el$189);
-    insert(_el$190, () => tr(locale(), "筛选目标", "Filter targets"));
-    _el$191.$$input = (event) => setSelectedSearch(event.currentTarget.value);
-    insert(_el$193, () => tr(locale(), "行动体", "Agents"));
-    insert(_el$194, createComponent(Show, {
+    }), _el$190);
+    insert(_el$191, () => tr(locale(), "筛选目标", "Filter targets"));
+    _el$192.$$input = (event) => setSelectedSearch(event.currentTarget.value);
+    insert(_el$194, () => tr(locale(), "行动体", "Agents"));
+    insert(_el$195, createComponent(Show, {
       get when() {
         return lists().agents.length > 0;
       },
@@ -20835,24 +20969,24 @@ function TargetsPanel() {
             const status = () => describeAgentSessionStatus(agent.id, locale());
             const displayName = () => agent.name || agent.label || agent.id;
             return (() => {
-              var _el$202 = _tmpl$42(), _el$203 = _el$202.firstChild, _el$204 = _el$203.firstChild, _el$206 = _el$203.nextSibling, _el$207 = _el$206.firstChild, _el$208 = _el$206.nextSibling, _el$209 = _el$208.nextSibling, _el$210 = _el$209.nextSibling;
-              _el$202.$$click = () => applySelection({
+              var _el$203 = _tmpl$43(), _el$204 = _el$203.firstChild, _el$205 = _el$204.firstChild, _el$207 = _el$204.nextSibling, _el$208 = _el$207.firstChild, _el$209 = _el$207.nextSibling, _el$210 = _el$209.nextSibling, _el$211 = _el$210.nextSibling;
+              _el$203.$$click = () => applySelection({
                 kind: "agent",
                 id: agent.id
               });
-              insert(_el$204, displayName);
-              insert(_el$203, createComponent(Show, {
+              insert(_el$205, displayName);
+              insert(_el$204, createComponent(Show, {
                 get when() {
                   return isSelectedTarget("agent", agent.id);
                 },
                 get children() {
-                  var _el$205 = _tmpl$41();
-                  insert(_el$205, () => tr(locale(), "已选中", "Selected"));
-                  return _el$205;
+                  var _el$206 = _tmpl$42();
+                  insert(_el$206, () => tr(locale(), "已选中", "Selected"));
+                  return _el$206;
                 }
               }), null);
-              insert(_el$207, () => agent.id);
-              insert(_el$208, createComponent(Badge, {
+              insert(_el$208, () => agent.id);
+              insert(_el$209, createComponent(Badge, {
                 get ["class"]() {
                   return status().badgeClass;
                 },
@@ -20860,7 +20994,7 @@ function TargetsPanel() {
                   return status().badge;
                 }
               }), null);
-              insert(_el$208, createComponent(Show, {
+              insert(_el$209, createComponent(Show, {
                 get when() {
                   return status().binding.playerId;
                 },
@@ -20872,23 +21006,23 @@ function TargetsPanel() {
                   });
                 }
               }), null);
-              insert(_el$209, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
-              insert(_el$202, createComponent(AgentActivitySurface, {
+              insert(_el$210, () => `${tr(locale(), "地点", "location")}=${agent.location_id} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(agent.resources)}`);
+              insert(_el$203, createComponent(AgentActivitySurface, {
                 get activity() {
                   return agent.activity;
                 },
                 get locale() {
                   return locale();
                 }
-              }), _el$210);
-              insert(_el$210, () => status().detail);
+              }), _el$211);
+              insert(_el$211, () => status().detail);
               createRenderEffect((_p$) => {
                 var _v$46 = index() === 0 ? "viewer-playthrough-select-agent" : `viewer-select-agent-${agent.id}`, _v$47 = agent.id, _v$48 = status().kind, _v$49 = isSelectedTarget("agent", agent.id), _v$50 = isSelectedTarget("agent", agent.id) ? "true" : "false";
-                _v$46 !== _p$.e && setAttribute(_el$202, "data-testid", _p$.e = _v$46);
-                _v$47 !== _p$.t && setAttribute(_el$202, "data-select-id", _p$.t = _v$47);
-                _v$48 !== _p$.a && setAttribute(_el$202, "data-agent-session-status", _p$.a = _v$48);
-                _v$49 !== _p$.o && setAttribute(_el$202, "data-selected", _p$.o = _v$49);
-                _v$50 !== _p$.i && setAttribute(_el$202, "aria-pressed", _p$.i = _v$50);
+                _v$46 !== _p$.e && setAttribute(_el$203, "data-testid", _p$.e = _v$46);
+                _v$47 !== _p$.t && setAttribute(_el$203, "data-select-id", _p$.t = _v$47);
+                _v$48 !== _p$.a && setAttribute(_el$203, "data-agent-session-status", _p$.a = _v$48);
+                _v$49 !== _p$.o && setAttribute(_el$203, "data-selected", _p$.o = _v$49);
+                _v$50 !== _p$.i && setAttribute(_el$203, "aria-pressed", _p$.i = _v$50);
                 return _p$;
               }, {
                 e: void 0,
@@ -20897,14 +21031,14 @@ function TargetsPanel() {
                 o: void 0,
                 i: void 0
               });
-              return _el$202;
+              return _el$203;
             })();
           }
         });
       }
     }));
-    insert(_el$196, () => tr(locale(), "地点", "Locations"));
-    insert(_el$197, createComponent(Show, {
+    insert(_el$197, () => tr(locale(), "地点", "Locations"));
+    insert(_el$198, createComponent(Show, {
       get when() {
         return lists().locations.length > 0;
       },
@@ -20928,29 +21062,29 @@ function TargetsPanel() {
             return lists().locations;
           },
           children: (location) => (() => {
-            var _el$211 = _tmpl$43(), _el$212 = _el$211.firstChild, _el$213 = _el$212.firstChild, _el$215 = _el$212.nextSibling;
-            _el$211.$$click = () => applySelection({
+            var _el$212 = _tmpl$44(), _el$213 = _el$212.firstChild, _el$214 = _el$213.firstChild, _el$216 = _el$213.nextSibling;
+            _el$212.$$click = () => applySelection({
               kind: "location",
               id: location.id
             });
-            insert(_el$213, () => location.name || location.id);
-            insert(_el$212, createComponent(Show, {
+            insert(_el$214, () => location.name || location.id);
+            insert(_el$213, createComponent(Show, {
               get when() {
                 return isSelectedTarget("location", location.id);
               },
               get children() {
-                var _el$214 = _tmpl$41();
-                insert(_el$214, () => tr(locale(), "已选中", "Selected"));
-                return _el$214;
+                var _el$215 = _tmpl$42();
+                insert(_el$215, () => tr(locale(), "已选中", "Selected"));
+                return _el$215;
               }
             }), null);
-            insert(_el$215, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
+            insert(_el$216, () => `id=${location.id} · ${tr(locale(), "半径", "radius")}=${formatPhysicalDistanceCm(location.profile?.radius_cm, locale()) || "-"} · ${tr(locale(), "资源", "resources")}=${renderResourceSummary(location.resources)}`);
             createRenderEffect((_p$) => {
               var _v$51 = `viewer-select-location-${location.id}`, _v$52 = location.id, _v$53 = isSelectedTarget("location", location.id), _v$54 = isSelectedTarget("location", location.id) ? "true" : "false";
-              _v$51 !== _p$.e && setAttribute(_el$211, "data-testid", _p$.e = _v$51);
-              _v$52 !== _p$.t && setAttribute(_el$211, "data-select-id", _p$.t = _v$52);
-              _v$53 !== _p$.a && setAttribute(_el$211, "data-selected", _p$.a = _v$53);
-              _v$54 !== _p$.o && setAttribute(_el$211, "aria-pressed", _p$.o = _v$54);
+              _v$51 !== _p$.e && setAttribute(_el$212, "data-testid", _p$.e = _v$51);
+              _v$52 !== _p$.t && setAttribute(_el$212, "data-select-id", _p$.t = _v$52);
+              _v$53 !== _p$.a && setAttribute(_el$212, "data-selected", _p$.a = _v$53);
+              _v$54 !== _p$.o && setAttribute(_el$212, "aria-pressed", _p$.o = _v$54);
               return _p$;
             }, {
               e: void 0,
@@ -20958,14 +21092,14 @@ function TargetsPanel() {
               a: void 0,
               o: void 0
             });
-            return _el$211;
+            return _el$212;
           })()
         });
       }
     }));
-    createRenderEffect(() => setAttribute(_el$191, "placeholder", tr(locale(), "搜索行动体或地点", "Search agents or locations")));
-    createRenderEffect(() => _el$191.value = getSelectedSearch());
-    return _el$188;
+    createRenderEffect(() => setAttribute(_el$192, "placeholder", tr(locale(), "搜索行动体或地点", "Search agents or locations")));
+    createRenderEffect(() => _el$192.value = getSelectedSearch());
+    return _el$189;
   })();
 }
 function WorldSummaryPanel(props = {}) {
@@ -20988,8 +21122,8 @@ function WorldSummaryPanel(props = {}) {
   const showPlayerSessionSurface = () => !!hostedRecoveryHint() || !state$1.auth.available && isHostedPublicJoinDeploymentMode(state$1.hostedAccess?.deployment_mode) || showRebindNotice();
   const diagnosticsSummaryBadges = () => [`auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`, `events=${state$1.recentEvents.length}`];
   return (() => {
-    var _el$216 = _tmpl$47(), _el$217 = _el$216.firstChild, _el$218 = _el$217.firstChild, _el$219 = _el$218.firstChild, _el$220 = _el$219.firstChild, _el$221 = _el$220.nextSibling, _el$222 = _el$218.nextSibling, _el$226 = _el$222.firstChild, _el$227 = _el$226.firstChild, _el$228 = _el$227.firstChild, _el$229 = _el$228.firstChild, _el$230 = _el$229.nextSibling, _el$231 = _el$228.nextSibling, _el$232 = _el$227.nextSibling, _el$233 = _el$232.firstChild, _el$234 = _el$233.nextSibling, _el$235 = _el$234.nextSibling, _el$243 = _el$235.nextSibling, _el$244 = _el$243.nextSibling, _el$245 = _el$244.firstChild, _el$246 = _el$245.nextSibling;
-    insert(_el$216, createComponent(Show, {
+    var _el$217 = _tmpl$48(), _el$218 = _el$217.firstChild, _el$219 = _el$218.firstChild, _el$220 = _el$219.firstChild, _el$221 = _el$220.firstChild, _el$222 = _el$221.nextSibling, _el$223 = _el$219.nextSibling, _el$227 = _el$223.firstChild, _el$228 = _el$227.firstChild, _el$229 = _el$228.firstChild, _el$230 = _el$229.firstChild, _el$231 = _el$230.nextSibling, _el$232 = _el$229.nextSibling, _el$233 = _el$228.nextSibling, _el$234 = _el$233.firstChild, _el$235 = _el$234.nextSibling, _el$236 = _el$235.nextSibling, _el$244 = _el$236.nextSibling, _el$245 = _el$244.nextSibling, _el$246 = _el$245.firstChild, _el$247 = _el$246.nextSibling;
+    insert(_el$217, createComponent(Show, {
       get when() {
         return memo(() => !!!starterOcGateOpen())() && starterOcAction(gameplaySummary());
       },
@@ -21012,15 +21146,15 @@ function WorldSummaryPanel(props = {}) {
           }
         });
       }
-    }), _el$217);
-    insert(_el$220, () => tr(locale(), "玩法明细", "Gameplay Details"));
-    insert(_el$221, () => tr(locale(), "世界棋盘上方已保留目标、下一步和回执；这里展开看完整状态机与经济明细。", "The world board already carries objective, next move, and receipt; expand here for the full state machine and economy details."));
-    insert(_el$218, createComponent(Badge, {
+    }), _el$218);
+    insert(_el$221, () => tr(locale(), "玩法明细", "Gameplay Details"));
+    insert(_el$222, () => tr(locale(), "世界棋盘上方已保留目标、下一步和回执；这里展开看完整状态机与经济明细。", "The world board already carries objective, next move, and receipt; expand here for the full state machine and economy details."));
+    insert(_el$219, createComponent(Badge, {
       get children() {
         return diagnosticsSummaryBadges().join(" · ");
       }
     }), null);
-    insert(_el$222, createComponent(PanelSection, {
+    insert(_el$223, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "正式玩法摘要", "Formal Gameplay Summary");
       },
@@ -21043,8 +21177,8 @@ function WorldSummaryPanel(props = {}) {
             });
           },
           children: (gameplay) => [(() => {
-            var _el$247 = _tmpl$8();
-            insert(_el$247, createComponent(Badge, {
+            var _el$248 = _tmpl$8();
+            insert(_el$248, createComponent(Badge, {
               get ["class"]() {
                 return gameplayStatusBadgeClass(gameplay().stageStatus);
               },
@@ -21052,13 +21186,13 @@ function WorldSummaryPanel(props = {}) {
                 return gameplayStageLabel(gameplay().stageStatus, locale());
               }
             }), null);
-            insert(_el$247, createComponent(Badge, {
+            insert(_el$248, createComponent(Badge, {
               "class": "badge badge--accent",
               get children() {
                 return gameplayProgressLabel(gameplay().progressPercent, locale());
               }
             }), null);
-            return _el$247;
+            return _el$248;
           })(), createComponent(FactoryProductionFailureDispositionCard, {
             get disposition() {
               return gameplay().factoryProductionFailureDisposition;
@@ -21083,12 +21217,12 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$248 = _tmpl$9();
-                insert(_el$248, () => gameplay().controlProof?.summary || tr(locale(), "等待控制证明链路发布。", "Waiting for the control proof chain."));
-                return _el$248;
+                var _el$249 = _tmpl$9();
+                insert(_el$249, () => gameplay().controlProof?.summary || tr(locale(), "等待控制证明链路发布。", "Waiting for the control proof chain."));
+                return _el$249;
               })(), (() => {
-                var _el$249 = _tmpl$0();
-                insert(_el$249, createComponent(MetricCard, {
+                var _el$250 = _tmpl$0();
+                insert(_el$250, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "玩家意图", "Player Intent");
                   },
@@ -21096,7 +21230,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().controlProof?.intent || tr(locale(), "待提交", "not submitted");
                   }
                 }), null);
-                insert(_el$249, createComponent(MetricCard, {
+                insert(_el$250, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "世界后果", "World Consequence");
                   },
@@ -21104,7 +21238,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().controlProof?.consequence || tr(locale(), "待回执", "waiting for receipt");
                   }
                 }), null);
-                insert(_el$249, createComponent(MetricCard, {
+                insert(_el$250, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "恢复动作", "Recovery Move");
                   },
@@ -21112,7 +21246,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().controlProof?.recovery || tr(locale(), "待发布", "not published");
                   }
                 }), null);
-                insert(_el$249, createComponent(MetricCard, {
+                insert(_el$250, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "下一步", "Next Move");
                   },
@@ -21120,7 +21254,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().controlProof?.nextMove || tr(locale(), "等待运行时指引", "waiting for runtime guidance");
                   }
                 }), null);
-                return _el$249;
+                return _el$250;
               })()];
             }
           }), createComponent(PanelSection, {
@@ -21135,20 +21269,20 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$250 = _tmpl$8();
-                insert(_el$250, createComponent(Badge, {
+                var _el$251 = _tmpl$8();
+                insert(_el$251, createComponent(Badge, {
                   get children() {
                     return gameplay().attractionProof?.verdict || "unverified";
                   }
                 }));
-                return _el$250;
-              })(), (() => {
-                var _el$251 = _tmpl$9();
-                insert(_el$251, () => gameplay().attractionProof?.summary || tr(locale(), "等待吸引力证据发布。", "Waiting for attraction proof."));
                 return _el$251;
               })(), (() => {
-                var _el$252 = _tmpl$0();
-                insert(_el$252, createComponent(MetricCard, {
+                var _el$252 = _tmpl$9();
+                insert(_el$252, () => gameplay().attractionProof?.summary || tr(locale(), "等待吸引力证据发布。", "Waiting for attraction proof."));
+                return _el$252;
+              })(), (() => {
+                var _el$253 = _tmpl$0();
+                insert(_el$253, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "我造成了什么", "What I caused");
                   },
@@ -21156,7 +21290,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().attractionProof?.whatICaused || tr(locale(), "等待玩家导致的世界变化", "waiting for player-caused world change");
                   }
                 }), null);
-                insert(_el$252, createComponent(MetricCard, {
+                insert(_el$253, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "新选择", "New option");
                   },
@@ -21164,7 +21298,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().attractionProof?.newOption || tr(locale(), "等待新选择", "waiting for new option");
                   }
                 }), null);
-                insert(_el$252, createComponent(MetricCard, {
+                insert(_el$253, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "为什么继续", "Why continue");
                   },
@@ -21172,7 +21306,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().attractionProof?.whyContinue || tr(locale(), "等待下一分支", "waiting for next branch");
                   }
                 }), null);
-                insert(_el$252, createComponent(MetricCard, {
+                insert(_el$253, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "等待代价", "Waiting cost");
                   },
@@ -21180,7 +21314,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().attractionProof?.waitingCost || tr(locale(), "等待 / 未验证", "waiting/unverified");
                   }
                 }), null);
-                insert(_el$252, createComponent(MetricCard, {
+                insert(_el$253, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "恢复", "Recovery");
                   },
@@ -21188,7 +21322,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().attractionProof?.recovery || tr(locale(), "等待恢复路径", "waiting for recovery path");
                   }
                 }), null);
-                return _el$252;
+                return _el$253;
               })()];
             }
           }), createComponent(PanelSection, {
@@ -21203,12 +21337,12 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$253 = _tmpl$9();
-                insert(_el$253, () => gameplay().agencyMoves?.summary || tr(locale(), "等待玩家能动性动词发布。", "Waiting for player agency moves."));
-                return _el$253;
+                var _el$254 = _tmpl$9();
+                insert(_el$254, () => gameplay().agencyMoves?.summary || tr(locale(), "等待玩家能动性动词发布。", "Waiting for player agency moves."));
+                return _el$254;
               })(), (() => {
-                var _el$254 = _tmpl$0();
-                insert(_el$254, createComponent(MetricCard, {
+                var _el$255 = _tmpl$0();
+                insert(_el$255, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "打断", "Interrupt");
                   },
@@ -21216,7 +21350,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().agencyMoves?.interrupt || tr(locale(), "未验证", "unverified");
                   }
                 }), null);
-                insert(_el$254, createComponent(MetricCard, {
+                insert(_el$255, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "重排", "Reprioritize");
                   },
@@ -21224,7 +21358,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().agencyMoves?.reprioritize || tr(locale(), "未验证", "unverified");
                   }
                 }), null);
-                insert(_el$254, createComponent(MetricCard, {
+                insert(_el$255, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "纠偏", "Correction");
                   },
@@ -21232,7 +21366,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().agencyMoves?.correction || tr(locale(), "等待替代意图", "waiting for replacement intent");
                   }
                 }), null);
-                insert(_el$254, createComponent(MetricCard, {
+                insert(_el$255, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "交接结果", "Handoff");
                   },
@@ -21240,7 +21374,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().agencyMoves?.handoff || tr(locale(), "等待新旧意图交接", "waiting for handoff");
                   }
                 }), null);
-                return _el$254;
+                return _el$255;
               })()];
             }
           }), createComponent(PanelSection, {
@@ -21255,12 +21389,12 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$255 = _tmpl$9();
-                insert(_el$255, () => gameplay().progressionProof?.summary || tr(locale(), "等待首胜与反刷证据发布。", "Waiting for first-win and anti-grind evidence."));
-                return _el$255;
+                var _el$256 = _tmpl$9();
+                insert(_el$256, () => gameplay().progressionProof?.summary || tr(locale(), "等待首胜与反刷证据发布。", "Waiting for first-win and anti-grind evidence."));
+                return _el$256;
               })(), (() => {
-                var _el$256 = _tmpl$0();
-                insert(_el$256, createComponent(MetricCard, {
+                var _el$257 = _tmpl$0();
+                insert(_el$257, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "首胜目标", "First Win");
                   },
@@ -21268,7 +21402,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().progressionProof?.firstWinGoal || tr(locale(), "待发布", "not published");
                   }
                 }), null);
-                insert(_el$256, createComponent(MetricCard, {
+                insert(_el$257, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "玩家动作", "Player Action");
                   },
@@ -21276,7 +21410,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().progressionProof?.playerAction || tr(locale(), "待提交", "not submitted");
                   }
                 }), null);
-                insert(_el$256, createComponent(MetricCard, {
+                insert(_el$257, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "世界变化", "World Change");
                   },
@@ -21284,7 +21418,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().progressionProof?.worldChange || tr(locale(), "待回执", "waiting for receipt");
                   }
                 }), null);
-                insert(_el$256, createComponent(MetricCard, {
+                insert(_el$257, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "反刷 leverage", "Anti-Grind Leverage");
                   },
@@ -21295,7 +21429,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().progressionProof?.leverageVerdict;
                   }
                 }), null);
-                return _el$256;
+                return _el$257;
               })()];
             }
           }), createComponent(PanelSection, {
@@ -21310,12 +21444,12 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$257 = _tmpl$9();
-                insert(_el$257, () => gameplay().matureWorldContinuation?.summary || tr(locale(), "等待成熟世界承接证据发布。", "Waiting for mature-world continuation evidence."));
-                return _el$257;
+                var _el$258 = _tmpl$9();
+                insert(_el$258, () => gameplay().matureWorldContinuation?.summary || tr(locale(), "等待成熟世界承接证据发布。", "Waiting for mature-world continuation evidence."));
+                return _el$258;
               })(), (() => {
-                var _el$258 = _tmpl$0();
-                insert(_el$258, createComponent(MetricCard, {
+                var _el$259 = _tmpl$0();
+                insert(_el$259, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "依赖状态", "Dependency");
                   },
@@ -21323,7 +21457,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().matureWorldContinuation?.dependencyStatus || tr(locale(), "未验证", "unverified");
                   }
                 }), null);
-                insert(_el$258, createComponent(MetricCard, {
+                insert(_el$259, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "恢复路径", "Recovery Path");
                   },
@@ -21331,7 +21465,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().matureWorldContinuation?.recoveryPath || tr(locale(), "等待运行时指引", "waiting for runtime guidance");
                   }
                 }), null);
-                insert(_el$258, createComponent(MetricCard, {
+                insert(_el$259, createComponent(MetricCard, {
                   get label() {
                     return tr(locale(), "分享回放", "Share Replay");
                   },
@@ -21342,7 +21476,7 @@ function WorldSummaryPanel(props = {}) {
                     return gameplay().shareReplay?.summary;
                   }
                 }), null);
-                return _el$258;
+                return _el$259;
               })(), createComponent(RecoveryOptionComparisonPanel, {
                 get continuation() {
                   return gameplay().matureWorldContinuation;
@@ -21368,30 +21502,30 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$259 = _tmpl$9();
-                insert(_el$259, () => gameplay().acceptedIntentSummary);
-                return _el$259;
-              })(), (() => {
-                var _el$260 = _tmpl$6();
-                insert(_el$260, () => gameplay().acceptedIntentDetail);
+                var _el$260 = _tmpl$9();
+                insert(_el$260, () => gameplay().acceptedIntentSummary);
                 return _el$260;
+              })(), (() => {
+                var _el$261 = _tmpl$6();
+                insert(_el$261, () => gameplay().acceptedIntentDetail);
+                return _el$261;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().resumeAnchor;
                 },
                 get children() {
                   return [(() => {
-                    var _el$261 = _tmpl$8();
-                    insert(_el$261, createComponent(Badge, {
+                    var _el$262 = _tmpl$8();
+                    insert(_el$262, createComponent(Badge, {
                       get children() {
                         return tr(locale(), "续玩锚点", "Resume Anchor");
                       }
                     }));
-                    return _el$261;
-                  })(), (() => {
-                    var _el$262 = _tmpl$6();
-                    insert(_el$262, () => gameplay().resumeAnchor);
                     return _el$262;
+                  })(), (() => {
+                    var _el$263 = _tmpl$6();
+                    insert(_el$263, () => gameplay().resumeAnchor);
+                    return _el$263;
                   })()];
                 }
               })];
@@ -21411,8 +21545,8 @@ function WorldSummaryPanel(props = {}) {
             },
             get children() {
               return [(() => {
-                var _el$263 = _tmpl$8();
-                insert(_el$263, createComponent(For, {
+                var _el$264 = _tmpl$8();
+                insert(_el$264, createComponent(For, {
                   get each() {
                     return gameplay().executionStateMachine || [];
                   },
@@ -21425,32 +21559,32 @@ function WorldSummaryPanel(props = {}) {
                     }
                   })
                 }));
-                return _el$263;
-              })(), (() => {
-                var _el$264 = _tmpl$9();
-                insert(_el$264, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
                 return _el$264;
+              })(), (() => {
+                var _el$265 = _tmpl$9();
+                insert(_el$265, () => gameplay().executionSummary || tr(locale(), "等待目标执行状态更新。", "Waiting for goal execution state updates."));
+                return _el$265;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseLabel;
                 },
                 get children() {
-                  var _el$265 = _tmpl$8();
-                  insert(_el$265, createComponent(Badge, {
+                  var _el$266 = _tmpl$8();
+                  insert(_el$266, createComponent(Badge, {
                     get children() {
                       return gameplay().executionCauseLabel;
                     }
                   }));
-                  return _el$265;
+                  return _el$266;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().executionCauseDetail;
                 },
                 get children() {
-                  var _el$266 = _tmpl$6();
-                  insert(_el$266, () => gameplay().executionCauseDetail);
-                  return _el$266;
+                  var _el$267 = _tmpl$6();
+                  insert(_el$267, () => gameplay().executionCauseDetail);
+                  return _el$267;
                 }
               })];
             }
@@ -21471,9 +21605,9 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().progressDetail;
                 },
                 get children() {
-                  var _el$267 = _tmpl$6();
-                  insert(_el$267, () => gameplay().progressDetail);
-                  return _el$267;
+                  var _el$268 = _tmpl$6();
+                  insert(_el$268, () => gameplay().progressDetail);
+                  return _el$268;
                 }
               }), createComponent(Show, {
                 get when() {
@@ -21481,18 +21615,18 @@ function WorldSummaryPanel(props = {}) {
                 },
                 get children() {
                   return [(() => {
-                    var _el$268 = _tmpl$48();
-                    insert(_el$268, createComponent(Badge, {
+                    var _el$269 = _tmpl$49();
+                    insert(_el$269, createComponent(Badge, {
                       "class": "badge badge--warn",
                       get children() {
                         return gameplay().blockerLabel || gameplay().blockerKind || tr(locale(), "当前阻塞", "Current Blocker");
                       }
                     }));
-                    return _el$268;
-                  })(), (() => {
-                    var _el$269 = _tmpl$6();
-                    insert(_el$269, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
                     return _el$269;
+                  })(), (() => {
+                    var _el$270 = _tmpl$6();
+                    insert(_el$270, () => gameplay().narrativeBlockerDetail || tr(locale(), "当前玩法被阻塞，需要显式恢复。", "Gameplay is blocked and needs explicit recovery."));
+                    return _el$270;
                   })()];
                 }
               }), createComponent(Show, {
@@ -21500,49 +21634,49 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().blockerSupplementalDetail;
                 },
                 get children() {
-                  var _el$270 = _tmpl$6();
-                  insert(_el$270, () => gameplay().blockerSupplementalDetail);
-                  return _el$270;
+                  var _el$271 = _tmpl$6();
+                  insert(_el$271, () => gameplay().blockerSupplementalDetail);
+                  return _el$271;
                 }
               }), (() => {
-                var _el$271 = _tmpl$48();
-                insert(_el$271, createComponent(Badge, {
+                var _el$272 = _tmpl$49();
+                insert(_el$272, createComponent(Badge, {
                   "class": "badge badge--accent",
                   get children() {
                     return tr(locale(), "下一步", "Next Step");
                   }
                 }));
-                return _el$271;
-              })(), (() => {
-                var _el$272 = _tmpl$9();
-                insert(_el$272, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次运行时指引更新。", "Wait for the next runtime guidance update."));
                 return _el$272;
+              })(), (() => {
+                var _el$273 = _tmpl$9();
+                insert(_el$273, () => gameplay().narrativeNextStep || tr(locale(), "等待下一次运行时指引更新。", "Wait for the next runtime guidance update."));
+                return _el$273;
               })(), createComponent(Show, {
                 get when() {
                   return gameplay().branchHint;
                 },
                 get children() {
-                  var _el$273 = _tmpl$6();
-                  insert(_el$273, () => gameplay().branchHint);
-                  return _el$273;
+                  var _el$274 = _tmpl$6();
+                  insert(_el$274, () => gameplay().branchHint);
+                  return _el$274;
                 }
               }), createComponent(Show, {
                 get when() {
                   return gameplay().entityCounts;
                 },
                 get children() {
-                  var _el$274 = _tmpl$8();
-                  insert(_el$274, createComponent(Badge, {
+                  var _el$275 = _tmpl$8();
+                  insert(_el$275, createComponent(Badge, {
                     get children() {
                       return `agents=${gameplay().entityCounts.agents}`;
                     }
                   }), null);
-                  insert(_el$274, createComponent(Badge, {
+                  insert(_el$275, createComponent(Badge, {
                     get children() {
                       return `locations=${gameplay().entityCounts.locations}`;
                     }
                   }), null);
-                  return _el$274;
+                  return _el$275;
                 }
               })];
             }
@@ -21584,21 +21718,21 @@ function WorldSummaryPanel(props = {}) {
               },
               get children() {
                 return [(() => {
-                  var _el$281 = _tmpl$50();
-                  insert(_el$281, () => `${preview().productId || tr(locale(), "未知产品", "Unknown product")} · ${preview().roleLabel || tr(locale(), "未知", "unknown")} · ${preview().tradable ? tr(locale(), "可交易", "tradable") : tr(locale(), "不可交易", "not tradable")}`);
-                  return _el$281;
-                })(), (() => {
-                  var _el$282 = _tmpl$6();
-                  insert(_el$282, () => `${tr(locale(), "阶段", "Stage")}: ${preview().currentStageLabel || tr(locale(), "未知", "unknown")} / ${preview().requiredStageLabel || tr(locale(), "未知", "unknown")}`);
+                  var _el$282 = _tmpl$51();
+                  insert(_el$282, () => `${preview().productId || tr(locale(), "未知产品", "Unknown product")} · ${preview().roleLabel || tr(locale(), "未知", "unknown")} · ${preview().tradable ? tr(locale(), "可交易", "tradable") : tr(locale(), "不可交易", "not tradable")}`);
                   return _el$282;
+                })(), (() => {
+                  var _el$283 = _tmpl$6();
+                  insert(_el$283, () => `${tr(locale(), "阶段", "Stage")}: ${preview().currentStageLabel || tr(locale(), "未知", "unknown")} / ${preview().requiredStageLabel || tr(locale(), "未知", "unknown")}`);
+                  return _el$283;
                 })(), createComponent(Show, {
                   get when() {
                     return preview().localizedNextStepHint;
                   },
                   get children() {
-                    var _el$283 = _tmpl$6();
-                    insert(_el$283, () => preview().localizedNextStepHint);
-                    return _el$283;
+                    var _el$284 = _tmpl$6();
+                    insert(_el$284, () => preview().localizedNextStepHint);
+                    return _el$284;
                   }
                 })];
               }
@@ -21614,8 +21748,8 @@ function WorldSummaryPanel(props = {}) {
               return tr(locale(), "把当前玩法拆成投入、产出、新用途、修复动作和下一步效果，帮助玩家判断现在该补资源、推进一步，还是换目标。", "Break the current loop into input, output, new use, repair move, and next effect so the player can choose whether to refill resources, advance one step, or switch targets.");
             },
             get children() {
-              var _el$275 = _tmpl$0();
-              insert(_el$275, createComponent(MetricCard, {
+              var _el$276 = _tmpl$0();
+              insert(_el$276, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "投入", "Input");
                 },
@@ -21623,7 +21757,7 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().economicSurface?.input || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$275, createComponent(MetricCard, {
+              insert(_el$276, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "产出", "Output");
                 },
@@ -21631,7 +21765,7 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().economicSurface?.output || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$275, createComponent(MetricCard, {
+              insert(_el$276, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "新用途", "New Use");
                 },
@@ -21639,7 +21773,7 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().economicSurface?.unlockedValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              insert(_el$275, createComponent(MetricCard, {
+              insert(_el$276, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "修复动作", "Repair Move");
                 },
@@ -21650,7 +21784,7 @@ function WorldSummaryPanel(props = {}) {
                   return memo(() => !!gameplay().economicSurface?.blockerLabel)() ? tr(locale(), `当前阻塞归类: ${gameplay().economicSurface.blockerLabel}`, `Current blocker class: ${gameplay().economicSurface.blockerLabel}`) : null;
                 }
               }), null);
-              insert(_el$275, createComponent(MetricCard, {
+              insert(_el$276, createComponent(MetricCard, {
                 get label() {
                   return tr(locale(), "下一步价值", "Next Value");
                 },
@@ -21658,7 +21792,7 @@ function WorldSummaryPanel(props = {}) {
                   return gameplay().economicSurface?.nextValue || tr(locale(), "待发布", "not published");
                 }
               }), null);
-              return _el$275;
+              return _el$276;
             }
           }), createComponent(MicroDepotFacilitiesPanel, {
             get facilities() {
@@ -21770,26 +21904,26 @@ function WorldSummaryPanel(props = {}) {
               },
               get children() {
                 return [(() => {
-                  var _el$284 = _tmpl$9();
-                  insert(_el$284, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
-                  return _el$284;
+                  var _el$285 = _tmpl$9();
+                  insert(_el$285, () => feedback().effect || feedback().reason || tr(locale(), "最新回执已更新，但还没有新的世界级后果。", "The latest feedback is in, but there is no new world-level consequence yet."));
+                  return _el$285;
                 })(), createComponent(Show, {
                   get when() {
                     return feedback().reason;
                   },
                   get children() {
-                    var _el$285 = _tmpl$6();
-                    insert(_el$285, () => feedback().reason);
-                    return _el$285;
+                    var _el$286 = _tmpl$6();
+                    insert(_el$286, () => feedback().reason);
+                    return _el$286;
                   }
                 }), createComponent(Show, {
                   get when() {
                     return feedback().hint;
                   },
                   get children() {
-                    var _el$286 = _tmpl$6();
-                    insert(_el$286, () => feedback().hint);
-                    return _el$286;
+                    var _el$287 = _tmpl$6();
+                    insert(_el$287, () => feedback().hint);
+                    return _el$287;
                   }
                 })];
               }
@@ -21872,9 +22006,9 @@ function WorldSummaryPanel(props = {}) {
               });
             }
           }), (() => {
-            var _el$276 = _tmpl$49(), _el$277 = _el$276.firstChild, _el$278 = _el$277.nextSibling;
-            insert(_el$277, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
-            insert(_el$278, createComponent(Show, {
+            var _el$277 = _tmpl$50(), _el$278 = _el$277.firstChild, _el$279 = _el$278.nextSibling;
+            insert(_el$278, () => tr(locale(), "可用玩法动作", "Available Gameplay Actions"));
+            insert(_el$279, createComponent(Show, {
               get when() {
                 return visibleGameplayActionsForPanels(gameplay()).length > 0;
               },
@@ -21918,30 +22052,30 @@ function WorldSummaryPanel(props = {}) {
                           },
                           get fallback() {
                             return (() => {
-                              var _el$295 = _tmpl$6();
-                              insert(_el$295, () => gameplayActionDetail(action2, gameplay(), locale()));
-                              return _el$295;
+                              var _el$296 = _tmpl$6();
+                              insert(_el$296, () => gameplayActionDetail(action2, gameplay(), locale()));
+                              return _el$296;
                             })();
                           },
                           get children() {
                             return [(() => {
-                              var _el$287 = _tmpl$6();
-                              setAttribute(_el$287, "id", blockedReasonId);
-                              insert(_el$287, disabledReason);
-                              return _el$287;
+                              var _el$288 = _tmpl$6();
+                              setAttribute(_el$288, "id", blockedReasonId);
+                              insert(_el$288, disabledReason);
+                              return _el$288;
                             })(), createComponent(Show, {
                               get when() {
                                 return gameplay().nextStepHint;
                               },
                               get children() {
-                                var _el$288 = _tmpl$6();
-                                insert(_el$288, () => gameplay().nextStepHint);
-                                return _el$288;
+                                var _el$289 = _tmpl$6();
+                                insert(_el$289, () => gameplay().nextStepHint);
+                                return _el$289;
                               }
                             }), (() => {
-                              var _el$289 = _tmpl$51(), _el$290 = _el$289.firstChild;
-                              insert(_el$290, () => tr(locale(), "重试前先查看下一步或玩法详情。", "Review Next Move or Gameplay Details before retrying."));
-                              return _el$289;
+                              var _el$290 = _tmpl$52(), _el$291 = _el$290.firstChild;
+                              insert(_el$291, () => tr(locale(), "重试前先查看下一步或玩法详情。", "Review Next Move or Gameplay Details before retrying."));
+                              return _el$290;
                             })()];
                           }
                         }), createComponent(Show, {
@@ -21949,17 +22083,17 @@ function WorldSummaryPanel(props = {}) {
                             return action2.executeKind === "request_snapshot" || action2.executeKind === "step" || action2.executeKind === "play" || action2.executeKind === "gameplay_action" || action2.executeKind === "claim_first_agent" || action2.executeKind === "claim_starter_oc";
                           },
                           get children() {
-                            var _el$291 = _tmpl$31(), _el$292 = _el$291.firstChild;
-                            _el$292.$$click = () => renderGameplayAction(action2);
-                            insert(_el$292, () => gameplayActionDisplayLabel(action2, locale()));
+                            var _el$292 = _tmpl$31(), _el$293 = _el$292.firstChild;
+                            _el$293.$$click = () => renderGameplayAction(action2);
+                            insert(_el$293, () => gameplayActionDisplayLabel(action2, locale()));
                             createRenderEffect((_p$) => {
                               var _v$55 = gameplayActionTestId(action2), _v$56 = action2.label || action2.actionId || void 0, _v$57 = gameplayActionButtonClass(action2), _v$58 = gameplayActionButtonBusyAttrs(action2), _v$59 = gameplayActionButtonDisabled(action2, gameplay(), locale()), _v$60 = disabledReason() ? blockedReasonId : void 0;
-                              _v$55 !== _p$.e && setAttribute(_el$292, "data-testid", _p$.e = _v$55);
-                              _v$56 !== _p$.t && setAttribute(_el$292, "aria-label", _p$.t = _v$56);
-                              _v$57 !== _p$.a && className(_el$292, _p$.a = _v$57);
-                              _v$58 !== _p$.o && setAttribute(_el$292, "aria-busy", _p$.o = _v$58);
-                              _v$59 !== _p$.i && (_el$292.disabled = _p$.i = _v$59);
-                              _v$60 !== _p$.n && setAttribute(_el$292, "aria-describedby", _p$.n = _v$60);
+                              _v$55 !== _p$.e && setAttribute(_el$293, "data-testid", _p$.e = _v$55);
+                              _v$56 !== _p$.t && setAttribute(_el$293, "aria-label", _p$.t = _v$56);
+                              _v$57 !== _p$.a && className(_el$293, _p$.a = _v$57);
+                              _v$58 !== _p$.o && setAttribute(_el$293, "aria-busy", _p$.o = _v$58);
+                              _v$59 !== _p$.i && (_el$293.disabled = _p$.i = _v$59);
+                              _v$60 !== _p$.n && setAttribute(_el$293, "aria-describedby", _p$.n = _v$60);
                               return _p$;
                             }, {
                               e: void 0,
@@ -21969,7 +22103,7 @@ function WorldSummaryPanel(props = {}) {
                               i: void 0,
                               n: void 0
                             });
-                            return _el$291;
+                            return _el$292;
                           }
                         }), createComponent(Show, {
                           get when() {
@@ -21990,17 +22124,17 @@ function WorldSummaryPanel(props = {}) {
                             return action2.executeKind === "agent_chat";
                           },
                           get children() {
-                            var _el$293 = _tmpl$31(), _el$294 = _el$293.firstChild;
-                            _el$294.$$click = () => renderGameplayAction(action2);
-                            insert(_el$294, () => gameplayActionDisplayLabel(action2, locale()));
+                            var _el$294 = _tmpl$31(), _el$295 = _el$294.firstChild;
+                            _el$295.$$click = () => renderGameplayAction(action2);
+                            insert(_el$295, () => gameplayActionDisplayLabel(action2, locale()));
                             createRenderEffect((_p$) => {
                               var _v$61 = gameplayActionTestId(action2), _v$62 = action2.label || action2.actionId || void 0, _v$63 = gameplayActionButtonClass(action2), _v$64 = gameplayActionButtonBusyAttrs(action2), _v$65 = gameplayActionButtonDisabled(action2, gameplay(), locale()), _v$66 = disabledReason() ? blockedReasonId : void 0;
-                              _v$61 !== _p$.e && setAttribute(_el$294, "data-testid", _p$.e = _v$61);
-                              _v$62 !== _p$.t && setAttribute(_el$294, "aria-label", _p$.t = _v$62);
-                              _v$63 !== _p$.a && className(_el$294, _p$.a = _v$63);
-                              _v$64 !== _p$.o && setAttribute(_el$294, "aria-busy", _p$.o = _v$64);
-                              _v$65 !== _p$.i && (_el$294.disabled = _p$.i = _v$65);
-                              _v$66 !== _p$.n && setAttribute(_el$294, "aria-describedby", _p$.n = _v$66);
+                              _v$61 !== _p$.e && setAttribute(_el$295, "data-testid", _p$.e = _v$61);
+                              _v$62 !== _p$.t && setAttribute(_el$295, "aria-label", _p$.t = _v$62);
+                              _v$63 !== _p$.a && className(_el$295, _p$.a = _v$63);
+                              _v$64 !== _p$.o && setAttribute(_el$295, "aria-busy", _p$.o = _v$64);
+                              _v$65 !== _p$.i && (_el$295.disabled = _p$.i = _v$65);
+                              _v$66 !== _p$.n && setAttribute(_el$295, "aria-describedby", _p$.n = _v$66);
                               return _p$;
                             }, {
                               e: void 0,
@@ -22010,7 +22144,7 @@ function WorldSummaryPanel(props = {}) {
                               i: void 0,
                               n: void 0
                             });
-                            return _el$293;
+                            return _el$294;
                           }
                         })];
                       }
@@ -22019,7 +22153,7 @@ function WorldSummaryPanel(props = {}) {
                 });
               }
             }));
-            return _el$276;
+            return _el$277;
           })(), createComponent(CalloutCard, {
             get title() {
               return tr(locale(), "未在此页暴露的动作", "Actions Not Exposed On This Page");
@@ -22028,20 +22162,20 @@ function WorldSummaryPanel(props = {}) {
             badgeClass: "badge badge--warn",
             get children() {
               return [(() => {
-                var _el$279 = _tmpl$9();
-                insert(_el$279, () => gameplay().assetGovernanceHandoff);
-                return _el$279;
-              })(), (() => {
-                var _el$280 = _tmpl$6();
-                insert(_el$280, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                var _el$280 = _tmpl$9();
+                insert(_el$280, () => gameplay().assetGovernanceHandoff);
                 return _el$280;
+              })(), (() => {
+                var _el$281 = _tmpl$6();
+                insert(_el$281, () => tr(locale(), "资产 / 治理相关能力请走单独 lane；这张主入口页面只保留正式玩法所需的最小动作面。", "Asset and governance actions stay on their dedicated lane; this primary entry only keeps the minimum surface needed for formal gameplay."));
+                return _el$281;
               })()];
             }
           })]
         });
       }
-    }), _el$226);
-    insert(_el$222, createComponent(Show, {
+    }), _el$227);
+    insert(_el$223, createComponent(Show, {
       get when() {
         return showPlayerSessionSurface();
       },
@@ -22058,8 +22192,8 @@ function WorldSummaryPanel(props = {}) {
           },
           get children() {
             return [(() => {
-              var _el$223 = _tmpl$8();
-              insert(_el$223, createComponent(Badge, {
+              var _el$224 = _tmpl$8();
+              insert(_el$224, createComponent(Badge, {
                 get ["class"]() {
                   return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
                 },
@@ -22067,23 +22201,23 @@ function WorldSummaryPanel(props = {}) {
                   return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
                 }
               }), null);
-              insert(_el$223, createComponent(Badge, {
+              insert(_el$224, createComponent(Badge, {
                 "class": "badge badge--accent",
                 get children() {
                   return `tier=${authSurface().currentTier}`;
                 }
               }), null);
-              insert(_el$223, createComponent(Badge, {
+              insert(_el$224, createComponent(Badge, {
                 get children() {
                   return `player=${state$1.auth.playerId || "-"}`;
                 }
               }), null);
-              insert(_el$223, createComponent(Badge, {
+              insert(_el$224, createComponent(Badge, {
                 get children() {
                   return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
                 }
               }), null);
-              return _el$223;
+              return _el$224;
             })(), createComponent(EmptyState, {
               get children() {
                 return hostedRecoveryHint()?.detail || state$1.auth.rebindNotice || authSurface().currentTierReason;
@@ -22113,21 +22247,21 @@ function WorldSummaryPanel(props = {}) {
                 return memo(() => !!state$1.auth.available)() && state$1.auth.source !== LEGACY_VIEWER_AUTH_BOOTSTRAP_SOURCE;
               },
               get children() {
-                var _el$224 = _tmpl$44(), _el$225 = _el$224.firstChild;
-                _el$225.$$click = () => {
+                var _el$225 = _tmpl$45(), _el$226 = _el$225.firstChild;
+                _el$226.$$click = () => {
                   void logoutHostedPlayerSession();
                 };
-                insert(_el$225, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-                return _el$224;
+                insert(_el$226, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+                return _el$225;
               }
             })];
           }
         });
       }
-    }), _el$226);
-    insert(_el$229, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
-    insert(_el$230, () => tr(locale(), "执行通道、认证/会话、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
-    insert(_el$231, createComponent(For, {
+    }), _el$227);
+    insert(_el$230, () => tr(locale(), "运行诊断", "Runtime Diagnostics"));
+    insert(_el$231, () => tr(locale(), "执行通道、认证/会话、托管矩阵与最近事件都收在这里，避免它们继续抢占主玩法首屏。", "Execution lanes, auth/session truth, hosted matrix, and recent events live here so they no longer dominate the primary gameplay viewport."));
+    insert(_el$232, createComponent(For, {
       get each() {
         return diagnosticsSummaryBadges();
       },
@@ -22136,7 +22270,7 @@ function WorldSummaryPanel(props = {}) {
         children: label
       })
     }));
-    insert(_el$232, createComponent(DirectorEntryCard, {
+    insert(_el$233, createComponent(DirectorEntryCard, {
       get controller() {
         return props.directorController;
       },
@@ -22144,28 +22278,28 @@ function WorldSummaryPanel(props = {}) {
       get onRequest() {
         return props.onRequestDirector;
       }
-    }), _el$233);
-    insert(_el$233, createComponent(Badge, {
+    }), _el$234);
+    insert(_el$234, createComponent(Badge, {
       get children() {
         return `ws=${state$1.wsUrl || "-"}`;
       }
     }), null);
-    insert(_el$233, createComponent(Badge, {
+    insert(_el$234, createComponent(Badge, {
       get children() {
         return `entryReason=${state$1.viewerReason || "-"}`;
       }
     }), null);
-    insert(_el$233, createComponent(Badge, {
+    insert(_el$234, createComponent(Badge, {
       get children() {
         return `renderer=${state$1.renderer || "n/a"}`;
       }
     }), null);
-    insert(_el$233, createComponent(Badge, {
+    insert(_el$234, createComponent(Badge, {
       get children() {
         return `controlProfile=${state$1.controlProfile}`;
       }
     }), null);
-    insert(_el$232, createComponent(PanelSection, {
+    insert(_el$233, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "执行通道", "Execution Lanes");
       },
@@ -22182,99 +22316,99 @@ function WorldSummaryPanel(props = {}) {
             });
           },
           children: (debug) => [(() => {
-            var _el$296 = _tmpl$8();
-            insert(_el$296, createComponent(Badge, {
+            var _el$297 = _tmpl$8();
+            insert(_el$297, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "selected agent lane"
             }), null);
-            insert(_el$296, createComponent(Badge, {
+            insert(_el$297, createComponent(Badge, {
               get children() {
                 return `provider=${debug().provider_mode || "-"}`;
               }
             }), null);
-            insert(_el$296, createComponent(Badge, {
+            insert(_el$297, createComponent(Badge, {
               get children() {
                 return `mode=${debug().execution_mode || "-"}`;
               }
             }), null);
-            insert(_el$296, createComponent(Badge, {
+            insert(_el$297, createComponent(Badge, {
               get children() {
                 return `env=${debug().environment_class || "-"}`;
               }
             }), null);
-            return _el$296;
+            return _el$297;
           })(), (() => {
-            var _el$297 = _tmpl$8();
-            insert(_el$297, createComponent(Badge, {
+            var _el$298 = _tmpl$8();
+            insert(_el$298, createComponent(Badge, {
               get children() {
                 return `obs=${debug().observation_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$297, createComponent(Badge, {
+            insert(_el$298, createComponent(Badge, {
               get children() {
                 return `act=${debug().action_schema_version || "-"}`;
               }
             }), null);
-            insert(_el$297, createComponent(Badge, {
+            insert(_el$298, createComponent(Badge, {
               get children() {
                 return `agentProfile=${debug().agent_profile || "-"}`;
               }
             }), null);
-            insert(_el$297, createComponent(Badge, {
+            insert(_el$298, createComponent(Badge, {
               get children() {
                 return `providerFallback=${debug().fallback_reason || "-"}`;
               }
             }), null);
-            return _el$297;
+            return _el$298;
           })(), createComponent(EmptyState, {
             "class": "flow-lift--tight",
             get children() {
               return tr(locale(), "上面的通道徽标表示 phase-1 期望执行契约；下面的提供方检查徽标表示 runtime_live 基于 /v1/provider/info 和 /v1/provider/health 的真实探测结果。", "Lane badges show the expected phase-1 execution contract. Provider check badges below show the actual runtime_live probe against /v1/provider/info and /v1/provider/health.");
             }
           }), (() => {
-            var _el$298 = _tmpl$8();
-            insert(_el$298, createComponent(Badge, {
+            var _el$299 = _tmpl$8();
+            insert(_el$299, createComponent(Badge, {
               "class": "badge badge--accent",
               children: "provider check"
             }), null);
-            insert(_el$298, createComponent(Badge, {
+            insert(_el$299, createComponent(Badge, {
               get children() {
                 return `status=${debug().provider_check_status || "-"}`;
               }
             }), null);
-            insert(_el$298, createComponent(Badge, {
+            insert(_el$299, createComponent(Badge, {
               get children() {
                 return `source=${debug().provider_check_source || "-"}`;
               }
             }), null);
-            insert(_el$298, createComponent(Badge, {
+            insert(_el$299, createComponent(Badge, {
               get children() {
                 return `fallback=${debug().provider_check_fallback_reason || "-"}`;
               }
             }), null);
-            return _el$298;
+            return _el$299;
           })(), createComponent(Show, {
             get when() {
               return debug().provider_check_error || debug().provider_reported_capabilities?.length || debug().provider_reported_supported_action_sets?.length;
             },
             get children() {
-              var _el$299 = _tmpl$8();
-              insert(_el$299, createComponent(Badge, {
+              var _el$300 = _tmpl$8();
+              insert(_el$300, createComponent(Badge, {
                 get children() {
                   return `actualCaps=${(debug().provider_reported_capabilities || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$299, createComponent(Badge, {
+              insert(_el$300, createComponent(Badge, {
                 get children() {
                   return `actualActions=${(debug().provider_reported_supported_action_sets || []).join(",") || "-"}`;
                 }
               }), null);
-              insert(_el$299, createComponent(Badge, {
+              insert(_el$300, createComponent(Badge, {
                 get children() {
                   return `checkError=${debug().provider_check_error || "-"}`;
                 }
               }), null);
-              return _el$299;
+              return _el$300;
             }
           }), createComponent(JsonBlock, {
             get value() {
@@ -22283,8 +22417,8 @@ function WorldSummaryPanel(props = {}) {
           })]
         });
       }
-    }), _el$234);
-    insert(_el$234, createComponent(Badge, {
+    }), _el$235);
+    insert(_el$235, createComponent(Badge, {
       get ["class"]() {
         return state$1.auth.available ? "badge badge--good" : "badge badge--warn";
       },
@@ -22292,71 +22426,71 @@ function WorldSummaryPanel(props = {}) {
         return `auth=${state$1.auth.available ? state$1.auth.registrationStatus || "ready" : "missing"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return `tier=${authSurface().currentTier}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `source=${authSurface().source}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `deploymentHint=${authSurface().deploymentHint}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `player=${state$1.auth.playerId || "-"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `pubkey=${state$1.auth.publicKey ? `${state$1.auth.publicKey.slice(0, 10)}…` : "-"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `epoch=${state$1.auth.sessionEpoch == null ? "-" : state$1.auth.sessionEpoch}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `runtime=${state$1.auth.runtimeStatus || "-"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `boundAgent=${state$1.auth.boundAgentId || "-"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return `requestedAgent=${state$1.auth.pendingRequestedAgentId || "-"}`;
       }
     }), null);
-    insert(_el$234, createComponent(Badge, {
+    insert(_el$235, createComponent(Badge, {
       get children() {
         return state$1.auth.pendingForceRebind ? "rebind=forcing" : "rebind=idle";
       }
     }), null);
-    insert(_el$235, createComponent(Show, {
+    insert(_el$236, createComponent(Show, {
       get when() {
         return memo(() => !!state$1.auth.available)() && state$1.auth.source !== LEGACY_VIEWER_AUTH_BOOTSTRAP_SOURCE;
       },
       get children() {
-        var _el$236 = _tmpl$45();
-        _el$236.$$click = () => {
+        var _el$237 = _tmpl$46();
+        _el$237.$$click = () => {
           void logoutHostedPlayerSession();
         };
-        insert(_el$236, () => tr(locale(), "释放玩家会话", "Release Player Session"));
-        return _el$236;
+        insert(_el$237, () => tr(locale(), "释放玩家会话", "Release Player Session"));
+        return _el$237;
       }
     }));
-    insert(_el$232, createComponent(Show, {
+    insert(_el$233, createComponent(Show, {
       get when() {
         return hostedRecoveryHint();
       },
@@ -22365,8 +22499,8 @@ function WorldSummaryPanel(props = {}) {
           return hint().detail;
         }
       })
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return memo(() => !!!state$1.auth.available)() && isHostedPublicJoinDeploymentMode(state$1.hostedAccess?.deployment_mode);
       },
@@ -22380,126 +22514,126 @@ function WorldSummaryPanel(props = {}) {
           codeId: "diag-hosted-login-code"
         });
       }
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return state$1.auth.recoveryErrorCode || state$1.auth.recoveryErrorMessage;
       },
       get children() {
-        var _el$237 = _tmpl$8();
-        insert(_el$237, createComponent(Badge, {
+        var _el$238 = _tmpl$8();
+        insert(_el$238, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `recoveryError=${state$1.auth.recoveryErrorCode || "-"}`;
           }
         }), null);
-        insert(_el$237, createComponent(Badge, {
+        insert(_el$238, createComponent(Badge, {
           get children() {
             return state$1.auth.recoveryErrorMessage || "-";
           }
         }), null);
-        return _el$237;
+        return _el$238;
       }
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return showRebindNotice();
       },
       get children() {
         return [(() => {
-          var _el$238 = _tmpl$8();
-          insert(_el$238, createComponent(Badge, {
+          var _el$239 = _tmpl$8();
+          insert(_el$239, createComponent(Badge, {
             "class": "badge badge--accent",
             children: "rebind"
           }), null);
-          insert(_el$238, createComponent(Badge, {
+          insert(_el$239, createComponent(Badge, {
             get children() {
               return `target=${state$1.auth.pendingRequestedAgentId || "-"}`;
             }
           }), null);
-          insert(_el$238, createComponent(Badge, {
+          insert(_el$239, createComponent(Badge, {
             get children() {
               return state$1.auth.pendingForceRebind ? "mode=force_rebind" : "mode=awaiting_retry";
             }
           }), null);
-          return _el$238;
+          return _el$239;
         })(), createComponent(EmptyState, {
           get children() {
             return tr(locale(), "玩家会话正在切换到请求的行动体；注册成功后，当前动作会继续执行。", "Player session is switching to the requested agent and the current action will continue after registration succeeds.");
           }
         })];
       }
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission;
       },
       children: (admission) => (() => {
-        var _el$300 = _tmpl$8();
-        insert(_el$300, createComponent(Badge, {
+        var _el$301 = _tmpl$8();
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `activeSlots=${admission().active_player_sessions}/${admission().max_player_sessions}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `effectiveSlots=${admission().effective_player_sessions == null ? "-" : `${admission().effective_player_sessions}/${admission().max_player_sessions}`}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `runtimeBound=${admission().runtime_bound_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `runtimeOnly=${admission().runtime_only_player_sessions ?? "-"}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `runtimeProbe=${admission().runtime_probe_status || "-"}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `issueBudget=${admission().remaining_issue_budget}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `leaseTTL=${admission().slot_lease_ttl_ms}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `issued=${admission().issued_players_total}`;
           }
         }), null);
-        insert(_el$300, createComponent(Badge, {
+        insert(_el$301, createComponent(Badge, {
           get children() {
             return `released=${admission().released_players_total}`;
           }
         }), null);
-        return _el$300;
+        return _el$301;
       })()
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return state$1.hostedAdmission?.runtime_probe_error;
       },
       get children() {
-        var _el$239 = _tmpl$8();
-        insert(_el$239, createComponent(Badge, {
+        var _el$240 = _tmpl$8();
+        insert(_el$240, createComponent(Badge, {
           "class": "badge badge--warn",
           get children() {
             return `runtimeProbeError=${state$1.hostedAdmission.runtime_probe_error}`;
           }
         }));
-        return _el$239;
+        return _el$240;
       }
-    }), _el$243);
-    insert(_el$232, createComponent(PanelSection, {
+    }), _el$244);
+    insert(_el$233, createComponent(PanelSection, {
       get title() {
         return tr(locale(), "会话阶梯", "Session Ladder");
       },
@@ -22509,8 +22643,8 @@ function WorldSummaryPanel(props = {}) {
             return authSurface().currentTierReason;
           }
         }), (() => {
-          var _el$240 = _tmpl$46();
-          insert(_el$240, createComponent(For, {
+          var _el$241 = _tmpl$47();
+          insert(_el$241, createComponent(For, {
             get each() {
               return authSurface().tiers;
             },
@@ -22529,10 +22663,10 @@ function WorldSummaryPanel(props = {}) {
               }
             })
           }));
-          return _el$240;
+          return _el$241;
         })(), (() => {
-          var _el$241 = _tmpl$8();
-          insert(_el$241, createComponent(Badge, {
+          var _el$242 = _tmpl$8();
+          insert(_el$242, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.prompt_control.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -22540,7 +22674,7 @@ function WorldSummaryPanel(props = {}) {
               return `prompt=${authSurface().capabilities.prompt_control.enabled ? "enabled" : authSurface().capabilities.prompt_control.code}`;
             }
           }), null);
-          insert(_el$241, createComponent(Badge, {
+          insert(_el$242, createComponent(Badge, {
             get ["class"]() {
               return authSurface().capabilities.agent_chat.enabled ? "badge badge--good" : "badge badge--warn";
             },
@@ -22548,21 +22682,21 @@ function WorldSummaryPanel(props = {}) {
               return `chat=${authSurface().capabilities.agent_chat.enabled ? "enabled" : authSurface().capabilities.agent_chat.code}`;
             }
           }), null);
-          insert(_el$241, createComponent(Badge, {
+          insert(_el$242, createComponent(Badge, {
             "class": "badge badge--warn",
             get children() {
               return `mainToken=${authSurface().capabilities.main_token_transfer.code}`;
             }
           }), null);
-          return _el$241;
+          return _el$242;
         })(), createComponent(EmptyState, {
           get children() {
             return authSurface().reconnect;
           }
         })];
       }
-    }), _el$243);
-    insert(_el$232, createComponent(Show, {
+    }), _el$244);
+    insert(_el$233, createComponent(Show, {
       get when() {
         return hostedActionMatrixView().length > 0;
       },
@@ -22577,8 +22711,8 @@ function WorldSummaryPanel(props = {}) {
                 return tr(locale(), "这里是启动器导出的托管公开加入真值面。质检应直接读取这些动作编号，而不是只靠按钮状态推断。", "This is the hosted public-join truth surface exported by the launcher. QA should read these action ids directly instead of inferring from button state alone.");
               }
             }), (() => {
-              var _el$242 = _tmpl$46();
-              insert(_el$242, createComponent(For, {
+              var _el$243 = _tmpl$47();
+              insert(_el$243, createComponent(For, {
                 get each() {
                   return hostedActionMatrixView();
                 },
@@ -22615,13 +22749,13 @@ function WorldSummaryPanel(props = {}) {
                   }
                 })
               }));
-              return _el$242;
+              return _el$243;
             })()];
           }
         });
       }
-    }), _el$243);
-    insert(_el$243, createComponent(MetricCard, {
+    }), _el$244);
+    insert(_el$244, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "提示词反馈", "Prompt Feedback");
       },
@@ -22646,7 +22780,7 @@ function WorldSummaryPanel(props = {}) {
         });
       }
     }), null);
-    insert(_el$243, createComponent(MetricCard, {
+    insert(_el$244, createComponent(MetricCard, {
       get label() {
         return tr(locale(), "聊天反馈", "Chat Feedback");
       },
@@ -22671,8 +22805,8 @@ function WorldSummaryPanel(props = {}) {
         });
       }
     }), null);
-    insert(_el$245, () => tr(locale(), "最近事件", "Recent Events"));
-    insert(_el$246, createComponent(Show, {
+    insert(_el$246, () => tr(locale(), "最近事件", "Recent Events"));
+    insert(_el$247, createComponent(Show, {
       get when() {
         return state$1.recentEvents.length > 0;
       },
@@ -22709,7 +22843,7 @@ function WorldSummaryPanel(props = {}) {
         });
       }
     }));
-    return _el$216;
+    return _el$217;
   })();
 }
 function InteractionPanel() {
@@ -22836,24 +22970,24 @@ function InteractionPanel() {
     },
     get fallback() {
       return memo(() => selectedTarget()?.kind === "location")() ? (() => {
-        var _el$357 = _tmpl$64(), _el$358 = _el$357.firstChild;
-        insert(_el$358, createComponent(Badge, {
+        var _el$358 = _tmpl$65(), _el$359 = _el$358.firstChild;
+        insert(_el$359, createComponent(Badge, {
           "class": "badge badge--accent",
           get children() {
             return tr(locale(), "当前核查目标", "Current Inspect Target");
           }
         }), null);
-        insert(_el$358, createComponent(Badge, {
+        insert(_el$359, createComponent(Badge, {
           get children() {
             return selectedTargetLabel();
           }
         }), null);
-        insert(_el$358, createComponent(Badge, {
+        insert(_el$359, createComponent(Badge, {
           get children() {
             return `location=${selectedTarget()?.id}`;
           }
         }), null);
-        insert(_el$357, createComponent(AgentContextLite, {
+        insert(_el$358, createComponent(AgentContextLite, {
           get model() {
             return selectedAgentContextModel();
           },
@@ -22864,7 +22998,7 @@ function InteractionPanel() {
             return selectedAgentContextFixtureMetadata();
           }
         }), null);
-        return _el$357;
+        return _el$358;
       })() : createComponent(Show, {
         get when() {
           return selectedAgentId$1();
@@ -22901,56 +23035,56 @@ function InteractionPanel() {
       });
     },
     get children() {
-      var _el$301 = _tmpl$63(), _el$302 = _el$301.firstChild, _el$303 = _el$302.firstChild, _el$304 = _el$303.firstChild, _el$305 = _el$304.firstChild;
-      _el$305.nextSibling;
-      var _el$307 = _el$304.nextSibling, _el$308 = _el$307.firstChild;
-      _el$308.nextSibling;
-      var _el$310 = _el$307.nextSibling, _el$311 = _el$310.firstChild;
-      _el$311.nextSibling;
-      var _el$314 = _el$302.nextSibling, _el$315 = _el$314.firstChild, _el$316 = _el$315.nextSibling, _el$325 = _el$314.nextSibling, _el$326 = _el$325.firstChild, _el$352 = _el$325.nextSibling, _el$353 = _el$352.firstChild;
-      insert(_el$302, createComponent(Badge, {
+      var _el$302 = _tmpl$64(), _el$303 = _el$302.firstChild, _el$304 = _el$303.firstChild, _el$305 = _el$304.firstChild, _el$306 = _el$305.firstChild;
+      _el$306.nextSibling;
+      var _el$308 = _el$305.nextSibling, _el$309 = _el$308.firstChild;
+      _el$309.nextSibling;
+      var _el$311 = _el$308.nextSibling, _el$312 = _el$311.firstChild;
+      _el$312.nextSibling;
+      var _el$315 = _el$303.nextSibling, _el$316 = _el$315.firstChild, _el$317 = _el$316.nextSibling, _el$326 = _el$315.nextSibling, _el$327 = _el$326.firstChild, _el$353 = _el$326.nextSibling, _el$354 = _el$353.firstChild;
+      insert(_el$303, createComponent(Badge, {
         "class": "badge badge--accent command-surface__target-secondary",
         get children() {
           return tr(locale(), "当前交互目标", "Current Target");
         }
-      }), _el$303);
-      insert(_el$302, createComponent(Badge, {
+      }), _el$304);
+      insert(_el$303, createComponent(Badge, {
         get children() {
           return selectedAgentLabel();
         }
-      }), _el$303);
-      insert(_el$302, createComponent(Badge, {
+      }), _el$304);
+      insert(_el$303, createComponent(Badge, {
         "class": "command-surface__target-secondary",
         get children() {
           return `agent=${agentId()}`;
         }
-      }), _el$303);
-      insert(_el$302, createComponent(Badge, {
+      }), _el$304);
+      insert(_el$303, createComponent(Badge, {
         get ["class"]() {
           return `${selectedAgentStatus().badgeClass} command-surface__target-secondary`;
         },
         get children() {
           return selectedAgentStatus().badge;
         }
-      }), _el$303);
-      insert(_el$302, createComponent(Badge, {
+      }), _el$304);
+      insert(_el$303, createComponent(Badge, {
         get ["class"]() {
           return `${chatControlsEnabled() ? "badge badge--good" : "badge badge--warn"} command-surface__target-secondary`;
         },
         get children() {
           return memo(() => !!chatControlsEnabled())() ? tr(locale(), "聊天可用", "Chat Ready") : tr(locale(), "聊天受限", "Chat Limited");
         }
-      }), _el$303);
-      insert(_el$305, () => tr(locale(), "状态", "Status"));
-      insert(_el$304, () => selectedAgentContextModel().state?.label || tr(locale(), "不可用", "Unavailable"), null);
-      insert(_el$308, () => tr(locale(), "新鲜度", "Freshness"));
-      insert(_el$307, () => selectedAgentContextModel().freshness?.label || tr(locale(), "不可用", "Unavailable"), null);
-      insert(_el$311, () => tr(locale(), "目标", "Objective"));
-      insert(_el$310, (() => {
+      }), _el$304);
+      insert(_el$306, () => tr(locale(), "状态", "Status"));
+      insert(_el$305, () => selectedAgentContextModel().state?.label || tr(locale(), "不可用", "Unavailable"), null);
+      insert(_el$309, () => tr(locale(), "新鲜度", "Freshness"));
+      insert(_el$308, () => selectedAgentContextModel().freshness?.label || tr(locale(), "不可用", "Unavailable"), null);
+      insert(_el$312, () => tr(locale(), "目标", "Objective"));
+      insert(_el$311, (() => {
         var _c$11 = memo(() => !!(selectedAgentContextModel().objective?.state === "published" && selectedAgentContextModel().objective.value));
         return () => _c$11() ? selectedAgentContextModel().objective.value : tr(locale(), "目标不可用", "Objective unavailable");
       })(), null);
-      insert(_el$301, createComponent(AgentContextLite, {
+      insert(_el$302, createComponent(AgentContextLite, {
         get model() {
           return selectedAgentContextModel();
         },
@@ -22960,8 +23094,8 @@ function InteractionPanel() {
         get fixtureMetadata() {
           return selectedAgentContextFixtureMetadata();
         }
-      }), _el$314);
-      insert(_el$301, createComponent(Show, {
+      }), _el$315);
+      insert(_el$302, createComponent(Show, {
         get when() {
           return memo(() => !!interactionEnabled())() && canControlSelectedAgent();
         },
@@ -22975,24 +23109,24 @@ function InteractionPanel() {
         },
         get children() {
           return [(() => {
-            var _el$313 = _tmpl$52();
-            insert(_el$313, createComponent(Badge, {
+            var _el$314 = _tmpl$53();
+            insert(_el$314, createComponent(Badge, {
               "class": "badge badge--good",
               get children() {
                 return authSurface().currentTier;
               }
             }), null);
-            insert(_el$313, createComponent(Badge, {
+            insert(_el$314, createComponent(Badge, {
               get children() {
                 return `player=${state.auth.playerId}`;
               }
             }), null);
-            insert(_el$313, createComponent(Badge, {
+            insert(_el$314, createComponent(Badge, {
               get children() {
                 return `source=${authSurface().source}`;
               }
             }), null);
-            return _el$313;
+            return _el$314;
           })(), createComponent(EmptyState, {
             "class": "command-surface__auth-boundary",
             get children() {
@@ -23000,21 +23134,21 @@ function InteractionPanel() {
             }
           })];
         }
-      }), _el$314);
-      insert(_el$315, () => tr(locale(), "能力诊断", "Capability Diagnostics"));
-      insert(_el$316, createComponent(Badge, {
+      }), _el$315);
+      insert(_el$316, () => tr(locale(), "能力诊断", "Capability Diagnostics"));
+      insert(_el$317, createComponent(Badge, {
         "class": "badge badge--diagnostic",
         get children() {
           return `boundPlayer=${binding()?.playerId || "-"}`;
         }
       }), null);
-      insert(_el$316, createComponent(Badge, {
+      insert(_el$317, createComponent(Badge, {
         "class": "badge badge--diagnostic",
         get children() {
           return `boundKey=${binding()?.publicKey ? `${binding().publicKey.slice(0, 10)}…` : "-"}`;
         }
       }), null);
-      insert(_el$316, createComponent(Badge, {
+      insert(_el$317, createComponent(Badge, {
         get ["class"]() {
           return promptControlsEnabled() ? "badge badge--good" : "badge badge--warn";
         },
@@ -23022,7 +23156,7 @@ function InteractionPanel() {
           return `prompt=${promptControlsEnabled() ? "enabled" : promptCapability().code || "agent_not_bound"}`;
         }
       }), null);
-      insert(_el$316, createComponent(Badge, {
+      insert(_el$317, createComponent(Badge, {
         get ["class"]() {
           return chatControlsEnabled() ? "badge badge--good" : "badge badge--warn";
         },
@@ -23030,7 +23164,7 @@ function InteractionPanel() {
           return `chat=${chatControlsEnabled() ? "enabled" : chatCapability().code || "agent_not_bound"}`;
         }
       }), null);
-      insert(_el$316, createComponent(Badge, {
+      insert(_el$317, createComponent(Badge, {
         get ["class"]() {
           return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
         },
@@ -23038,29 +23172,29 @@ function InteractionPanel() {
           return `mainToken=${assetLaneStatusText()}`;
         }
       }), null);
-      insert(_el$301, createComponent(Show, {
+      insert(_el$302, createComponent(Show, {
         get when() {
           return memo(() => !!(!starterOcGateOpen() && canControlSelectedAgent()))() && commandStarterOcAction();
         },
         children: (action2) => (() => {
-          var _el$359 = _tmpl$31(), _el$360 = _el$359.firstChild;
-          _el$360.$$click = () => renderGameplayAction(action2());
-          insert(_el$360, () => gameplayActionDisplayLabel(action2(), locale()));
+          var _el$360 = _tmpl$31(), _el$361 = _el$360.firstChild;
+          _el$361.$$click = () => renderGameplayAction(action2());
+          insert(_el$361, () => gameplayActionDisplayLabel(action2(), locale()));
           createRenderEffect((_p$) => {
             var _v$76 = gameplayActionButtonClass(action2()), _v$77 = gameplayActionButtonBusyAttrs(action2()), _v$78 = gameplayActionButtonDisabled(action2(), gameplaySummary(), locale());
-            _v$76 !== _p$.e && className(_el$360, _p$.e = _v$76);
-            _v$77 !== _p$.t && setAttribute(_el$360, "aria-busy", _p$.t = _v$77);
-            _v$78 !== _p$.a && (_el$360.disabled = _p$.a = _v$78);
+            _v$76 !== _p$.e && className(_el$361, _p$.e = _v$76);
+            _v$77 !== _p$.t && setAttribute(_el$361, "aria-busy", _p$.t = _v$77);
+            _v$78 !== _p$.a && (_el$361.disabled = _p$.a = _v$78);
             return _p$;
           }, {
             e: void 0,
             t: void 0,
             a: void 0
           });
-          return _el$359;
+          return _el$360;
         })()
-      }), _el$325);
-      insert(_el$301, createComponent(PanelSection, {
+      }), _el$326);
+      insert(_el$302, createComponent(PanelSection, {
         "class": "command-surface__chat-panel",
         get title() {
           return tr(locale(), "行动体聊天", "Agent Chat");
@@ -23073,29 +23207,29 @@ function InteractionPanel() {
         },
         get children() {
           return [(() => {
-            var _el$317 = _tmpl$53(), _el$318 = _el$317.firstChild, _el$319 = _el$318.nextSibling;
-            insert(_el$318, () => tr(locale(), "消息", "Message"));
-            _el$319.$$input = (event) => {
+            var _el$318 = _tmpl$54(), _el$319 = _el$318.firstChild, _el$320 = _el$319.nextSibling;
+            insert(_el$319, () => tr(locale(), "消息", "Message"));
+            _el$320.$$input = (event) => {
               state.chatDraft.message = String(event.currentTarget.value || "");
               state.chatDraft.dirty = true;
             };
             createRenderEffect((_p$) => {
               var _v$67 = tr(locale(), "给当前选中的行动体发一条消息", "Send a message to the selected agent"), _v$68 = !chatControlsEnabled();
-              _v$67 !== _p$.e && setAttribute(_el$319, "placeholder", _p$.e = _v$67);
-              _v$68 !== _p$.t && (_el$319.disabled = _p$.t = _v$68);
+              _v$67 !== _p$.e && setAttribute(_el$320, "placeholder", _p$.e = _v$67);
+              _v$68 !== _p$.t && (_el$320.disabled = _p$.t = _v$68);
               return _p$;
             }, {
               e: void 0,
               t: void 0
             });
-            createRenderEffect(() => _el$319.value = state.chatDraft.message);
-            return _el$317;
+            createRenderEffect(() => _el$320.value = state.chatDraft.message);
+            return _el$318;
           })(), (() => {
-            var _el$320 = _tmpl$54(), _el$321 = _el$320.firstChild;
-            _el$321.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
-            insert(_el$321, () => tr(locale(), "发送聊天", "Send Chat"));
-            createRenderEffect(() => _el$321.disabled = !chatControlsEnabled());
-            return _el$320;
+            var _el$321 = _tmpl$55(), _el$322 = _el$321.firstChild;
+            _el$322.$$click = () => sendAgentChat(agentId(), state.chatDraft.message);
+            insert(_el$322, () => tr(locale(), "发送聊天", "Send Chat"));
+            createRenderEffect(() => _el$322.disabled = !chatControlsEnabled());
+            return _el$321;
           })(), createComponent(Show, {
             get when() {
               return chatFeedback();
@@ -23116,9 +23250,9 @@ function InteractionPanel() {
               }
             })
           }), (() => {
-            var _el$322 = _tmpl$1(), _el$323 = _el$322.firstChild, _el$324 = _el$323.nextSibling;
-            insert(_el$323, () => tr(locale(), "消息流", "Message Flow"));
-            insert(_el$324, createComponent(Show, {
+            var _el$323 = _tmpl$1(), _el$324 = _el$323.firstChild, _el$325 = _el$324.nextSibling;
+            insert(_el$324, () => tr(locale(), "消息流", "Message Flow"));
+            insert(_el$325, createComponent(Show, {
               get when() {
                 return chatHistory().length > 0;
               },
@@ -23149,9 +23283,9 @@ function InteractionPanel() {
                     },
                     get children() {
                       return [(() => {
-                        var _el$361 = _tmpl$9();
-                        insert(_el$361, () => chatEntryMessage(entry, locale()));
-                        return _el$361;
+                        var _el$362 = _tmpl$9();
+                        insert(_el$362, () => chatEntryMessage(entry, locale()));
+                        return _el$362;
                       })(), createComponent(DiagnosticDetails, {
                         value: entry
                       })];
@@ -23160,30 +23294,30 @@ function InteractionPanel() {
                 });
               }
             }));
-            return _el$322;
+            return _el$323;
           })()];
         }
-      }), _el$325);
-      insert(_el$326, () => tr(locale(), "高级提示词设置", "Advanced Prompt Settings"));
-      insert(_el$325, createComponent(PanelSection, {
+      }), _el$326);
+      insert(_el$327, () => tr(locale(), "高级提示词设置", "Advanced Prompt Settings"));
+      insert(_el$326, createComponent(PanelSection, {
         "class": "command-surface__advanced-panel",
         get title() {
           return tr(locale(), "高级控制", "Advanced Controls");
         },
         get children() {
           return [(() => {
-            var _el$327 = _tmpl$8();
-            insert(_el$327, createComponent(Badge, {
+            var _el$328 = _tmpl$8();
+            insert(_el$328, createComponent(Badge, {
               get children() {
                 return `activePrompt=v${promptVersionState().currentVersion}`;
               }
             }), null);
-            insert(_el$327, createComponent(Badge, {
+            insert(_el$328, createComponent(Badge, {
               get children() {
                 return `nextRollback=v${promptVersionState().nextRollbackTargetVersion}`;
               }
             }), null);
-            insert(_el$327, createComponent(Show, {
+            insert(_el$328, createComponent(Show, {
               get when() {
                 return promptVersionState().restoredFromVersion != null;
               },
@@ -23195,7 +23329,7 @@ function InteractionPanel() {
                 });
               }
             }), null);
-            insert(_el$327, createComponent(Badge, {
+            insert(_el$328, createComponent(Badge, {
               get ["class"]() {
                 return promptOverridesVisible() ? "badge badge--good" : "badge";
               },
@@ -23203,26 +23337,26 @@ function InteractionPanel() {
                 return memo(() => !!promptOverridesVisible())() ? tr(locale(), "状态=已展开", "state=expanded") : tr(locale(), "状态=默认收起", "state=hidden_by_default");
               }
             }), null);
-            insert(_el$327, createComponent(Badge, {
+            insert(_el$328, createComponent(Badge, {
               get children() {
                 return tr(locale(), "本地设置持久化", "locally persisted");
               }
             }), null);
-            return _el$327;
+            return _el$328;
           })(), createComponent(EmptyState, {
             get children() {
               return promptSettingsSummary();
             }
           }), (() => {
-            var _el$328 = _tmpl$55(), _el$329 = _el$328.firstChild;
-            _el$329.$$click = () => togglePromptOverridesVisible();
-            insert(_el$329, promptSettingsButtonLabel);
-            createRenderEffect(() => _el$329.disabled = !canControlSelectedAgent());
-            return _el$328;
+            var _el$329 = _tmpl$56(), _el$330 = _el$329.firstChild;
+            _el$330.$$click = () => togglePromptOverridesVisible();
+            insert(_el$330, promptSettingsButtonLabel);
+            createRenderEffect(() => _el$330.disabled = !canControlSelectedAgent());
+            return _el$329;
           })()];
         }
       }), null);
-      insert(_el$325, createComponent(Show, {
+      insert(_el$326, createComponent(Show, {
         get when() {
           return promptOverridesVisible();
         },
@@ -23233,97 +23367,97 @@ function InteractionPanel() {
             },
             get children() {
               return [(() => {
-                var _el$330 = _tmpl$6();
-                insert(_el$330, () => promptVersionState().summary);
-                return _el$330;
-              })(), (() => {
                 var _el$331 = _tmpl$6();
-                insert(_el$331, () => promptVersionState().detail);
+                insert(_el$331, () => promptVersionState().summary);
                 return _el$331;
+              })(), (() => {
+                var _el$332 = _tmpl$6();
+                insert(_el$332, () => promptVersionState().detail);
+                return _el$332;
               })(), createComponent(Show, {
                 get when() {
                   return memo(() => !!authSurface().capabilities.prompt_control.enabled)() && isHostedPublicJoinDeploymentMode(state.hostedAccess?.deployment_mode);
                 },
                 get children() {
-                  var _el$332 = _tmpl$56(), _el$333 = _el$332.firstChild, _el$334 = _el$333.nextSibling;
-                  insert(_el$333, () => tr(locale(), "后端审批码", "Backend Approval Code"));
-                  _el$334.$$input = (event) => {
+                  var _el$333 = _tmpl$57(), _el$334 = _el$333.firstChild, _el$335 = _el$334.nextSibling;
+                  insert(_el$334, () => tr(locale(), "后端审批码", "Backend Approval Code"));
+                  _el$335.$$input = (event) => {
                     state.strongAuth.approvalCode = String(event.currentTarget.value || "");
                   };
-                  createRenderEffect(() => _el$334.value = state.strongAuth.approvalCode || "");
-                  return _el$332;
+                  createRenderEffect(() => _el$335.value = state.strongAuth.approvalCode || "");
+                  return _el$333;
                 }
               }), (() => {
-                var _el$335 = _tmpl$57(), _el$336 = _el$335.firstChild, _el$337 = _el$336.nextSibling;
-                insert(_el$336, () => tr(locale(), "系统提示词覆盖", "System Prompt Override"));
-                _el$337.$$input = (event) => {
+                var _el$336 = _tmpl$58(), _el$337 = _el$336.firstChild, _el$338 = _el$337.nextSibling;
+                insert(_el$337, () => tr(locale(), "系统提示词覆盖", "System Prompt Override"));
+                _el$338.$$input = (event) => {
                   state.promptDraft.systemPrompt = String(event.currentTarget.value || "");
                   state.promptDraft.dirty = true;
                 };
-                createRenderEffect(() => _el$337.disabled = !promptControlsEnabled());
-                createRenderEffect(() => _el$337.value = state.promptDraft.systemPrompt);
-                return _el$335;
+                createRenderEffect(() => _el$338.disabled = !promptControlsEnabled());
+                createRenderEffect(() => _el$338.value = state.promptDraft.systemPrompt);
+                return _el$336;
               })(), (() => {
-                var _el$338 = _tmpl$58(), _el$339 = _el$338.firstChild, _el$340 = _el$339.nextSibling;
-                insert(_el$339, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
-                _el$340.$$input = (event) => {
+                var _el$339 = _tmpl$59(), _el$340 = _el$339.firstChild, _el$341 = _el$340.nextSibling;
+                insert(_el$340, () => tr(locale(), "短期目标覆盖", "Short-Term Goal Override"));
+                _el$341.$$input = (event) => {
                   state.promptDraft.shortTermGoal = String(event.currentTarget.value || "");
                   state.promptDraft.dirty = true;
                 };
-                createRenderEffect(() => _el$340.disabled = !promptControlsEnabled());
-                createRenderEffect(() => _el$340.value = state.promptDraft.shortTermGoal);
-                return _el$338;
+                createRenderEffect(() => _el$341.disabled = !promptControlsEnabled());
+                createRenderEffect(() => _el$341.value = state.promptDraft.shortTermGoal);
+                return _el$339;
               })(), (() => {
-                var _el$341 = _tmpl$59(), _el$342 = _el$341.firstChild, _el$343 = _el$342.nextSibling;
-                insert(_el$342, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
-                _el$343.$$input = (event) => {
+                var _el$342 = _tmpl$60(), _el$343 = _el$342.firstChild, _el$344 = _el$343.nextSibling;
+                insert(_el$343, () => tr(locale(), "长期目标覆盖", "Long-Term Goal Override"));
+                _el$344.$$input = (event) => {
                   state.promptDraft.longTermGoal = String(event.currentTarget.value || "");
                   state.promptDraft.dirty = true;
                 };
-                createRenderEffect(() => _el$343.disabled = !promptControlsEnabled());
-                createRenderEffect(() => _el$343.value = state.promptDraft.longTermGoal);
-                return _el$341;
+                createRenderEffect(() => _el$344.disabled = !promptControlsEnabled());
+                createRenderEffect(() => _el$344.value = state.promptDraft.longTermGoal);
+                return _el$342;
               })(), (() => {
-                var _el$344 = _tmpl$60(), _el$345 = _el$344.firstChild, _el$346 = _el$345.nextSibling;
-                _el$345.$$click = () => sendPromptControl("preview", null);
-                insert(_el$345, () => tr(locale(), "预览提示词", "Preview Prompt"));
-                _el$346.$$click = () => sendPromptControl("apply", null);
-                insert(_el$346, () => tr(locale(), "应用提示词", "Apply Prompt"));
+                var _el$345 = _tmpl$61(), _el$346 = _el$345.firstChild, _el$347 = _el$346.nextSibling;
+                _el$346.$$click = () => sendPromptControl("preview", null);
+                insert(_el$346, () => tr(locale(), "预览提示词", "Preview Prompt"));
+                _el$347.$$click = () => sendPromptControl("apply", null);
+                insert(_el$347, () => tr(locale(), "应用提示词", "Apply Prompt"));
                 createRenderEffect((_p$) => {
                   var _v$69 = !promptControlsEnabled(), _v$70 = !promptControlsEnabled();
-                  _v$69 !== _p$.e && (_el$345.disabled = _p$.e = _v$69);
-                  _v$70 !== _p$.t && (_el$346.disabled = _p$.t = _v$70);
+                  _v$69 !== _p$.e && (_el$346.disabled = _p$.e = _v$69);
+                  _v$70 !== _p$.t && (_el$347.disabled = _p$.t = _v$70);
                   return _p$;
                 }, {
                   e: void 0,
                   t: void 0
                 });
-                return _el$344;
+                return _el$345;
               })(), (() => {
-                var _el$347 = _tmpl$61(), _el$348 = _el$347.firstChild, _el$349 = _el$348.firstChild, _el$350 = _el$349.nextSibling, _el$351 = _el$348.nextSibling;
-                insert(_el$349, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
-                _el$350.$$input = (event) => {
+                var _el$348 = _tmpl$62(), _el$349 = _el$348.firstChild, _el$350 = _el$349.firstChild, _el$351 = _el$350.nextSibling, _el$352 = _el$349.nextSibling;
+                insert(_el$350, () => tr(locale(), "下一次回滚目标版本", "Next Rollback Target Version"));
+                _el$351.$$input = (event) => {
                   const nextValue = Number(event.currentTarget.value || 0);
                   state.promptDraft.rollbackTargetVersion = Math.max(0, Math.floor(nextValue || 0));
                   requestRender();
                 };
-                _el$351.$$click = () => {
+                _el$352.$$click = () => {
                   sendPromptControl("rollback", {
                     toVersion: Number(state.promptDraft.rollbackTargetVersion || 0)
                   });
                 };
-                insert(_el$351, () => tr(locale(), "回滚提示词", "Rollback Prompt"));
+                insert(_el$352, () => tr(locale(), "回滚提示词", "Rollback Prompt"));
                 createRenderEffect((_p$) => {
                   var _v$71 = !promptControlsEnabled(), _v$72 = !promptControlsEnabled();
-                  _v$71 !== _p$.e && (_el$350.disabled = _p$.e = _v$71);
-                  _v$72 !== _p$.t && (_el$351.disabled = _p$.t = _v$72);
+                  _v$71 !== _p$.e && (_el$351.disabled = _p$.e = _v$71);
+                  _v$72 !== _p$.t && (_el$352.disabled = _p$.t = _v$72);
                   return _p$;
                 }, {
                   e: void 0,
                   t: void 0
                 });
-                createRenderEffect(() => _el$350.value = Number(state.promptDraft.rollbackTargetVersion || 0));
-                return _el$347;
+                createRenderEffect(() => _el$351.value = Number(state.promptDraft.rollbackTargetVersion || 0));
+                return _el$348;
               })(), createComponent(Show, {
                 get when() {
                   return promptFeedback();
@@ -23371,16 +23505,16 @@ function InteractionPanel() {
           });
         }
       }), null);
-      insert(_el$353, () => tr(locale(), "资产 / 治理通道", "Asset / Governance Lane"));
-      insert(_el$352, createComponent(PanelSection, {
+      insert(_el$354, () => tr(locale(), "资产 / 治理通道", "Asset / Governance Lane"));
+      insert(_el$353, createComponent(PanelSection, {
         "class": "command-surface__asset-panel",
         get title() {
           return tr(locale(), "后置能力", "Deferred Surface");
         },
         get children() {
           return [(() => {
-            var _el$354 = _tmpl$8();
-            insert(_el$354, createComponent(Badge, {
+            var _el$355 = _tmpl$8();
+            insert(_el$355, createComponent(Badge, {
               get ["class"]() {
                 return mainTokenTransferCapability().enabled ? "badge badge--good" : "badge badge--warn";
               },
@@ -23388,17 +23522,17 @@ function InteractionPanel() {
                 return `main_token_transfer=${assetLaneStatusText()}`;
               }
             }), null);
-            insert(_el$354, createComponent(Badge, {
+            insert(_el$355, createComponent(Badge, {
               get children() {
                 return `required_auth=${mainTokenTransferPolicy()?.required_auth || "-"}`;
               }
             }), null);
-            insert(_el$354, createComponent(Badge, {
+            insert(_el$355, createComponent(Badge, {
               get children() {
                 return `availability=${mainTokenTransferPolicy()?.availability || "-"}`;
               }
             }), null);
-            return _el$354;
+            return _el$355;
           })(), createComponent(EmptyState, {
             get children() {
               return assetLaneDetail();
@@ -23408,24 +23542,24 @@ function InteractionPanel() {
               return mainTokenTransferPolicy()?.reason || tr(locale(), "当前通道没有 main_token_transfer 的托管动作策略。", "No hosted action policy is available for main_token_transfer on this lane.");
             }
           }), (() => {
-            var _el$355 = _tmpl$62(), _el$356 = _el$355.firstChild;
-            insert(_el$356, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
-            return _el$355;
+            var _el$356 = _tmpl$63(), _el$357 = _el$356.firstChild;
+            insert(_el$357, () => tr(locale(), "主代币转账（这里暂未开放）", "Main Token Transfer (Not Exposed Here Yet)"));
+            return _el$356;
           })()];
         }
       }), null);
       createRenderEffect((_p$) => {
         var _v$73 = agentId(), _v$74 = String(chatHistory().length), _v$75 = tr(locale(), "指挥连续性摘要", "Command continuity summary");
-        _v$73 !== _p$.e && setAttribute(_el$301, "data-command-agent", _p$.e = _v$73);
-        _v$74 !== _p$.t && setAttribute(_el$301, "data-command-chat-history", _p$.t = _v$74);
-        _v$75 !== _p$.a && setAttribute(_el$303, "aria-label", _p$.a = _v$75);
+        _v$73 !== _p$.e && setAttribute(_el$302, "data-command-agent", _p$.e = _v$73);
+        _v$74 !== _p$.t && setAttribute(_el$302, "data-command-chat-history", _p$.t = _v$74);
+        _v$75 !== _p$.a && setAttribute(_el$304, "aria-label", _p$.a = _v$75);
         return _p$;
       }, {
         e: void 0,
         t: void 0,
         a: void 0
       });
-      return _el$301;
+      return _el$302;
     }
   });
 }
@@ -23468,19 +23602,19 @@ function DetailsPanel() {
   });
   const hasSnapshotDiagnostics = () => !!state.snapshot || !!state.metrics || !!state.hostedAccess;
   return (() => {
-    var _el$362 = _tmpl$66(), _el$363 = _el$362.firstChild, _el$364 = _el$363.nextSibling, _el$365 = _el$364.firstChild, _el$366 = _el$365.nextSibling, _el$367 = _el$366.nextSibling;
-    insert(_el$363, createComponent(Badge, {
+    var _el$363 = _tmpl$67(), _el$364 = _el$363.firstChild, _el$365 = _el$364.nextSibling, _el$366 = _el$365.firstChild, _el$367 = _el$366.nextSibling, _el$368 = _el$367.nextSibling;
+    insert(_el$364, createComponent(Badge, {
       "class": "badge badge--accent",
       get children() {
         return tr(locale(), "当前命令目标", "Current Command Target");
       }
     }), null);
-    insert(_el$363, createComponent(Badge, {
+    insert(_el$364, createComponent(Badge, {
       get children() {
         return selectedLabel();
       }
     }), null);
-    insert(_el$362, createComponent(Show, {
+    insert(_el$363, createComponent(Show, {
       get when() {
         return !hiddenSelectedAgent();
       },
@@ -23494,8 +23628,8 @@ function DetailsPanel() {
       get children() {
         return createComponent(InteractionPanel, {});
       }
-    }), _el$364);
-    insert(_el$362, createComponent(Show, {
+    }), _el$365);
+    insert(_el$363, createComponent(Show, {
       get when() {
         return hasVisibleSelectedObject();
       },
@@ -23526,35 +23660,35 @@ function DetailsPanel() {
         },
         value: () => clone(selected())
       })
-    }), _el$364);
-    insert(_el$365, () => tr(locale(), "世界规模", "World Scale"));
-    insert(_el$366, createComponent(Badge, {
+    }), _el$365);
+    insert(_el$366, () => tr(locale(), "世界规模", "World Scale"));
+    insert(_el$367, createComponent(Badge, {
       get children() {
         return `agents=${snapshotCounts().agents}`;
       }
     }), null);
-    insert(_el$366, createComponent(Badge, {
+    insert(_el$367, createComponent(Badge, {
       get children() {
         return `locations=${snapshotCounts().locations}`;
       }
     }), null);
-    insert(_el$366, createComponent(Badge, {
+    insert(_el$367, createComponent(Badge, {
       get children() {
         return `promptProfiles=${snapshotCounts().promptProfiles}`;
       }
     }), null);
-    insert(_el$366, createComponent(Badge, {
+    insert(_el$367, createComponent(Badge, {
       get children() {
         return `debugContexts=${snapshotCounts().executionDebugContexts}`;
       }
     }), null);
-    insert(_el$366, createComponent(Badge, {
+    insert(_el$367, createComponent(Badge, {
       get children() {
         return tr(locale(), "snapshot.config.space", "snapshot.config.space");
       }
     }), null);
-    insert(_el$367, worldMetaSummary);
-    insert(_el$364, createComponent(Show, {
+    insert(_el$368, worldMetaSummary);
+    insert(_el$365, createComponent(Show, {
       get when() {
         return hasSnapshotDiagnostics();
       },
@@ -23573,18 +23707,18 @@ function DetailsPanel() {
         });
       }
     }), null);
-    insert(_el$362, createComponent(Show, {
+    insert(_el$363, createComponent(Show, {
       get when() {
         return state.lastError;
       },
       get children() {
-        var _el$368 = _tmpl$65(), _el$369 = _el$368.firstChild, _el$370 = _el$369.nextSibling;
-        insert(_el$369, () => tr(locale(), "最近错误", "Last Error"));
-        insert(_el$370, () => state.lastError);
-        return _el$368;
+        var _el$369 = _tmpl$66(), _el$370 = _el$369.firstChild, _el$371 = _el$370.nextSibling;
+        insert(_el$370, () => tr(locale(), "最近错误", "Last Error"));
+        insert(_el$371, () => state.lastError);
+        return _el$369;
       }
     }), null);
-    return _el$362;
+    return _el$363;
   })();
 }
 function AppShell() {
@@ -23602,25 +23736,25 @@ function AppShell() {
   const starterOcGateOpen = () => shouldShowStarterOcRequiredGate(buildGameplaySummary(locale()));
   onMount(() => onCleanup(installViewerRouteController()));
   return (() => {
-    var _el$371 = _tmpl$67(), _el$372 = _el$371.firstChild, _el$373 = _el$372.firstChild, _el$374 = _el$373.firstChild, _el$375 = _el$374.nextSibling, _el$376 = _el$375.nextSibling, _el$377 = _el$376.nextSibling, _el$378 = _el$373.nextSibling, _el$379 = _el$372.nextSibling, _el$380 = _el$379.firstChild, _el$381 = _el$380.firstChild, _el$382 = _el$379.nextSibling, _el$383 = _el$382.firstChild, _el$384 = _el$383.firstChild, _el$385 = _el$384.nextSibling, _el$386 = _el$385.nextSibling, _el$387 = _el$386.nextSibling, _el$388 = _el$383.nextSibling;
-    insert(_el$371, createComponent(MobileJumpRail, {
+    var _el$372 = _tmpl$68(), _el$373 = _el$372.firstChild, _el$374 = _el$373.firstChild, _el$375 = _el$374.firstChild, _el$376 = _el$375.nextSibling, _el$377 = _el$376.nextSibling, _el$378 = _el$377.nextSibling, _el$379 = _el$374.nextSibling, _el$380 = _el$373.nextSibling, _el$381 = _el$380.firstChild, _el$382 = _el$381.firstChild, _el$383 = _el$380.nextSibling, _el$384 = _el$383.firstChild, _el$385 = _el$384.firstChild, _el$386 = _el$385.nextSibling, _el$387 = _el$386.nextSibling, _el$388 = _el$387.nextSibling, _el$389 = _el$384.nextSibling;
+    insert(_el$372, createComponent(MobileJumpRail, {
       locale,
       tr,
       "data-viewer-overlay": "navigation"
-    }), _el$372);
-    insert(_el$371, createComponent(SecondaryViewerNavigation, {
+    }), _el$373);
+    insert(_el$372, createComponent(SecondaryViewerNavigation, {
       locale,
       tr
-    }), _el$372);
-    insert(_el$371, createComponent(HostedLoginGate, {}), _el$372);
-    insert(_el$371, createComponent(StarterOcRequiredGate, {}), _el$372);
-    insert(_el$374, () => tr(locale(), "导航", "Navigate"));
-    insert(_el$375, () => tr(locale(), "目标", "Targets"));
-    insert(_el$376, () => tr(locale(), "先在 Targets 中锁定对象，再进入世界舞台或指挥面板。", "Lock onto a target in Targets first, then move into the stage or command surface."));
-    addEventListener(_el$377, "click", focusViewerAnchor);
-    insert(_el$377, () => tr(locale(), "返回世界", "Back to World"));
-    insert(_el$378, createComponent(TargetsPanel, {}));
-    insert(_el$381, createComponent(Show, {
+    }), _el$373);
+    insert(_el$372, createComponent(HostedLoginGate, {}), _el$373);
+    insert(_el$372, createComponent(StarterOcRequiredGate, {}), _el$373);
+    insert(_el$375, () => tr(locale(), "导航", "Navigate"));
+    insert(_el$376, () => tr(locale(), "目标", "Targets"));
+    insert(_el$377, () => tr(locale(), "先在 Targets 中锁定对象，再进入世界舞台或指挥面板。", "Lock onto a target in Targets first, then move into the stage or command surface."));
+    addEventListener(_el$378, "click", focusViewerAnchor);
+    insert(_el$378, () => tr(locale(), "返回世界", "Back to World"));
+    insert(_el$379, createComponent(TargetsPanel, {}));
+    insert(_el$382, createComponent(Show, {
       get when() {
         return diagnosticsVisualFixture();
       },
@@ -23635,13 +23769,13 @@ function AppShell() {
         });
       }
     }), null);
-    insert(_el$381, createComponent(WorldStageHero, {}), null);
-    insert(_el$381, createComponent(PixelWorldHost, {
+    insert(_el$382, createComponent(WorldStageHero, {}), null);
+    insert(_el$382, createComponent(PixelWorldHost, {
       get locale() {
         return locale();
       }
     }), null);
-    insert(_el$381, createComponent(Show, {
+    insert(_el$382, createComponent(Show, {
       get when() {
         return !diagnosticsVisualFixture();
       },
@@ -23656,19 +23790,19 @@ function AppShell() {
         });
       }
     }), null);
-    insert(_el$381, createComponent(WorldFeedSurface, {
+    insert(_el$382, createComponent(WorldFeedSurface, {
       core,
       locale,
       tr,
       onReloadSnapshot: () => reloadWorldFeedFromAuthoritativeSnapshot()
     }), null);
-    insert(_el$384, () => tr(locale(), "指挥与核查", "Command and Inspect"));
-    insert(_el$385, () => tr(locale(), "交互与明细", "Interact and Inspect"));
-    insert(_el$386, () => tr(locale(), "只有锁定目标后才进入 Command。聊天优先，提示词与对象核查继续后置。", "Enter Command only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
-    addEventListener(_el$387, "click", focusViewerAnchor);
-    insert(_el$387, () => tr(locale(), "返回世界", "Back to World"));
-    insert(_el$388, createComponent(DetailsPanel, {}));
-    insert(_el$371, createComponent(DirectorSurface, {
+    insert(_el$385, () => tr(locale(), "指挥与核查", "Command and Inspect"));
+    insert(_el$386, () => tr(locale(), "交互与明细", "Interact and Inspect"));
+    insert(_el$387, () => tr(locale(), "只有锁定目标后才进入 Command。聊天优先，提示词与对象核查继续后置。", "Enter Command only after locking a target. Chat comes first; prompt controls and raw inspection stay behind it."));
+    addEventListener(_el$388, "click", focusViewerAnchor);
+    insert(_el$388, () => tr(locale(), "返回世界", "Back to World"));
+    insert(_el$389, createComponent(DetailsPanel, {}));
+    insert(_el$372, createComponent(DirectorSurface, {
       get controller() {
         return directorSession.controller;
       },
@@ -23677,12 +23811,12 @@ function AppShell() {
     }), null);
     createRenderEffect((_p$) => {
       var _v$79 = starterOcGateOpen() ? "true" : void 0, _v$80 = starterOcGateOpen() ? true : void 0, _v$81 = starterOcGateOpen() ? "true" : void 0, _v$82 = starterOcGateOpen() ? true : void 0, _v$83 = starterOcGateOpen() ? "true" : void 0, _v$84 = starterOcGateOpen() ? true : void 0;
-      _v$79 !== _p$.e && setAttribute(_el$372, "aria-hidden", _p$.e = _v$79);
-      _v$80 !== _p$.t && (_el$372.inert = _p$.t = _v$80);
-      _v$81 !== _p$.a && setAttribute(_el$379, "aria-hidden", _p$.a = _v$81);
-      _v$82 !== _p$.o && (_el$379.inert = _p$.o = _v$82);
-      _v$83 !== _p$.i && setAttribute(_el$382, "aria-hidden", _p$.i = _v$83);
-      _v$84 !== _p$.n && (_el$382.inert = _p$.n = _v$84);
+      _v$79 !== _p$.e && setAttribute(_el$373, "aria-hidden", _p$.e = _v$79);
+      _v$80 !== _p$.t && (_el$373.inert = _p$.t = _v$80);
+      _v$81 !== _p$.a && setAttribute(_el$380, "aria-hidden", _p$.a = _v$81);
+      _v$82 !== _p$.o && (_el$380.inert = _p$.o = _v$82);
+      _v$83 !== _p$.i && setAttribute(_el$383, "aria-hidden", _p$.i = _v$83);
+      _v$84 !== _p$.n && (_el$383.inert = _p$.n = _v$84);
       return _p$;
     }, {
       e: void 0,
@@ -23692,7 +23826,7 @@ function AppShell() {
       i: void 0,
       n: void 0
     });
-    return _el$371;
+    return _el$372;
   })();
 }
 function viewerVisualFixtureNameFromQuery() {

--- a/crates/oasis7_viewer/viewer.js
+++ b/crates/oasis7_viewer/viewer.js
@@ -9375,6 +9375,12 @@ function installTestApi() {
     togglePromptOverridesVisible,
     setStrongAuthApprovalCode,
     injectSnapshot,
+    injectWorldFeedForTest(feed) {
+      if (!isTestApiEnabled() || getSearchParams().get("connect") !== "0") throw new Error("feed fixture requires test_api=1&connect=0");
+      worldFeedTransport.handleWorldFeed(clone(feed));
+      render();
+      return clone(state.worldFeed);
+    },
     injectRefineQuotePreflightForTest,
     injectProductValidationQuoteForTest,
     injectPowerSaleQuoteForTest,
@@ -9764,7 +9770,7 @@ function installPixelWorldHotspotPointerProbe({
   getHoverSelection,
   getHoveredHotspot
 }) {
-  if (typeof window === "undefined" || !["hotspot_tooltip", "recent_event_glyphs"].includes(fixtureName)) {
+  if (typeof window === "undefined" || !["hotspot_tooltip", "recent_event_glyphs", "routes_and_events"].includes(fixtureName)) {
     return () => {
     };
   }
@@ -9796,6 +9802,10 @@ function installPixelWorldHotspotPointerProbe({
       }));
       dispatchMove(point.clientX, point.clientY);
       await nextFrame();
+      for (let frame = 0; frame < 8 && getHoveredHotspot()?.id !== hotspot.id; frame += 1) {
+        dispatchMove(point.clientX, point.clientY);
+        await nextFrame();
+      }
       const visibleHotspot = getHoveredHotspot();
       return {
         ...receiptBase(),
@@ -9958,6 +9968,18 @@ function createPixelWorldRendererRouteSignals(route, signalFactory) {
   const [rendererFatal, setRendererFatal] = signalFactory(route.fatal);
   const [runtimeSource, setRuntimeSource] = signalFactory(route.source);
   return [rendererStatus, setRendererStatus, rendererFatal, setRendererFatal, runtimeSource, setRuntimeSource];
+}
+function pixelWorldRoutesAndEventsVisualFixture() {
+  const snapshot = pixelWorldSelectedBlockerVisualFixture();
+  const relation = { kind: "agent_assignment", status: "active", source_class: "runtime_projection", freshness: "current" };
+  snapshot.model.agents["agent-0"].relation = { ...relation };
+  snapshot.model.agents["agent-1"].relation = { ...relation };
+  snapshot.model.agents["agent-1"].pos = { x_cm: 37e5, y_cm: 23e5, z_cm: 0 };
+  snapshot.model.locations["loc-0"].pos = { x_cm: 43e5, y_cm: 31e5, z_cm: 0 };
+  snapshot.model.locations["loc-1"].pos = { x_cm: 52e5, y_cm: 265e4, z_cm: 0 };
+  snapshot.model.agent_player_bindings["agent-1"] = "player-one";
+  snapshot.model.agent_player_public_key_bindings["agent-1"] = snapshot.model.agent_player_public_key_bindings["agent-0"];
+  return snapshot;
 }
 function pixelWorldSelectedBlockerVisualFixture() {
   return {
@@ -10211,6 +10233,7 @@ function installPixelWorldVisualFixtureHook() {
     selected_blocker: () => clone(pixelWorldSelectedBlockerVisualFixture()),
     hotspot_tooltip: () => clone(pixelWorldSelectedBlockerVisualFixture()),
     recent_event_glyphs: () => clone(pixelWorldSelectedBlockerVisualFixture()),
+    routes_and_events: () => clone(pixelWorldRoutesAndEventsVisualFixture()),
     recommended_target: () => clone(pixelWorldRecommendedTargetVisualFixture()),
     module_visual_entities: () => clone(pixelWorldModuleVisualEntitiesFixture()),
     micro_depot_stock_runway: () => clone(pixelWorldMicroDepotStockRunwayVisualFixture())
@@ -10236,7 +10259,7 @@ function installPixelWorldVisualFixtureHook() {
       }
     };
   }
-  if (fixtureName === "recent_event_glyphs") {
+  if (["recent_event_glyphs", "routes_and_events"].includes(fixtureName)) {
     state.recentEvents = [
       { event_id: "resource-transfer-fixture", title: "Resource transfer completed", kind: "resource_transfer" },
       { event_id: "build-queue-fixture", title: "Build queue updated", kind: "build_queue" }
@@ -10255,6 +10278,10 @@ function installPixelWorldVisualFixtureHook() {
       ...model.agent_player_public_key_bindings || {},
       "agent-0": publicKey
     };
+    if (fixtureName === "routes_and_events") {
+      model.agent_player_bindings["agent-1"] = playerId;
+      model.agent_player_public_key_bindings["agent-1"] = publicKey;
+    }
     state.auth = {
       ...state.auth,
       available: true,
@@ -11442,6 +11469,19 @@ function PixelWorldHotspotTooltip(props) {
   });
 }
 delegateEvents(["mousemove", "keydown", "click"]);
+function forwardRendererTargetPointer(event) {
+  const canvas = event.currentTarget.closest(".pixel-world-canvas")?.querySelector("canvas");
+  if (!canvas) return;
+  canvas.dispatchEvent(new PointerEvent("pointerdown", {
+    clientX: event.clientX,
+    clientY: event.clientY,
+    pointerId: event.pointerId,
+    pointerType: event.pointerType,
+    button: event.button,
+    buttons: event.buttons,
+    isPrimary: event.isPrimary
+  }));
+}
 var _tmpl$$q = /* @__PURE__ */ template(`<button type=button class="pixel-world-entity pixel-world-renderer-target"data-renderer-target=true>`);
 function rendererEntityTargetStyle(entity, worldBounds, size, camera) {
   const {
@@ -11489,6 +11529,7 @@ function PixelWorldRendererTargets(props) {
         kind,
         id: entity.id
       }));
+      addEventListener(_el$, "pointerdown", forwardRendererTargetPointer);
       _el$.$$click = () => props.onSelect({
         kind,
         id: entity.id
@@ -11516,7 +11557,7 @@ function PixelWorldRendererTargets(props) {
     })()
   });
 }
-delegateEvents(["click"]);
+delegateEvents(["click", "pointerdown"]);
 var _tmpl$$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--goal">`), _tmpl$2$p = /* @__PURE__ */ template(`<div class="pixel-world-canvas__callout pixel-world-canvas__callout--blocker">`), _tmpl$3$m = /* @__PURE__ */ template(`<div class=pixel-world-canvas__selection>`), _tmpl$4$j = /* @__PURE__ */ template(`<div class="pixel-world-canvas pixel-world-canvas--rendered"><canvas id=pixel-world-embedded-runtime-canvas class=pixel-world-canvas__surface tabindex=0 role=img aria-describedby=pixel-world-canvas-accessible-summary width=960 height=540></canvas><div id=pixel-world-canvas-accessible-summary class=sr-only></div><div class=pixel-world-canvas__overlay>`), _tmpl$5$i = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__detail>`), _tmpl$6$c = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__changes data-receipt-changes=true>`), _tmpl$7$8 = /* @__PURE__ */ template(`<span>`), _tmpl$8$5 = /* @__PURE__ */ template(`<div class=pixel-world-action-receipt__meta><span>`), _tmpl$9$4 = /* @__PURE__ */ template(`<div data-viewer-overlay=receipt><div class=pixel-world-action-receipt__label></div><div class=pixel-world-action-receipt__body><div class=pixel-world-action-receipt__title></div><div class=pixel-world-action-receipt__summary>`), _tmpl$0$4 = /* @__PURE__ */ template(`<span class=pixel-world-command-cell__blocker-chip>`), _tmpl$1$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__detail>`), _tmpl$10$2 = /* @__PURE__ */ template(`<div class=pixel-world-command-cell__feedback data-primary-action-feedback=true aria-live=polite>`), _tmpl$11$1 = /* @__PURE__ */ template(`<span class="badge badge--accent">`), _tmpl$12$1 = /* @__PURE__ */ template(`<div id=viewer-decision-area class=pixel-world-decision-area data-viewer-decision-area=true><div class=pixel-world-command-strip data-viewer-overlay=next-move><div class="pixel-world-command-cell pixel-world-command-cell--next pixel-world-shell-region pixel-world-shell-region--primary"data-shell-region=next-move-primary><div class=pixel-world-command-cell__header><div class=pixel-world-command-cell__label></div></div><div class=pixel-world-command-cell__value></div><a class=pixel-world-command-cell__action data-primary-action=true aria-live=polite></a></div><div class="pixel-world-command-cell pixel-world-shell-region pixel-world-shell-region--supporting"data-shell-region=supporting-context><div class="pixel-world-shell-context-group pixel-world-shell-context-group--objective"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div></div><div class="pixel-world-shell-context-group pixel-world-shell-context-group--leverage"><div class=pixel-world-command-cell__label></div><div class=pixel-world-command-cell__value></div><div class=pixel-world-command-cell__detail></div><div class=pixel-world-shell-context-group__agent><span class=pixel-world-command-cell__label></span><strong></strong></div></div></div></div><div class="pixel-world-readout badge-row"><span></span><span></span><span class="badge badge--accent">`), _tmpl$13$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--tick"data-hud-priority=telemetry><span></span><strong></strong><em>`), _tmpl$14$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-hud data-focus-hud=true><div class=pixel-world-focus-hud__identity><div class=pixel-world-focus-hud__eyebrow></div><div class=pixel-world-focus-hud__title></div></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--prompt"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--mission"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-hud__cell pixel-world-focus-hud__cell--blocker"><span></span><strong></strong></div><div class=pixel-world-focus-controls><button type=button class="pixel-world-focus-control pixel-world-focus-control--primary"></button><button id=viewer-focus-exit type=button class="pixel-world-focus-control pixel-world-focus-control--quiet"></button><details class=pixel-world-focus-more-controls><summary></summary><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary"></button><button type=button class="pixel-world-focus-control pixel-world-focus-control--secondary">`), _tmpl$15$1 = /* @__PURE__ */ template(`<span class="badge badge--warn">`), _tmpl$16$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-cinematic data-focus-cinematic=true><div class=pixel-world-focus-cinematic__eyebrow></div><div class=pixel-world-focus-cinematic__title></div><div class=pixel-world-focus-cinematic__body></div><div class=badge-row><span class="badge badge--accent">`), _tmpl$17$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-rail__item pixel-world-focus-rail__item--blocker"data-focus-priority=blocker><span></span><strong>`), _tmpl$18$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail__item><span></span><strong>`), _tmpl$19$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-rail data-focus-rail=true><div class=pixel-world-focus-rail__label>`), _tmpl$20$1 = /* @__PURE__ */ template(`<span class=sr-only>`), _tmpl$21$1 = /* @__PURE__ */ template(`<div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--selected"data-selected=true><span></span><strong>`), _tmpl$22$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-minimap data-focus-minimap=true><div class=pixel-world-focus-minimap__label></div><div class=pixel-world-focus-minimap__grid></div><div class=pixel-world-focus-minimap__route></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--target"><span></span><strong></strong></div><div class="pixel-world-focus-minimap__node pixel-world-focus-minimap__node--agent"><span></span><strong></strong></div><div class=pixel-world-focus-minimap__meta><span></span><span></span><span></span><span>`), _tmpl$23$1 = /* @__PURE__ */ template(`<pre class=json>`), _tmpl$24$1 = /* @__PURE__ */ template(`<details class=diagnostic><summary>`), _tmpl$25$1 = /* @__PURE__ */ template(`<span class=badge>`), _tmpl$26$1 = /* @__PURE__ */ template(`<div class=badge-row><span class="badge badge--accent"></span><span class=badge></span><span>`), _tmpl$27$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-command-tray><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--target"><span></span><strong></strong><em></em></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--blocker"><span></span><strong></strong></div><div class="pixel-world-focus-command-chip pixel-world-focus-command-chip--receipt"><span></span><strong></strong></div><button type=button class="pixel-world-focus-command-chip pixel-world-focus-command-chip--primary"data-chat-send=1>`), _tmpl$28$1 = /* @__PURE__ */ template(`<div class=empty>`), _tmpl$29$1 = /* @__PURE__ */ template(`<div class="panel panel--nested"><div class=panel__header><div class="stack stack--compact"><div class=panel__eyebrow></div><div class=panel__title></div><div class=panel__meta-copy></div></div></div><div class="panel__body stack"><div class=field><label for=agent-chat-message></label><textarea id=agent-chat-message rows=2></textarea></div><div class=toolbar><button type=button data-chat-send=1></button></div><div><div class="panel__title panel__title--spaced"></div><div class=event-list>`), _tmpl$30$1 = /* @__PURE__ */ template(`<div id=viewer-command-console class="pixel-world-focus-command-surface stack">`), _tmpl$31$1 = /* @__PURE__ */ template(`<div class=feedback-detail>`), _tmpl$32$1 = /* @__PURE__ */ template(`<div class=feedback-card><div class=badge-row><span></span></div><div class=feedback-summary>`), _tmpl$33$1 = /* @__PURE__ */ template(`<div><div class=event-card__title><span></span></div><div class=event-card__meta></div><div class=feedback-summary>`), _tmpl$34$1 = /* @__PURE__ */ template(`<div class=pixel-world-host__summary><div class=pixel-world-host__summary-copy><div class=pixel-world-host__headline></div><div class=feedback-detail>`), _tmpl$35$1 = /* @__PURE__ */ template(`<div class="empty pixel-world-render-unavailable"data-viewer-overlay=renderer-unavailable>`), _tmpl$36$1 = /* @__PURE__ */ template(`<div class=pixel-world-focus-receipt>`), _tmpl$37$1 = /* @__PURE__ */ template(`<details id=viewer-focus-command-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--command"><summary></summary><div class=pixel-world-focus-drawer__body>`), _tmpl$38$1 = /* @__PURE__ */ template(`<div class=feedback-detail data-renderer-fatal>`), _tmpl$39$1 = /* @__PURE__ */ template(`<details class="diagnostic pixel-world-render-diagnostics"><summary></summary><div class="pixel-world-host__toolbar badge-row"><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class="badge badge--accent"></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><span class=badge></span><button type=button></button><button type=button></button><div class=feedback-detail>`), _tmpl$40$1 = /* @__PURE__ */ template(`<details id=viewer-focus-diagnostics-drawer class="pixel-world-focus-drawer pixel-world-focus-drawer--diagnostics"><summary></summary><div class=pixel-world-focus-drawer__body><div class=badge-row><span class=badge></span><span class=badge></span><span class=badge></span></div><div class="toolbar toolbar--spaced"><button type=button>`), _tmpl$41$1 = /* @__PURE__ */ template(`<div class="stack flow-top"><pre class=json>`), _tmpl$42$1 = /* @__PURE__ */ template(`<div data-viewer-overlay=world-hud><div class=pixel-world-focus-entry data-viewer-overlay=cinematic-entry><div id=pixel-world-focus-entry-hint class=pixel-world-focus-entry__hint></div><button type=button class=pixel-world-focus-entry__button aria-pressed=false></button></div><details class=diagnostic><summary>`), _tmpl$43$1 = /* @__PURE__ */ template(`<div>`), _tmpl$44$1 = /* @__PURE__ */ template(`<button type=button class=pixel-world-render-unavailable__retry>`);
 function tr$1(locale, zh, en) {
   return isLocaleZh(locale) ? zh : en;

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -580,6 +580,22 @@ body {
   background: rgba(15, 21, 17, 0.42);
 }
 
+.world-feed__event--major {
+  border-left-width: 3px;
+}
+
+.world-feed__event--severity-1 { border-left-color: rgba(141, 199, 170, 0.72); }
+.world-feed__event--severity-2 { border-left-color: rgba(174, 213, 198, 0.82); }
+.world-feed__event--severity-3 { border-left-color: rgba(250, 204, 21, 0.82); }
+.world-feed__event--severity-4 { border-left-color: rgba(245, 158, 11, 0.92); }
+.world-feed__event--severity-5 { border-left-color: rgba(229, 143, 118, 0.98); }
+.world-feed__event--lifecycle-resolved { border-left-style: dashed; }
+.world-feed__event--lifecycle-timed_out { border-left-style: dotted; }
+.world-feed__major-event-status {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 .world-feed__receipt-link {
   display: inline-block;
   margin-top: 6px;
@@ -604,6 +620,65 @@ body {
   display: grid;
   min-width: 0;
   gap: 8px;
+}
+
+.pixel-world-readout {
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.pixel-world-readout__connection,
+.pixel-world-readout__feed {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.pixel-world-readout__connection::before,
+.pixel-world-readout__feed::before {
+  display: inline-block;
+  margin-right: 5px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.pixel-world-readout__connection--online::before,
+.pixel-world-readout__feed--live::before { content: "•"; }
+.pixel-world-readout__connection--connecting::before,
+.pixel-world-readout__connection--reconnecting::before,
+.pixel-world-readout__feed--syncing::before { content: "↻"; }
+.pixel-world-readout__connection--offline::before,
+.pixel-world-readout__connection--closed::before,
+.pixel-world-readout__feed--gap::before,
+.pixel-world-readout__feed--stale::before,
+.pixel-world-readout__feed--unavailable::before { content: "!"; }
+.pixel-world-readout__feed--replay::before { content: "↺"; }
+.pixel-world-readout__feed--empty::before { content: "—"; }
+
+.pixel-world-canvas__sparse-guidance {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px 10px;
+  min-width: 0;
+  padding: 7px 9px;
+  border: 1px dashed rgba(141, 199, 170, 0.3);
+  border-radius: 8px;
+  background: rgba(7, 12, 18, 0.58);
+  color: var(--muted-strong);
+  font-size: 10px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.pixel-world-canvas__sparse-title {
+  grid-column: 1 / -1;
+  color: var(--text);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .pixel-world-action-receipt__changes {
@@ -1178,6 +1253,10 @@ body {
     left: 10px;
   }
 
+  [data-viewer-shell="player-fullscreen"] [data-viewer-overlay="cinematic-entry"] {
+    top: 80px;
+  }
+
   [data-viewer-overlay="renderer-unavailable"] {
     top: 158px;
     left: 10px;
@@ -1208,8 +1287,9 @@ body {
   }
 
   [data-viewer-shell="player-fullscreen"] .pixel-world-readout {
-    display: none;
-    top: 132px;
+    position: static;
+    display: flex;
+    max-width: none;
   }
 
   [data-viewer-overlay="feed"] {
@@ -1531,8 +1611,20 @@ body {
     z-index: auto;
     width: max-content;
     max-width: 100%;
-    margin: 0;
+    margin: 0 0 0 auto;
     pointer-events: none;
+  }
+
+  [data-viewer-overlay="world-hud"] .pixel-world-canvas__selection {
+    top: 264px;
+    left: 10px;
+    right: auto;
+    max-height: 42px;
+    z-index: 20;
+  }
+
+  .pixel-world-canvas__sparse-guidance {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .pixel-world-entity {
@@ -1561,6 +1653,9 @@ body {
   flex-direction: column;
   gap: 2px;
   overflow: visible;
+  min-width: 44px;
+  min-height: 44px;
+  box-sizing: border-box;
 }
 
 .pixel-world-entity[data-selected="true"] {

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -202,6 +202,11 @@ body {
   width: min(560px, calc(100vw - 48px));
   max-height: calc(100dvh - 120px);
   overflow: auto;
+  background: #141d19;
+  border: 1px solid rgba(152, 177, 150, 0.34);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  overscroll-behavior: contain;
 }
 
 [data-viewer-overlay="next-move"] {
@@ -1282,14 +1287,14 @@ body {
   }
 
   [data-viewer-overlay="renderer-unavailable"] {
-    top: 158px;
+    top: calc(132px + min(20dvh, 128px) + 8px);
     left: 10px;
     right: 10px;
     max-width: calc(100vw - 20px);
   }
 
   [data-viewer-overlay="world-hud"] .pixel-world-render-diagnostics[data-renderer-state="unavailable"] {
-    top: 232px;
+    top: calc(132px + min(20dvh, 128px) + 120px);
     left: 10px;
     right: 10px;
     max-width: calc(100vw - 20px);
@@ -1717,4 +1722,20 @@ body {
     bottom: 10px;
     width: auto;
   }
+}
+
+/* Expanded details form one opaque reading surface over the map and Feed. */
+[data-viewer-overlay="world-summary"] #viewer-gameplay-details[open] > summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+}
+[data-viewer-overlay="world-summary"] #viewer-gameplay-details[open] > summary > .badge {
+  justify-self: start;
+  max-width: 100%;
+  white-space: normal;
+}
+.pixel-world-render-unavailable__retry {
+  min-height: 44px;
 }

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -1207,6 +1207,30 @@ body {
   }
 }
 
+.pixel-world-host:has([data-renderer-projection="true"]) > .pixel-world-decision-area {
+  position: absolute;
+  left: 16px;
+  right: auto;
+  bottom: 16px;
+  width: min(760px, calc(100% - 32px));
+  max-height: var(--renderer-decision-max-height, calc(50dvh - 76px));
+  overflow-y: auto;
+  align-content: start;
+  pointer-events: auto;
+}
+.pixel-world-host:has([data-renderer-projection="true"]) > .pixel-world-decision-area > [data-viewer-overlay],
+.pixel-world-host:has([data-renderer-projection="true"]) > .pixel-world-decision-area > .pixel-world-readout,
+.pixel-world-host:has([data-renderer-projection="true"]) > .pixel-world-decision-area > .pixel-world-canvas__sparse-guidance,
+.pixel-world-host:has([data-renderer-projection="true"]) > .pixel-world-decision-area > .pixel-world-canvas__legend {
+  position: static;
+  inset: auto;
+  width: auto;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  overflow: visible;
+}
+
 @media (max-width: 640px) {
   #viewer-details-panel {
     --command-route-chrome-height: 118px;
@@ -1662,4 +1686,35 @@ body {
   min-width: 44px;
   min-height: 44px;
   box-sizing: border-box;
+}
+
+/* WASM owns visible entity and hotspot pixels. These transparent controls keep
+ * keyboard/touch access at the same camera-projected point. */
+[data-viewer-overlay="world-hud"] [data-renderer-projection="true"] .pixel-world-canvas__overlay {
+  pointer-events: none;
+}
+[data-renderer-projection="true"] [data-renderer-target="true"] {
+  pointer-events: auto;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  outline: none;
+}
+[data-renderer-projection="true"] [data-renderer-target="true"]:focus-visible {
+  outline: 2px solid #edf1e6;
+  outline-offset: 2px;
+}
+[data-renderer-projection="true"] .pixel-world-hotspot__glyph {
+  visibility: hidden;
+}
+
+@media (max-width: 640px) {
+  /* Keep the renderer's centered selection visible. The decision stack scrolls
+   * below the map instead of moving an accessible world target away from it. */
+  .pixel-world-host:has([data-renderer-projection="true"]) .pixel-world-decision-area {
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    width: auto;
+  }
 }

--- a/crates/oasis7_viewer/viewer_terminal_shell.css
+++ b/crates/oasis7_viewer/viewer_terminal_shell.css
@@ -474,6 +474,28 @@ body {
   flex: 0 0 auto;
 }
 
+.world-feed__latest {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 5px 8px;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.world-feed__latest-copy {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.world-feed__latest--empty {
+  color: var(--muted);
+}
+
 .world-feed__summary::-webkit-details-marker {
   display: none;
 }
@@ -574,6 +596,144 @@ body {
 .world-feed__empty {
   color: var(--muted);
   font-size: 13px;
+}
+
+/* Player clarity surfaces: the inline canonical document stays within its
+   structure budget while this loaded stylesheet owns the visual treatment. */
+.pixel-world-decision-area {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+}
+
+.pixel-world-action-receipt__changes {
+  color: rgba(174, 213, 198, 0.9);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.pixel-world-command-cell__feedback {
+  color: var(--muted-strong);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.stage-hero__secondary-action {
+  opacity: 0.72;
+}
+
+.stage-hero__secondary-action .callout {
+  border-color: rgba(152, 177, 150, 0.2);
+  background: rgba(255, 255, 255, 0.018);
+  box-shadow: none;
+}
+
+.stage-hero__secondary-action .toolbar button {
+  min-height: 36px;
+  padding-inline: 12px;
+  font-size: 12px;
+}
+
+.pixel-world-fragment-terrain--associated {
+  opacity: 0.98;
+  box-shadow:
+    inset 0 0 0 2px rgba(250, 204, 21, 0.7),
+    0 0 28px rgba(250, 204, 21, 0.42);
+}
+
+.pixel-world-fragment-terrain--muted {
+  opacity: 0.2;
+  filter: saturate(0.35);
+}
+
+.pixel-world-route--associated {
+  opacity: 1;
+  box-shadow: 0 0 22px rgba(250, 204, 21, 0.62), 0 0 4px rgba(255, 255, 255, 0.28);
+}
+
+.pixel-world-route--muted,
+.pixel-world-route-waypoint--muted {
+  opacity: 0.2 !important;
+  filter: saturate(0.35);
+}
+
+.pixel-world-route-waypoint--associated {
+  border-color: rgba(250, 204, 21, 0.98);
+  box-shadow: 0 0 22px rgba(250, 204, 21, 0.72);
+}
+
+.pixel-world-entity__code {
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.pixel-world-canvas__legend {
+  position: absolute;
+  top: 96px;
+  left: 16px;
+  z-index: 12;
+  display: grid;
+  gap: 5px;
+  min-width: 128px;
+  padding: 8px 10px;
+  border: 1px solid rgba(141, 199, 170, 0.28);
+  border-radius: 7px;
+  background: rgba(7, 12, 18, 0.8);
+  box-shadow: var(--shadow-inset-stage), 0 8px 18px rgba(0, 0, 0, 0.18);
+  color: var(--muted-strong);
+  font-size: 10px;
+  line-height: 1.2;
+  pointer-events: none;
+}
+
+.pixel-world-canvas__legend-title {
+  color: var(--text);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.pixel-world-canvas__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.pixel-world-canvas__legend-swatch {
+  width: 14px;
+  min-width: 14px;
+  height: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.pixel-world-canvas__legend-item--route .pixel-world-canvas__legend-swatch {
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(141, 199, 170, 0.94);
+  box-shadow: 0 0 8px rgba(141, 199, 170, 0.55);
+}
+
+.pixel-world-canvas__legend-item--goal .pixel-world-canvas__legend-swatch { color: rgba(250, 204, 21, 0.96); }
+.pixel-world-canvas__legend-item--blocker .pixel-world-canvas__legend-swatch { color: rgba(229, 143, 118, 0.98); }
+.pixel-world-canvas__legend-item--resource .pixel-world-canvas__legend-swatch { color: rgba(110, 231, 183, 0.98); }
+
+.pixel-world-host--focus > .pixel-world-decision-area {
+  display: none;
 }
 
 .agent-activity,
@@ -770,6 +930,18 @@ body {
     min-height: 100dvh;
     width: 100%;
     overflow-x: hidden;
+  }
+
+  .pixel-world-command-cell__action {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 10px;
+  }
+
+  .pixel-world-entity {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 4px;
   }
 
   #viewer-stage-panel[data-viewer-map-layer="base"] {
@@ -1001,7 +1173,7 @@ body {
   }
 
   [data-viewer-overlay="cinematic-entry"] {
-    top: 64px;
+    top: 80px;
     right: auto;
     left: 10px;
   }
@@ -1037,7 +1209,7 @@ body {
 
   [data-viewer-shell="player-fullscreen"] .pixel-world-readout {
     display: none;
-    top: 112px;
+    top: 132px;
   }
 
   [data-viewer-overlay="feed"] {
@@ -1268,4 +1440,131 @@ body {
     bottom: calc(48px + 16px + min(42dvh, calc(100dvh - 72px - min(12dvh, 48px) - 16px - 8px - 96px)) + 8px);
     max-height: calc(100dvh - 72px - 48px - 16px - min(42dvh, calc(100dvh - 72px - min(12dvh, 48px) - 16px - 8px - 96px)) - 8px);
   }
+}
+
+/* Keep the player decision stack in one layout context on narrow screens.
+ * The map remains the visual backdrop, while command, context, receipt, and
+ * legend occupy a single bottom anchored flow so a long receipt can grow and
+ * scroll with the decision surface instead of being clipped by a second
+ * viewport overlay. */
+@media (max-width: 640px) {
+  /* Feed is a compact, scrollable context band below the top chrome. Keep it
+   * above the map backdrop but outside the bottom decision/receipt band. */
+  .stack > [data-viewer-overlay="feed"] {
+    position: absolute;
+    top: 132px;
+    right: 10px;
+    bottom: auto;
+    left: 10px;
+    width: auto;
+    max-width: none;
+    max-height: min(20dvh, 128px);
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  .stack > [data-viewer-overlay="feed"][open] {
+    position: absolute;
+    top: 132px;
+    bottom: auto;
+    max-height: min(20dvh, 128px);
+  }
+
+  .pixel-world-decision-area {
+    position: absolute;
+    z-index: 25;
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    max-height: calc(100dvh - 276px);
+    overflow-x: visible;
+    overflow-y: auto;
+    align-content: start;
+    gap: 8px;
+    scroll-padding-block: 8px;
+    pointer-events: auto;
+  }
+
+  .pixel-world-decision-area > [data-viewer-overlay="next-move"],
+  .pixel-world-decision-area > [data-viewer-overlay="receipt"] {
+    position: static;
+    inset: auto;
+    width: auto;
+    max-width: none;
+    max-height: none;
+    height: auto;
+    overflow: visible;
+  }
+
+  .pixel-world-decision-area > [data-viewer-overlay="next-move"] {
+    grid-template-columns: 1fr;
+    padding: 0;
+    gap: 8px;
+  }
+
+  .pixel-world-decision-area .pixel-world-command-cell,
+  .pixel-world-decision-area [data-shell-region="supporting-context"] {
+    min-height: 0;
+    height: auto;
+    overflow: visible;
+  }
+
+  .pixel-world-decision-area [data-shell-region="supporting-context"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+
+  .pixel-world-decision-area > [data-viewer-overlay="receipt"] {
+    min-height: 0;
+    padding: 10px 12px;
+    overflow-wrap: anywhere;
+  }
+
+  .pixel-world-decision-area .pixel-world-command-cell__action,
+  [data-viewer-overlay="cinematic-entry"] .pixel-world-focus-entry__button {
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  .pixel-world-decision-area .pixel-world-canvas__legend {
+    position: static;
+    z-index: auto;
+    width: max-content;
+    max-width: 100%;
+    margin: 0;
+    pointer-events: none;
+  }
+
+  .pixel-world-entity {
+    flex-direction: column;
+    gap: 2px;
+    min-width: 44px;
+    min-height: 44px;
+    height: auto;
+    padding: 4px;
+    overflow: visible;
+  }
+
+  .pixel-world-entity[data-selected="true"] {
+    min-width: 44px;
+    min-height: 44px;
+    width: auto;
+    height: auto;
+  }
+
+}
+
+/* Markers stay terse; selected and hover context stays in the safe HUD callouts
+ * so identity remains collision-free without turning the map into a wall of
+ * names. */
+.pixel-world-entity {
+  flex-direction: column;
+  gap: 2px;
+  overflow: visible;
+}
+
+.pixel-world-entity[data-selected="true"] {
+  min-width: 44px;
+  min-height: 44px;
+  box-sizing: border-box;
 }

--- a/crates/pixel_world_bridge/src/facility_signature.rs
+++ b/crates/pixel_world_bridge/src/facility_signature.rs
@@ -1,0 +1,15 @@
+use super::*;
+
+/// Passive visuals invalidate content without changing camera or hit authority.
+pub(super) fn hash_visuals(hasher: &mut DefaultHasher, facilities: &[MicroDepotFacility]) {
+    facilities.len().hash(hasher);
+    for facility in facilities {
+        facility.id.hash(hasher);
+        hash_position(hasher, &facility.pos);
+        facility.status.hash(hasher);
+        hash_f64(hasher, facility.service_radius_cm);
+        facility.available_units_by_kind.hash(hasher);
+        facility.throughput_remaining_units.hash(hasher);
+        facility.throughput_limit_units_per_epoch.hash(hasher);
+    }
+}

--- a/crates/pixel_world_bridge/src/lib.rs
+++ b/crates/pixel_world_bridge/src/lib.rs
@@ -16,6 +16,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
 mod host_state;
+mod presentation_clock;
 mod render;
 #[path = "lib_test_hit_targets.rs"]
 mod test_hit_targets;
@@ -344,6 +345,7 @@ enum InputEvent {
 
 #[derive(Default)]
 struct BridgeSharedState {
+    reduced_motion: bool,
     booted: bool,
     mounted: bool,
     canvas_selector: Option<String>,
@@ -359,6 +361,7 @@ struct BridgeSharedState {
 
 #[derive(Resource, Default)]
 struct BevyRuntimeState {
+    reduced_motion: bool,
     mounted: bool,
     render_state: Option<RenderState>,
     render_version: u64,
@@ -1021,6 +1024,7 @@ fn sync_external_state(mut runtime: ResMut<BevyRuntimeState>) {
     }
     runtime.needs_reconcile |= has_input;
     let animation_version = shared_animation_version();
+    runtime.reduced_motion = BRIDGE_SHARED.with(|shared| shared.borrow().reduced_motion);
     runtime.animation_dirty |= animation_version != runtime.animation_version;
     if runtime.animation_dirty {
         runtime.animation_version = animation_version;
@@ -1106,19 +1110,6 @@ impl PixelWorldBridge {
             shared.render_version += 1;
         });
         status_value("ready")
-    }
-
-    #[wasm_bindgen]
-    pub fn tick(&mut self, _animation_ms: f64) -> JsValue {
-        if self.mounted {
-            BRIDGE_SHARED.with(|shared| {
-                let mut shared = shared.borrow_mut();
-                shared.animation_version = shared.animation_version.wrapping_add(1);
-            });
-            status_value("ready")
-        } else {
-            status_value("detached")
-        }
     }
 
     #[wasm_bindgen]

--- a/crates/pixel_world_bridge/src/lib.rs
+++ b/crates/pixel_world_bridge/src/lib.rs
@@ -15,6 +15,7 @@ use serde_wasm_bindgen::{Serializer, from_value};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
+mod facility_signature;
 mod host_state;
 mod presentation_clock;
 mod render;
@@ -783,6 +784,7 @@ fn render_signature(render_state: Option<&RenderState>, mode: RenderSignatureMod
 
     if matches!(mode, RenderSignatureMode::Content) {
         hash_social_links(&mut hasher, &render_state.social_links);
+        facility_signature::hash_visuals(&mut hasher, &render_state.micro_depot_facilities);
     }
 
     render_state.visual_hotspots.len().hash(&mut hasher);

--- a/crates/pixel_world_bridge/src/lib.rs
+++ b/crates/pixel_world_bridge/src/lib.rs
@@ -743,6 +743,9 @@ fn render_signature(render_state: Option<&RenderState>, mode: RenderSignatureMod
         hash_position(&mut hasher, &fragment.pos);
         hash_f64(&mut hasher, fragment.footprint_cm);
         fragment.color.hash(&mut hasher);
+        if matches!(mode, RenderSignatureMode::Content) {
+            fragment.dominant_compound.hash(&mut hasher);
+        }
         hash_f64(&mut hasher, fragment.emphasis.unwrap_or(0.0));
     }
 

--- a/crates/pixel_world_bridge/src/presentation_clock.rs
+++ b/crates/pixel_world_bridge/src/presentation_clock.rs
@@ -1,0 +1,30 @@
+//! Presentation-only animation clock and motion preference controls.
+use super::{BRIDGE_SHARED, PixelWorldBridge, status_value};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl PixelWorldBridge {
+    #[wasm_bindgen]
+    pub fn set_reduced_motion(&mut self, reduced_motion: bool) {
+        BRIDGE_SHARED.with(|shared| {
+            let mut shared = shared.borrow_mut();
+            if shared.reduced_motion != reduced_motion {
+                shared.reduced_motion = reduced_motion;
+                shared.animation_version = shared.animation_version.wrapping_add(1);
+            }
+        });
+    }
+
+    #[wasm_bindgen]
+    pub fn tick(&mut self, _animation_ms: f64) -> JsValue {
+        if self.mounted {
+            BRIDGE_SHARED.with(|shared| {
+                let mut shared = shared.borrow_mut();
+                shared.animation_version = shared.animation_version.wrapping_add(1);
+            });
+            status_value("ready")
+        } else {
+            status_value("detached")
+        }
+    }
+}

--- a/crates/pixel_world_bridge/src/render.rs
+++ b/crates/pixel_world_bridge/src/render.rs
@@ -933,7 +933,11 @@ pub(crate) fn render_scene(
         runtime.needs_reconcile = false;
         runtime.animation_dirty = false;
     }
-    let animation_ms = time.elapsed_secs_f64() * 1000.0;
+    let animation_ms = if runtime.reduced_motion {
+        0.0
+    } else {
+        time.elapsed_secs_f64() * 1000.0
+    };
     let mut rebuild_hit_regions = false;
     if static_reconcile {
         canvas_resize::requeue_follow_target_after_resize(&mut runtime, width, height);

--- a/crates/pixel_world_bridge/src/render.rs
+++ b/crates/pixel_world_bridge/src/render.rs
@@ -3,6 +3,8 @@ use bevy::ecs::system::SystemParam;
 use std::collections::{HashMap, HashSet};
 #[path = "render_fragment_visuals.rs"]
 mod fragment_visuals;
+#[path = "render_grounding.rs"]
+mod grounding;
 use fragment_visuals::reconcile_fragments;
 #[path = "render_micro_depot_facilities.rs"]
 mod micro_depot_facilities;
@@ -141,6 +143,8 @@ pub(crate) struct GridLayoutKey {
     step_milli: i32,
     offset_x_milli: i32,
     offset_y_milli: i32,
+    major_phase_x: i32,
+    major_phase_y: i32,
 }
 #[derive(Component)]
 pub(crate) struct PixelWorldGridVisual;
@@ -259,6 +263,8 @@ pub(crate) fn build_grid_layout(camera: &CameraState, width: f64, height: f64) -
         step_milli: (grid_step * 1000.0).round() as i32,
         offset_x_milli: (offset_x * 1000.0).round() as i32,
         offset_y_milli: (offset_y * 1000.0).round() as i32,
+        major_phase_x: (camera.pan_x_px / grid_step).floor().rem_euclid(5.0) as i32,
+        major_phase_y: (camera.pan_y_px / grid_step).floor().rem_euclid(5.0) as i32,
     }
 }
 pub(crate) fn fragment_screen_size_px(
@@ -387,7 +393,7 @@ fn grid_geometry(layout: &GridLayoutKey) -> (f64, f64, f64, f64, Color) {
         layout.offset_x_milli as f64 / 1000.0,
         layout.offset_y_milli as f64 / 1000.0,
         layout.width as f64,
-        Color::srgba_u8(99, 179, 255, 26),
+        Color::srgba_u8(99, 179, 255, 12),
     )
 }
 fn reconcile_grid(
@@ -408,8 +414,14 @@ fn reconcile_grid(
     let layout_height = next_layout.height as f64;
     let mut x = offset_x;
     while x <= layout_width {
+        let color =
+            if (((x - runtime.camera.pan_x_px) / grid_step).round() as i64).rem_euclid(5) == 0 {
+                Color::srgba_u8(99, 179, 255, 20)
+            } else {
+                grid_color
+            };
         commands.spawn((
-            sprite_for_rect(grid_color, 1.0, layout_height as f32),
+            sprite_for_rect(color, 1.0, layout_height as f32),
             Transform::from_translation(to_bevy_translation(
                 x,
                 layout_height / 2.0,
@@ -423,8 +435,14 @@ fn reconcile_grid(
     }
     let mut y = offset_y;
     while y <= layout_height {
+        let color =
+            if (((y - runtime.camera.pan_y_px) / grid_step).round() as i64).rem_euclid(5) == 0 {
+                Color::srgba_u8(99, 179, 255, 20)
+            } else {
+                grid_color
+            };
         commands.spawn((
-            sprite_for_rect(grid_color, layout_width as f32, 1.0),
+            sprite_for_rect(color, layout_width as f32, 1.0),
             Transform::from_translation(to_bevy_translation(
                 layout_width / 2.0,
                 y,
@@ -490,9 +508,10 @@ fn reconcile_locations(
             height,
             style.layer_z,
         ));
-        let sprite = sprite_for_square(
+        let sprite = sprite_for_rect(
             Color::srgba_u8(110, 231, 183, (style.alpha * 255.0).round() as u8),
             style.size_px as f32,
+            style.size_px as f32 * 0.72,
         );
         if let Some(entity) = runtime.location_entities.get(&location.id).copied() {
             commands.entity(entity).insert((sprite, transform));
@@ -569,7 +588,7 @@ fn reconcile_agents(
             height,
             style.layer_z,
         ));
-        let sprite = sprite_for_square(color, style.size_px as f32);
+        let sprite = sprite_for_rect(color, style.size_px as f32 * 0.66, style.size_px as f32);
         if let Some(entity) = runtime.agent_entities.get(&agent.id).copied() {
             commands.entity(entity).insert((sprite, transform));
         } else {
@@ -701,6 +720,7 @@ fn clear_runtime_visuals(commands: &mut Commands, runtime: &mut BevyRuntimeState
 pub(crate) struct RenderSceneQueries<'w, 's> {
     windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     current_grid: Query<'w, 's, Entity, With<PixelWorldGridVisual>>,
+    grounding: Query<'w, 's, (Entity, &'static grounding::PixelWorldGroundingVisual)>,
     fragment_visuals: Query<'w, 's, (Entity, &'static PixelWorldFragmentVisual)>,
     fragment_shadows: Query<'w, 's, (Entity, &'static PixelWorldFragmentShadowVisual)>,
     fragment_insets: Query<'w, 's, (Entity, &'static PixelWorldFragmentInsetVisual)>,
@@ -740,6 +760,7 @@ pub(crate) fn render_scene(
     time: Res<Time>,
 ) {
     if !runtime.mounted {
+        grounding::clear(&mut commands, &queries.grounding);
         clear_runtime_visuals(&mut commands, &mut runtime);
         for (entity, _) in queries.selected_location_cues.iter() {
             commands.entity(entity).despawn();
@@ -840,6 +861,7 @@ pub(crate) fn render_scene(
         return;
     };
     let Some(_) = runtime.render_state.as_ref() else {
+        grounding::clear(&mut commands, &queries.grounding);
         clear_runtime_visuals(&mut commands, &mut runtime);
         for (entity, _) in queries.selected_location_cues.iter() {
             commands.entity(entity).despawn();
@@ -1025,6 +1047,14 @@ pub(crate) fn render_scene(
         height,
         animation_ms,
         rebuild_hit_regions,
+    );
+    grounding::reconcile(
+        &mut commands,
+        &runtime,
+        &queries.grounding,
+        width,
+        height,
+        animation_ms,
     );
     reconcile_agent_labels(
         &mut commands,

--- a/crates/pixel_world_bridge/src/render_fragment_visuals.rs
+++ b/crates/pixel_world_bridge/src/render_fragment_visuals.rs
@@ -15,16 +15,16 @@ pub(super) fn fragment_color(fragment: &FragmentTerrainPatch, lod: FragmentTerra
 pub(super) fn fragment_inset_color(fragment: &FragmentTerrainPatch) -> Color {
     let alpha = fragment_alpha(fragment, FragmentTerrainLod::Detail);
     Color::srgba_u8(
-        fragment.color[0].saturating_mul(3) / 5,
-        fragment.color[1].saturating_mul(3) / 5,
-        fragment.color[2].saturating_mul(3) / 5,
+        (u16::from(fragment.color[0]) * 3 / 5) as u8,
+        (u16::from(fragment.color[1]) * 3 / 5) as u8,
+        (u16::from(fragment.color[2]) * 3 / 5) as u8,
         (alpha.clamp(0.0, 1.0) * 255.0).round() as u8,
     )
 }
 
 pub(super) fn fragment_fleck_color(fragment: &FragmentTerrainPatch) -> Color {
     let alpha = fragment_alpha(fragment, FragmentTerrainLod::Detail);
-    let lighten = |channel: u8| channel.saturating_add((u8::MAX - channel) * 2 / 5);
+    let lighten = |channel: u8| (u16::from(channel) + u16::from(u8::MAX - channel) * 2 / 5) as u8;
     Color::srgba_u8(
         lighten(fragment.color[0]),
         lighten(fragment.color[1]),
@@ -39,9 +39,9 @@ pub(super) fn fragment_shadow_color(
 ) -> Color {
     let alpha = fragment_alpha(fragment, lod) * f64::from(FRAGMENT_SHADOW_ALPHA_CAP);
     Color::srgba_u8(
-        fragment.color[0].saturating_mul(2) / 5,
-        fragment.color[1].saturating_mul(2) / 5,
-        fragment.color[2].saturating_mul(2) / 5,
+        (u16::from(fragment.color[0]) * 2 / 5) as u8,
+        (u16::from(fragment.color[1]) * 2 / 5) as u8,
+        (u16::from(fragment.color[2]) * 2 / 5) as u8,
         (alpha.clamp(0.0, 1.0) * 255.0).round() as u8,
     )
 }
@@ -128,7 +128,7 @@ pub(super) fn reconcile_fragments(
         let mut shadow_transform = transform;
         shadow_transform.translation += Vec3::new(
             shadow_offset,
-            shadow_offset,
+            -shadow_offset,
             FRAGMENT_SHADOW_LAYER_Z - style.layer_z,
         );
         let shadow_sprite = sprite_for_square(
@@ -176,7 +176,16 @@ pub(super) fn reconcile_fragments(
                 inset_offset,
                 FRAGMENT_INSET_LAYER_Z - style.layer_z,
             );
-            let inset_sprite = sprite_for_square(fragment_inset_color(fragment), inset_size);
+            let compound_parity = fragment
+                .dominant_compound
+                .bytes()
+                .fold(0u8, u8::wrapping_add)
+                % 2;
+            let inset_sprite = sprite_for_rect(
+                fragment_inset_color(fragment),
+                inset_size,
+                inset_size * if compound_parity == 0 { 0.45 } else { 1.0 },
+            );
             if let Some(entity) = existing_insets_by_id.get(&fragment.id) {
                 commands
                     .entity(*entity)

--- a/crates/pixel_world_bridge/src/render_grounding.rs
+++ b/crates/pixel_world_bridge/src/render_grounding.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+/// Passive pixel geometry; never contributes a hit region or world semantics.
+#[derive(Component)]
+pub(super) struct PixelWorldGroundingVisual {
+    key: String,
+}
+
+pub(super) fn clear(commands: &mut Commands, query: &Query<(Entity, &PixelWorldGroundingVisual)>) {
+    for (entity, _) in query.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+pub(super) fn reconcile(
+    commands: &mut Commands,
+    runtime: &BevyRuntimeState,
+    query: &Query<(Entity, &PixelWorldGroundingVisual)>,
+    width: f64,
+    height: f64,
+    animation_ms: f64,
+) {
+    let mut existing = query
+        .iter()
+        .map(|(entity, visual)| (visual.key.clone(), entity))
+        .collect::<HashMap<_, _>>();
+    let mut specs = Vec::new();
+    if let Some(state) = runtime.render_state.as_ref() {
+        for (index, agent) in state.agents.iter().enumerate() {
+            let selected = state
+                .selection
+                .as_ref()
+                .is_some_and(|s| s.kind == "agent" && s.id == agent.id);
+            let style = agent_visual_style(agent, selected, animation_ms, index);
+            let point = state
+                .world_bounds
+                .as_ref()
+                .and_then(|bounds| {
+                    agent.pos.as_ref().and_then(|pos| {
+                        to_canvas_point(pos, bounds, width, height, &runtime.camera)
+                    })
+                })
+                .unwrap_or_else(|| {
+                    fallback_point_for_entity(&agent.id, width, height, &runtime.camera)
+                });
+            specs.push((
+                format!("agent:{}", agent.id),
+                point,
+                style.size_px as f32,
+                style.layer_z,
+                true,
+            ));
+        }
+        if let Some(bounds) = state.world_bounds.as_ref() {
+            for location in &state.locations {
+                if let Some(point) =
+                    to_canvas_point(&location.pos, bounds, width, height, &runtime.camera)
+                {
+                    let selected = state
+                        .selection
+                        .as_ref()
+                        .is_some_and(|s| s.kind == "location" && s.id == location.id);
+                    let style = selected_location_visual_style(location, selected, animation_ms);
+                    specs.push((
+                        format!("location:{}", location.id),
+                        point,
+                        style.size_px as f32,
+                        style.layer_z,
+                        false,
+                    ));
+                }
+            }
+            for facility in &state.micro_depot_facilities {
+                if !matches!(
+                    facility.status.as_str(),
+                    "active" | "suspended" | "depleted"
+                ) {
+                    continue;
+                }
+                if let Some(point) =
+                    to_canvas_point(&facility.pos, bounds, width, height, &runtime.camera)
+                {
+                    specs.push((
+                        format!("facility:{}", facility.id),
+                        point,
+                        9.0,
+                        MICRO_DEPOT_LAYER_Z,
+                        false,
+                    ));
+                }
+            }
+        }
+    }
+    for (id, (x, y), size, z, upright) in specs {
+        let half_height = size * if upright { 0.5 } else { 0.36 };
+        // Shared light direction: upper-left rim, lower-right contact shadow.
+        for (part, dx, dy, w, h, color, layer) in [
+            (
+                "shadow",
+                1.0,
+                half_height + 1.0,
+                size * 0.88,
+                2.0,
+                Color::srgba_u8(2, 6, 23, 180),
+                z - 0.16,
+            ),
+            (
+                "rim",
+                -size * 0.12,
+                -half_height + 1.0,
+                size * if upright { 0.40 } else { 0.70 },
+                1.0,
+                Color::srgba_u8(226, 232, 240, 175),
+                z + 0.006,
+            ),
+            (
+                "profile",
+                0.0,
+                -half_height,
+                size * if upright { 0.30 } else { 0.55 },
+                if upright { 3.0 } else { 2.0 },
+                Color::srgba_u8(148, 163, 184, 205),
+                z - 0.01,
+            ),
+        ] {
+            let key = format!("{id}:{part}");
+            let sprite = sprite_for_rect(color, w, h);
+            let transform = Transform::from_translation(to_bevy_translation(
+                x + f64::from(dx),
+                y + f64::from(dy),
+                width,
+                height,
+                layer,
+            ));
+            if let Some(entity) = existing.remove(&key) {
+                commands.entity(entity).insert((sprite, transform));
+            } else {
+                commands.spawn((sprite, transform, PixelWorldGroundingVisual { key }));
+            }
+        }
+    }
+    for entity in existing.into_values() {
+        commands.entity(entity).despawn();
+    }
+}

--- a/crates/pixel_world_bridge/src/render_hotspot_cues.rs
+++ b/crates/pixel_world_bridge/src/render_hotspot_cues.rs
@@ -2,7 +2,7 @@ use super::*;
 use bevy::ecs::system::SystemParam;
 use std::collections::{HashMap, HashSet};
 
-const HOTSPOT_CUE_LAYER_Z_OFFSET: f32 = 0.005;
+const HOTSPOT_CUE_LAYER_Z_OFFSET: f32 = 0.02;
 const HOTSPOT_CUE_COLOR: Color = Color::srgba_u8(226, 232, 240, 220);
 const HOTSPOT_CUE_THICKNESS_PX: f32 = 1.5;
 
@@ -97,23 +97,23 @@ pub(crate) fn reconcile_hotspot_cues(
                 (HotspotCuePart::GoalCornerRight, 0.22, 0.22, 1.0, 0.44, 0.0),
             ],
             "resource_transfer" => &[
-                // Offset twin strokes suggest directed movement while retaining the
-                // neutral, low-density event hierarchy of the shared hotspot base.
+                // A right-facing chevron stays legible without color. It denotes
+                // transfer, not the direction of any world route.
                 (
                     HotspotCuePart::ResourceTransferLead,
-                    0.18,
+                    0.08,
                     -0.20,
-                    0.64,
+                    0.60,
                     1.34,
-                    0.0,
+                    -std::f32::consts::FRAC_PI_4,
                 ),
                 (
                     HotspotCuePart::ResourceTransferTrail,
-                    -0.18,
+                    0.08,
                     0.20,
-                    0.64,
+                    0.60,
                     1.34,
-                    0.0,
+                    std::f32::consts::FRAC_PI_4,
                 ),
             ],
             "build_queue" => &[
@@ -121,13 +121,13 @@ pub(crate) fn reconcile_hotspot_cues(
                 // from the diagonal progression of resource movement.
                 (
                     HotspotCuePart::BuildQueueUpper,
-                    -0.16,
+                    -0.10,
                     -0.24,
-                    0.48,
+                    0.62,
                     1.34,
                     0.0,
                 ),
-                (HotspotCuePart::BuildQueueLower, 0.13, 0.24, 0.82, 1.34, 0.0),
+                (HotspotCuePart::BuildQueueLower, 0.0, 0.24, 0.82, 1.34, 0.0),
             ],
             _ => &[(HotspotCuePart::RecentEventTick, 0.0, -0.26, 0.48, 1.0, 0.0)],
         };

--- a/crates/pixel_world_bridge/src/render_location_corner_frame_raster_tests.rs
+++ b/crates/pixel_world_bridge/src/render_location_corner_frame_raster_tests.rs
@@ -41,7 +41,7 @@ fn location_corner_frame_raster_exports_mint_pixels_without_changing_location_ba
     );
     assert_eq!(
         summary.location_sample_rgba,
-        [83, 171, 139, 255],
+        [82, 170, 138, 255],
         "the display-only frame must not obscure the terrain-composited mint base-location sample"
     );
     assert_eq!(

--- a/crates/pixel_world_bridge/src/render_material_hierarchy_tests.rs
+++ b/crates/pixel_world_bridge/src/render_material_hierarchy_tests.rs
@@ -226,6 +226,57 @@ fn paused_animation_keeps_event_shapes_static_and_above_core() {
 }
 
 #[test]
+fn same_color_compound_update_reconciles_inset_without_resetting_camera() {
+    let mut state = sample_render_state(20_000.0);
+    state.fragment_terrain[0].dominant_compound = "compound_a".into();
+    let mut app = render_test_app(state.clone());
+    let inset = |app: &mut App| {
+        let world = app.world_mut();
+        world
+            .query_filtered::<(Entity, &Sprite), With<PixelWorldFragmentInsetVisual>>()
+            .single(world)
+            .map(|(entity, sprite)| (entity, sprite.custom_size.unwrap()))
+            .unwrap()
+    };
+    let before = inset(&mut app);
+    let camera_signature = camera_content_signature(Some(&state));
+    state.fragment_terrain[0].dominant_compound = "compound_b".into();
+    {
+        let mut runtime = app.world_mut().resource_mut::<BevyRuntimeState>();
+        runtime.reactive_scheduling = true;
+        runtime.animation_dirty = false;
+        runtime.needs_reconcile = false;
+        runtime.hit_regions_dirty = false;
+        runtime.camera_user_override = true;
+        runtime.render_content_signature = render_content_signature(runtime.render_state.as_ref());
+        let version = runtime.render_version + 1;
+        apply_external_render_snapshot(
+            &mut runtime,
+            true,
+            RenderSnapshot::Changed {
+                version,
+                state: Some(state.clone()),
+            },
+        );
+        assert!(
+            runtime.needs_reconcile,
+            "compound-only update must reconcile"
+        );
+        assert!(!runtime.hit_regions_dirty);
+        assert!(runtime.camera_user_override);
+    }
+    assert_eq!(camera_signature, camera_content_signature(Some(&state)));
+    app.update();
+    let after = inset(&mut app);
+    assert_eq!(before.0, after.0, "reuse the existing inset entity");
+    assert_eq!(before.1.x, after.1.x);
+    assert_ne!(
+        before.1.y, after.1.y,
+        "compound-only update changes inset shape"
+    );
+}
+
+#[test]
 fn compound_shading_preserves_channels_without_saturation_or_overflow() {
     let mut patch = sample_render_state(20_000.0).fragment_terrain.remove(0);
     patch.color = [200, 100, 0];

--- a/crates/pixel_world_bridge/src/render_material_hierarchy_tests.rs
+++ b/crates/pixel_world_bridge/src/render_material_hierarchy_tests.rs
@@ -1,0 +1,237 @@
+use super::*;
+
+#[test]
+fn agent_profile_is_upright_while_location_is_a_footprint() {
+    let mut app = render_test_app(sample_render_state(12_000.0));
+    let world = app.world_mut();
+    let agent = world
+        .query_filtered::<&Sprite, With<PixelWorldAgentVisual>>()
+        .single(world)
+        .unwrap()
+        .custom_size
+        .unwrap();
+    let location = world
+        .query_filtered::<&Sprite, With<PixelWorldLocationVisual>>()
+        .single(world)
+        .unwrap()
+        .custom_size
+        .unwrap();
+    assert!(
+        agent.x < agent.y * 0.8,
+        "agent must have an upright grayscale profile"
+    );
+    assert!(
+        location.x > location.y,
+        "location must have a broad footprint"
+    );
+}
+
+#[test]
+fn minor_grid_is_subordinate_to_material_detail() {
+    let layout = build_grid_layout(&CameraState::default(), 960.0, 540.0);
+    assert!(grid_geometry(&layout).4.alpha() <= 0.06);
+    let camera = CameraState {
+        pan_x_px: 24.0,
+        ..Default::default()
+    };
+    assert_ne!(
+        layout,
+        build_grid_layout(&camera, 960.0, 540.0),
+        "one-cell pan must invalidate the major-line phase even when minor offsets repeat"
+    );
+}
+
+fn material_route_fixture() -> RenderState {
+    let mut state = sample_render_state_with_beacon_candidates("agent", "agent-0");
+    state.agents[0].pos = Some(sample_position(800_000.0, 800_000.0));
+    state.agents[0].position_source = AgentPositionSource::Snapshot;
+    state.locations[0].pos = sample_position(1_300_000.0, 800_000.0);
+    state.locations[1].pos = sample_position(1_900_000.0, 1_200_000.0);
+    state.fragment_terrain[0].footprint_cm = 100_000.0;
+    state.fragment_terrain[0].pos = sample_position(1_000_000.0, 1_200_000.0);
+    let mut second = state.fragment_terrain[0].clone();
+    second.id = "fragment-oxide".into();
+    second.pos = sample_position(1_300_000.0, 1_200_000.0);
+    second.dominant_compound = "iron_oxide".into();
+    second.color = [190, 142, 103];
+    state.fragment_terrain.push(second);
+    state.micro_depot_facilities = vec![serde_json::from_value(serde_json::json!({
+        "id": "facility-active", "facility_id": "depot", "location_id": "loc-0", "status": "active",
+        "pos": { "x_cm": 1_900_000.0, "y_cm": 1_500_000.0, "z_cm": 0.0 }
+    })).unwrap()];
+    state.links = vec![
+        Link {
+            id: "published-primary".into(),
+            kind: "route".into(),
+            from: state.agents[0].pos.clone().unwrap(),
+            to: state.locations[0].pos.clone(),
+            emphasis: Some(1.0),
+            status: None,
+            source_class: None,
+            freshness: None,
+        },
+        Link {
+            id: "published-secondary".into(),
+            kind: "route".into(),
+            from: state.locations[0].pos.clone(),
+            to: state.locations[1].pos.clone(),
+            emphasis: Some(0.25),
+            status: None,
+            source_class: None,
+            freshness: None,
+        },
+    ];
+    state.visual_hotspots = vec![
+        VisualHotspot {
+            id: "transfer".into(),
+            label: "Resource transfer".into(),
+            kind: "resource_transfer".into(),
+            pos: sample_position(1_000_000.0, 1_500_000.0),
+            emphasis: Some(0.7),
+            size_hint_px: Some(12.0),
+        },
+        VisualHotspot {
+            id: "queue".into(),
+            label: "Build queue".into(),
+            kind: "build_queue".into(),
+            pos: sample_position(1_300_000.0, 1_500_000.0),
+            emphasis: Some(0.7),
+            size_hint_px: Some(12.0),
+        },
+    ];
+    state
+}
+
+#[test]
+fn bevy_pixel_regression_exports_material_route_hierarchy() {
+    let mut app = render_test_app(material_route_fixture());
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .camera
+        .zoom = 1.0;
+    app.update();
+    let layers = collect_pixel_layers(&mut app);
+    assert_eq!(layers.iter().filter(|l| l.kind == "link").count(), 2);
+    let diagonal = layers
+        .iter()
+        .find(|l| l.kind == "link" && l.rotation.abs() > 0.1)
+        .unwrap();
+    let endpoint = Vec2::new(diagonal.center_x, diagonal.center_y)
+        + Vec2::new(diagonal.rotation.cos(), diagonal.rotation.sin()) * diagonal.size.x * 0.5;
+    let runtime = app.world().resource::<BevyRuntimeState>();
+    let state = runtime.render_state.as_ref().unwrap();
+    let expected = to_canvas_point(
+        &state.links[1].to,
+        state.world_bounds.as_ref().unwrap(),
+        960.0,
+        540.0,
+        &runtime.camera,
+    )
+    .unwrap();
+    assert!(
+        endpoint.distance(Vec2::new(expected.0 as f32, expected.1 as f32)) < 0.1,
+        "CPU readback must preserve the real Bevy route endpoint, including Y-axis inversion"
+    );
+    let (image, summary) = rasterize_pixel_regression(&mut app);
+    assert!(summary.fragment_fleck_pixels > 0);
+    assert!(summary.selected_agent_cue_pixels > 0);
+    assert!(layers.iter().any(|l| l.kind == "hotspot_cue"));
+    write_pixel_probe_if_requested(&image, &summary);
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .render_state
+        .as_mut()
+        .unwrap()
+        .links
+        .clear();
+    app.update();
+    assert!(
+        !collect_pixel_layers(&mut app)
+            .iter()
+            .any(|l| l.kind == "link"),
+        "empty scene must not invent routes"
+    );
+}
+
+#[test]
+fn grounding_is_passive_reused_and_removed_with_scene() {
+    let mut app = render_test_app(material_route_fixture());
+    let before = hit_regions(&mut app).len();
+    let entities = |app: &mut App| {
+        let world = app.world_mut();
+        let mut ids = world
+            .query_filtered::<Entity, With<grounding::PixelWorldGroundingVisual>>()
+            .iter(world)
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    };
+    let first = entities(&mut app);
+    assert!(!first.is_empty());
+    app.update();
+    assert_eq!(first, entities(&mut app));
+    assert_eq!(before, hit_regions(&mut app).len());
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .render_state = None;
+    app.update();
+    assert!(entities(&mut app).is_empty());
+}
+
+#[test]
+fn paused_animation_keeps_event_shapes_static_and_above_core() {
+    let mut app = render_test_app(material_route_fixture());
+    let cue_geometry = |app: &mut App| {
+        let world = app.world_mut();
+        world
+            .query::<(
+                &hotspot_cues::PixelWorldHotspotCueVisual,
+                &Sprite,
+                &Transform,
+            )>()
+            .iter(world)
+            .map(|(cue, sprite, transform)| {
+                (
+                    cue.id.clone(),
+                    sprite.custom_size,
+                    transform.translation,
+                    transform.rotation,
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    let first = cue_geometry(&mut app);
+    assert!(first.iter().all(|(_, _, pos, _)| pos.z
+        > hotspot_layer_z("resource_transfer") + hotspot_core::HOTSPOT_CORE_LAYER_Z_OFFSET));
+    {
+        let mut runtime = app.world_mut().resource_mut::<BevyRuntimeState>();
+        runtime.reactive_scheduling = true;
+        runtime.needs_reconcile = false;
+        runtime.animation_dirty = false;
+    }
+    app.update();
+    assert_eq!(first, cue_geometry(&mut app));
+    app.world_mut()
+        .resource_mut::<Time>()
+        .advance_by(Duration::from_millis(70));
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .animation_dirty = true;
+    app.update();
+    assert_ne!(
+        first,
+        cue_geometry(&mut app),
+        "animation tick must retain the existing pulse"
+    );
+}
+
+#[test]
+fn compound_shading_preserves_channels_without_saturation_or_overflow() {
+    let mut patch = sample_render_state(20_000.0).fragment_terrain.remove(0);
+    patch.color = [200, 100, 0];
+    let inset = fragment_visuals::fragment_inset_color(&patch).to_srgba();
+    let fleck = fragment_visuals::fragment_fleck_color(&patch).to_srgba();
+    assert!((inset.red - 120.0 / 255.0).abs() < 0.001);
+    assert!((inset.green - 60.0 / 255.0).abs() < 0.001);
+    assert!((fleck.blue - 102.0 / 255.0).abs() < 0.001);
+}

--- a/crates/pixel_world_bridge/src/render_material_pixel_layers.rs
+++ b/crates/pixel_world_bridge/src/render_material_pixel_layers.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+pub(super) fn collect(world: &mut World, layers: &mut Vec<PixelLayer>) {
+    let mut grounding =
+        world.query::<(&grounding::PixelWorldGroundingVisual, &Sprite, &Transform)>();
+    layers.extend(
+        grounding
+            .iter(world)
+            .map(|(_, sprite, transform)| pixel_layer("grounding", sprite, transform)),
+    );
+    let mut cues = world.query::<(
+        &hotspot_cues::PixelWorldHotspotCueVisual,
+        &Sprite,
+        &Transform,
+    )>();
+    layers.extend(
+        cues.iter(world)
+            .map(|(_, sprite, transform)| pixel_layer("hotspot_cue", sprite, transform)),
+    );
+    let mut links = world.query::<(&PixelWorldLinkVisual, &Sprite, &Transform)>();
+    layers.extend(
+        links
+            .iter(world)
+            .map(|(_, sprite, transform)| pixel_layer("link", sprite, transform)),
+    );
+    let mut facilities = world.query::<(&PixelWorldMicroDepotVisual, &Sprite, &Transform)>();
+    layers.extend(
+        facilities
+            .iter(world)
+            .map(|(_, sprite, transform)| pixel_layer("facility", sprite, transform)),
+    );
+}

--- a/crates/pixel_world_bridge/src/render_micro_depot_facilities_tests.rs
+++ b/crates/pixel_world_bridge/src/render_micro_depot_facilities_tests.rs
@@ -35,6 +35,123 @@ fn depot_with_service_radius(id: &str, service_radius_cm: f64) -> MicroDepotFaci
     }
 }
 
+#[test]
+fn facility_only_snapshots_reconcile_added_glyph_and_grounding() {
+    assert_facility_snapshot_reconciles(false);
+}
+
+#[test]
+fn facility_visual_changes_invalidate_content_without_refitting_camera() {
+    let mut initial = sample_render_state(12_000.0);
+    initial
+        .micro_depot_facilities
+        .push(depot("snapshot", "active"));
+    let mutations: &[fn(&mut MicroDepotFacility)] = &[
+        |facility| facility.id.push_str("-new"),
+        |facility| facility.pos = sample_position(1_630_000.0, 1_010_000.0),
+        |facility| facility.status = "suspended".into(),
+        |facility| facility.service_radius_cm = 240_000.0,
+        |facility| {
+            facility.available_units_by_kind.insert("food".into(), 5);
+        },
+        |facility| facility.throughput_remaining_units = 10,
+        |facility| facility.throughput_limit_units_per_epoch = 20,
+    ];
+    for (index, mutate) in mutations.iter().enumerate() {
+        let mut changed = initial.clone();
+        mutate(&mut changed.micro_depot_facilities[0]);
+        assert_ne!(
+            render_content_signature(Some(&initial)),
+            render_content_signature(Some(&changed)),
+            "rendered facility field mutation {index} must invalidate content"
+        );
+        assert_eq!(
+            camera_content_signature(Some(&initial)),
+            camera_content_signature(Some(&changed))
+        );
+    }
+}
+
+#[test]
+fn facility_only_snapshots_reconcile_removed_glyph_and_grounding() {
+    assert_facility_snapshot_reconciles(true);
+}
+
+fn assert_facility_snapshot_reconciles(initially_present: bool) {
+    use crate::render::grounding::PixelWorldGroundingVisual;
+    let mut state = sample_render_state(12_000.0);
+    if initially_present {
+        state
+            .micro_depot_facilities
+            .push(depot("snapshot", "active"));
+    }
+    let mut app = render_test_app(state.clone());
+    let grounding_before = {
+        let world = app.world_mut();
+        world
+            .query::<&PixelWorldGroundingVisual>()
+            .iter(world)
+            .count()
+    };
+    if initially_present {
+        state.micro_depot_facilities.clear();
+    } else {
+        state
+            .micro_depot_facilities
+            .push(depot("snapshot", "active"));
+    }
+    {
+        let mut runtime = app.world_mut().resource_mut::<BevyRuntimeState>();
+        runtime.reactive_scheduling = true;
+        runtime.animation_dirty = true;
+        runtime.needs_reconcile = false;
+        runtime.hit_regions_dirty = false;
+        runtime.camera_user_override = true;
+        runtime.render_content_signature = render_content_signature(runtime.render_state.as_ref());
+        let version = runtime.render_version + 1;
+        apply_external_render_snapshot(
+            &mut runtime,
+            true,
+            RenderSnapshot::Changed {
+                version,
+                state: Some(state),
+            },
+        );
+        assert!(!runtime.hit_regions_dirty);
+        assert!(runtime.camera_user_override);
+    }
+    app.update();
+    let world = app.world_mut();
+    let expected = usize::from(!initially_present);
+    assert_eq!(
+        world
+            .query::<&PixelWorldMicroDepotVisual>()
+            .iter(world)
+            .count(),
+        expected,
+        "facility-only snapshots must reconcile static glyphs"
+    );
+    assert_eq!(
+        world
+            .query::<&PixelWorldMicroDepotDetailVisual>()
+            .iter(world)
+            .count(),
+        expected
+    );
+    let grounding_after = world
+        .query::<&PixelWorldGroundingVisual>()
+        .iter(world)
+        .count();
+    assert_eq!(
+        grounding_after,
+        if initially_present {
+            grounding_before - 3
+        } else {
+            grounding_before + 3
+        }
+    );
+}
+
 fn render_state_with_stock(remaining_units: i64, limit_units: i64) -> RenderState {
     serde_json::from_value(json!({
         "world_bounds": {

--- a/crates/pixel_world_bridge/src/render_selected_raster_tests.rs
+++ b/crates/pixel_world_bridge/src/render_selected_raster_tests.rs
@@ -4,6 +4,28 @@ use super::fixtures::{
 use super::*;
 
 #[test]
+fn reduced_motion_freezes_pixels_across_reconcile_and_resumes_on_preference_change() {
+    let mut app = render_test_app(sample_render_state(12_000.0));
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .reduced_motion = true;
+    app.update();
+    let (first, _) = rasterize_pixel_regression(&mut app);
+    app.world_mut()
+        .resource_mut::<Time>()
+        .advance_by(std::time::Duration::from_millis(350));
+    app.update();
+    let (frozen, _) = rasterize_pixel_regression(&mut app);
+    assert_eq!(first, frozen, "static reconcile must not restart motion");
+    app.world_mut()
+        .resource_mut::<BevyRuntimeState>()
+        .reduced_motion = false;
+    app.update();
+    let (resumed, _) = rasterize_pixel_regression(&mut app);
+    assert_ne!(frozen, resumed, "normal motion must resume");
+}
+
+#[test]
 fn bevy_pixel_regression_exports_selected_location_ring_with_world_layers() {
     let mut app = render_test_app(sample_render_state_with_beacon_candidates(
         "location", "loc-0",

--- a/crates/pixel_world_bridge/src/render_test_modules.rs
+++ b/crates/pixel_world_bridge/src/render_test_modules.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[path = "render_material_hierarchy_tests.rs"]
+mod material_hierarchy_tests;
+
 #[path = "render_agent_core_tests.rs"]
 mod agent_core_tests;
 

--- a/crates/pixel_world_bridge/src/render_tests.rs
+++ b/crates/pixel_world_bridge/src/render_tests.rs
@@ -246,14 +246,18 @@ fn pixel_layer(kind: &'static str, sprite: &Sprite, transform: &Transform) -> Pi
         center_x: (VIEWPORT_WIDTH as f32 / 2.0) + transform.translation.x,
         center_y: (VIEWPORT_HEIGHT as f32 / 2.0) - transform.translation.y,
         size: sprite.custom_size.unwrap_or(Vec2::splat(size_px)),
-        rotation: transform.rotation.to_euler(EulerRot::XYZ).2,
+        // Canvas Y points down; both position and rotation must change basis.
+        rotation: -transform.rotation.to_euler(EulerRot::XYZ).2,
         z: transform.translation.z,
         rgba: [color.red, color.green, color.blue, color.alpha],
     }
 }
+#[path = "render_material_pixel_layers.rs"]
+mod material_pixel_layers;
 fn collect_pixel_layers(app: &mut App) -> Vec<PixelLayer> {
     let world = app.world_mut();
     let mut layers = Vec::new();
+    material_pixel_layers::collect(world, &mut layers);
     let mut grid_query = world.query::<(&PixelWorldGridVisual, &Sprite, &Transform)>();
     layers.extend(
         grid_query


### PR DESCRIPTION
The viewer presents one primary decision area with truthful action receipts, stable marker codes, localized blocker explanations, scoped connection/feed status, and published scene/event context.

Real Bevy mode now aligns transparent 44px accessible targets with the renderer camera instead of showing duplicate markers at unrelated positions. Pan, zoom, resize, hover cleanup, and mobile map access are covered by real WASM interaction checks; the standalone fallback retains its marker presentation.

Bevy rendering gains a quieter minor grid, preserved major grid orientation, corrected compound shading, distinct agent/location silhouettes, restrained contact shadows and rims, and legible transfer/queue glyphs above hotspot cores. A deterministic fixture includes two published links, terrain compounds, entities and events; removing links leaves no synthetic routes. CPU raster rotation now matches Bevy's coordinate convention.

The bottom decision stack scrolls below visible event hit areas, preserving their world positions and a minimum usable panel. This keeps queue feedback readable without repositioning the world glyph.

Entity-origin drags now reach the canvas capture path while native keyboard and touch selection remain usable. Reduced-motion preferences freeze the renderer's presentation clock across snapshot and input updates; disabling the preference resumes animation.

Narrow-screen renderer recovery stays below World Feed with a fully visible 44px retry control. Open Gameplay Details uses an opaque, scrollable panel and stacked heading so pending context remains readable.

Unknown blocker codes also resolve to localized generic labels in expanded Capability Economics summaries, while raw diagnostic fields retain their original values. Six EN/ZH unknown, known and absent-blocker regression cases were added; the affected module passes 25 tests and four EN/ZH desktop/narrow browser cases pass after a lock-consistent build.

Required CI also exposed a yanked locked dependency. The lockfile moves only `chacha20` from 0.10.1 to compatible 0.10.2, with no manifest or advisory-policy changes; locked metadata, the consuming bridge build, and `cargo deny check advisories` pass.

Renderer targets now retain DOM identity and keyboard focus across same-ID snapshot refreshes, while labels, positions, selection and callbacks update. Regression coverage includes kind-scoped IDs, reorder and removal. The focused suite passes 55 tests, and real WASM Chrome checks retain focus after identical and moved snapshots at 1440, 390 and 320 px widths.

Earlier full-suite validation: 580 UI tests and 145 Rust renderer tests passed. Real WASM GPU input/state/fallback smoke passed at 1440×1000, 390×844 and 320×568, covering native target-origin drag, Enter and emulated touch selection, same-node focused pending feedback, and visible feed sequence/replay/gap/unavailable states. Route/motion evidence uses two published links and verifies preference changes without a reload, static reduced frames, continued snapshot/input updates, and resumed animation. CPU ECS rasters separately cover materials and route geometry. Fixtures establish deterministic consumer/presentation behavior, not live provider operation or physical touch latency. Extreme bottom-edge events retain a minimum 160px scrollable decision area.

The provider recovery test now waits for its asynchronous dispatch condition with a bounded deadline instead of a fixed yield count. Existing business assertions remain intact. The CI-feature-matched target and static checks pass; a separate loopback provider failure in the broader local run remains under investigation, so that broader run is not claimed as passing.

Compound-only fragment updates now invalidate the content signature, so inset geometry refreshes even when fallback color is unchanged. A RED/GREEN regression verifies the same rendered entity updates while camera and hit-region state remain intact; all 146 native bridge tests pass. Connection/feed status already uses Solid reactive state; an added same-node transition regression confirms startup, ready and stale states without changing production behavior (56 focused tests pass).

Partially visible 44px renderer targets remain accessible at all canvas edges. On cramped mobile layouts, generic clearance preserves the selected marker’s command-priority offset when no free placement exists; feasible placement still wins. Reactive facility-only snapshots now refresh glyphs and grounding together through presentation-field content hashing, without invalidating camera authority.

Latest correction validation: 16 focused UI tests, 149 native Bevy tests, viewer build, frontend structure, feedback contract, bundle freshness and Rust size checks passed. The full UI run passed 590 tests before one additional solver test was added; the final focused run covers that addition. Chromium component fixtures verify visible edge selection and an 8px mobile command gap. These targeted captures use synthetic panel geometry and do not claim a repeated full-app GPU playtest. New-head CI is running. The intermittent broader provider failure remains an explicit, scoped nonblocking risk per independent QA/runtime review; its root cause is not established.

Refs #3634

Task: task_4ec89bf638344864888b677bd42ff7c1
