### PR TITLE
贯通系统设计与项目管理记录规范

### DIFF
--- a/.pm/README.md
+++ b/.pm/README.md
@@ -4,11 +4,14 @@ Canonical workflow: [capability](../doc/engineering/workflow/source-of-truth.md#
 
 This file is an operator command index, not a second workflow specification.
 
+PM 内容规范：[项目管理记录规范](../doc/engineering/doc-governance/project-management-record-standard.design.md)。生命周期、绑定、准入、权限、门禁与收尾仍以 [workflow source of truth](../doc/engineering/workflow/source-of-truth.md) 为准。
+
 ## Storage Contract
 
 - GitHub Issues + GitHub Project 是 authoritative project-management truth；GitHub Project 是 active work queue。
 - `Task UID` is stable identity. GitHub issue number / Project item id 只是外部对象句柄。
-- `.pm/tasks/` and `.pm/archive/` are generated/cache views; do not edit them manually.
+- `.pm/github-project-sync/tasks.json` is the generated task-to-Issue/Project mapping cache; it may be regenerated and is not task truth. Do not edit it manually.
+- `.pm/github-project-sync/task-archive.jsonl` is the immutable repo-local archive for historical task metadata and evidence; it is not a planning queue or current-status source.
 - Task issue evidence comments are the formal evidence sink. Fallback evidence is temporary until replayed.
 
 ## Start and Inspect

--- a/doc/engineering/doc-governance/README.md
+++ b/doc/engineering/doc-governance/README.md
@@ -3,6 +3,8 @@
 本目录是 `doc/` 文档树治理的唯一上游分流入口，收拢文档组织、路径落位、入口减重与存量维护成本治理。读者应先从这里判断问题属于哪一类，再进入当前 authority；不要把同一治理规则继续复制到模块 README 或零散专题里。
 
 ## 首读路径
+- 专业系统设计的十二段骨架、需求承接、验证映射与证据边界：`doc/engineering/doc-governance/system-design-writing-standard.design.md`
+- GitHub-backed 项目记录、任务合同、专业 slice 与组合验收：`doc/engineering/doc-governance/project-management-record-standard.design.md`
 - 文档组织规则、后缀职责、模块 README 边界：`doc/engineering/doc-governance/doc-structure-standard.design.md`
 - 产品文档内容要求、四模块边界与三类采纳试点：`doc/engineering/doc-governance/product-documentation-standard.design.md`
 - 产品文档采纳目标、Done 与范围：`doc/engineering/doc-governance/product-documentation-standard.prd.md`
@@ -19,6 +21,8 @@
 | 新文档应该放在哪里、承担什么职责 | `doc-structure-standard.design.md` | 顶层组织规范；定义模块、专题、分册、README、PRD/design/manual/runbook 边界，并将任务追踪定向到 GitHub Issue/Project |
 | 产品文档应该写什么、如何验收和追踪 | `product-documentation-standard.design.md` | 在现有四模块与专业 authority 上补充内容合同、REQ/AC 追踪、状态/证据边界和三类试点 |
 | 产品文档如何套用结构、迁移代表性主题 | `product-documentation-standard.templates.md` | 提供根/专题/design 模板、需求/验收卡和 Prompt/首局/SC-31 迁移模式 |
+| 专业系统设计如何承接需求、表达合同并映射验证 | `system-design-writing-standard.design.md` | 十二段技术骨架；不替代产品设计、实现、运行或发布证据 |
+| 任务、slice、固定输入和组合验收如何留证 | `project-management-record-standard.design.md` | 复用现有 GitHub Issue/Project 与 workflow；不新增本地台账或状态机 |
 | 需要执行迁移、登记一级目录/例外或处理治理检查失败 | `documentation-governance.manual.md` | maintainer how-to；只执行 Design 已定义的规则，不另行裁定规则 |
 | 根入口或模块 README 过长、重复维护共享规则 | `doc-structure-standard.design.md` | 处理默认阅读面噪音，避免 landing page 变成第二份规范正文 |
 | 文档总量、热点子目录、devlog backlog 或近限长文件抬高维护成本 | `../governance/README.md` | 处理入口减重之后的存量维护成本，配合 `scripts/doc-inventory-report.sh` 复算 |

--- a/doc/engineering/doc-governance/doc-structure-standard.design.md
+++ b/doc/engineering/doc-governance/doc-structure-standard.design.md
@@ -9,7 +9,7 @@
 1. 一个新文档应该放在哪个目录；
 2. 一个新文档应该承担什么职责。
 
-产品文档的内容合同、REQ/AC 追踪、玩家体验与证据边界由配对的 [`product-documentation-standard.design.md`](product-documentation-standard.design.md) 承接；本文继续拥有目录落位、文件职责、入口与专题可达性。两份规范共同维护现有四模块产品树，不新增第五模块。
+产品文档的内容合同、REQ/AC 追踪、玩家体验与证据边界由配对的 [`product-documentation-standard.design.md`](product-documentation-standard.design.md) 承接；专业技术设计的内容合同与验证映射由 [`system-design-writing-standard.design.md`](system-design-writing-standard.design.md) 承接，任务记录和组合验收由 [`project-management-record-standard.design.md`](project-management-record-standard.design.md) 承接；本文继续拥有目录落位、文件职责、入口与专题可达性。共同规则维护现有四模块产品树，不新增第五模块。
 
 本规范只规定组织形式与职责边界，不处理历史迁移节奏。
 
@@ -29,6 +29,8 @@
 推荐职责后缀如下：
 - `*.prd.md`：Why / What / Done
 - `*.design.md`：How / Structure / Contract
+- `system-design-writing-standard.design.md`：专业技术设计的十二段内容、需求承接与验证映射
+- `project-management-record-standard.design.md`：GitHub-backed 任务记录、证据与组合验收内容
 - GitHub Issue / GitHub Project-backed task truth：任务、状态与过程证据的唯一可变载体；仓库不再创建本地 project ledger
 - `*.manual.md`：How to use / verify
 - `*.runbook.md`：How to operate / release / recover

--- a/doc/engineering/doc-governance/documentation-governance.manual.md
+++ b/doc/engineering/doc-governance/documentation-governance.manual.md
@@ -2,11 +2,14 @@
 
 本手册只说明维护操作；组织规则、权威边界与裁定原则以 [`doc-structure-standard.design.md`](doc-structure-standard.design.md) 为准。
 
+系统设计正文按 [`system-design-writing-standard.design.md`](system-design-writing-standard.design.md) 的十二段骨架、需求承接和验证映射维护；项目管理记录按 [`project-management-record-standard.design.md`](project-management-record-standard.design.md) 维护。生命周期、权限、任务状态和门禁仍只从 [`workflow source of truth`](../workflow/source-of-truth.md) 读取。
+
 ## 1. Intake 与分类
 
 1. 先识别读者对象与文档职责，再选择目录和后缀。
 2. 产品承诺、跨域组合和端到端成功标准，进入既有 `doc/product/` 四模块之一；实现合同、指标、测试、运维与历史证据留在专业域。
 3. 不确定时暂停建档，记录候选目录、冲突的权威和需要裁定的问题，交由对应 domain owner 与 `repository_health_engineer` 复核；不要以新根级目录或双写规避判断。
+4. 专业技术设计使用系统设计写作规范；任务、slice、变更与验收事实使用 GitHub-backed PM 记录规范，不在产品或设计正文复制可变状态。
 
 ### 1.1 新建与实质变更产品文档的作者步骤
 

--- a/doc/engineering/doc-governance/project-management-record-standard.design.md
+++ b/doc/engineering/doc-governance/project-management-record-standard.design.md
@@ -1,0 +1,350 @@
+# 项目管理记录规范
+
+- 状态：active
+- 适用范围：GitHub-backed 变更记录、叶子任务、专业 slice、依赖、证据与组合验收
+- 当前入口：[engineering/doc-governance README](README.md)
+- 系统设计配套：[系统设计写作规范](system-design-writing-standard.design.md)
+- 任务生命周期与门禁权威：[workflow source of truth](../workflow/source-of-truth.md)
+
+本文是项目管理内容规范。它规定记录应表达什么、如何固定输入、如何保留证据和如何判断组合交付；不新增任务 schema、状态枚举、权限模型、loop activation、Project 字段、服务或调度器。生命周期、绑定、准入、权限、评审、CI、收尾和 epoch 规则始终以 workflow source of truth 及现行 helper 的实际 readback 为准。
+
+## 1. 权威、载体与边界
+
+GitHub Issue 是任务身份和正式证据 envelope；GitHub Project item 与字段是 active queue 和规定管理视图。`Task UID` 是稳定内部身份，Issue number 与 Project item ID 是外部对象句柄。任务标题、Issue 正文和 evidence comments 可以组织信息，但不能替代现行 binding 或 workflow gate。
+
+生成的本地材料只用于映射、缓存和历史审计：
+
+- `.pm/github-project-sync/tasks.json` 是可重新生成的 task-to-Issue/Project mapping cache，不是任务队列或可手写状态源；
+- `.pm/github-project-sync/task-archive.jsonl` 是 repo-local 的历史 metadata/evidence archive，不是当前计划或准入依据；
+- GitHub task issue evidence comments 承载正式执行、评审、验证和收尾证据；无法写入时使用现有 fallback/replay 机制，不建立新的本地台账。
+
+同一事实只保留一个可写权威。产品文档保留产品价值、范围、玩家承诺与体验验收；专业系统设计保留技术合同、边界与验证设计；源码、测试与运行配置保留实现事实；GitHub task truth 保留本次交付的身份、范围、依赖、过程和实际证据；workflow source of truth 保留生命周期、权限和门禁。发生冲突时，在当前 Issue evidence 中记录冲突、影响、裁决 owner 与后续动作，不在本规范静默覆盖其他 authority。
+
+## 2. 对象、角色与交付关系
+
+项目管理记录区分长期主题、一次变更、叶子任务、PR 和组合验收：
+
+| 对象 | 作用 | 正式维护位置 |
+| --- | --- | --- |
+| 产品或专业主题 | 维护稳定要求、规则和设计 | 对应文档 authority |
+| 一次变更 | 约束有限范围、交付义务和验收候选 | 已授权的协调 Issue；需要时以 `change_id` 关联 |
+| 叶子任务 | 一个 owner、固定输入、有限 scope 和独立完成边界 | 一个 Task UID 对应的 GitHub Issue/Project item |
+| PR 或非 PR 交付 | 交付叶子任务的仓库或验证链 | GitHub PR 或现行非 PR evidence path |
+| 组合验收 | 对同一候选版本和范围判断完整能力 | GitHub task evidence 与适用 QA/专业产物 |
+
+每个叶子任务 MUST 有一个 outcome owner role、一个稳定 `Task UID` 和现行 workflow 规定的 canonical worktree/PR chain。协作 slice 可以提出发现或交付局部义务，但不改变唯一 owner。TPM 负责 task truth、dispatch、集成顺序和主链；专业角色负责其领域判断；QA 负责可验证性与发布判断的专业收口；repository health 负责组织、引用、证据边界和债务判断；涉及公开说明时由相应 LiveOps/community 角色参与。角色名或模板填写不自动产生独立评审、准入或发布权限。
+
+## 3. 固定输入与证据身份
+
+任务必须把“最新可读文档”“本任务批准消费的合同”和“实际测试候选”分开：
+
+| 层次 | 必须表达 | 不得替代 |
+| --- | --- | --- |
+| 当前阅读版本 | 为发现当前方向而阅读的路径、版本或提交 | 在途任务的自动替换输入 |
+| 任务消费版本 | 获批准且固定的产品/系统合同、发布记录、不可变内容与 consumed clauses | 浮动 `main`、分支名或 `latest` |
+| 验收候选版本 | 实际测试的 source/integration identity、配置、环境和入口 | 任意历史 green、文档 active 或 Issue closed |
+
+在有效机制支持时，复用现行 `input_contracts` 的 `contract_id`、`revision`、`contract_digest`、`publication_ref` 和 `consumed_clauses`；同时记录任务实际需要的 `acceptance_refs`。在未激活或不支持的环境，把这些语义放在可读 Issue/evidence 中，但不得用手工 JSON、front matter 或“已评审”文字伪造 adapter 绑定或消费资格。
+
+固定输入至少应能定位到：来源路径或对象、不可变提交/发布记录、内容摘要或 digest、批准来源、消费条款、适用 owner 和失效条件。源文档仍是 proposal 时必须明确标为 proposal；本任务的 source snapshot、当前 HEAD 与 live 状态不得被历史附件中的旧 PR/分支叙述替换。
+
+输入改变与目标分支推进是两类事件。上游语义、权限、合同资格或验收发生实质变化时，按影响范围保留旧基线、暂停并迁移、或缩小 scope，并按现行 workflow 重新绑定/验证；main 因无关变更推进时，更新 integration/CI 证据，不自动重写产品或系统要求。不能在执行中静默换合同版本。
+
+## 4. 叶子任务最小内容
+
+任务标题应表达可验证交付结果。正文和正式 evidence 至少覆盖以下信息；字段名仅作为与现行 binding 的语义对应，不是新 schema：
+
+1. **结果与来源**：交付什么、依据哪个用户请求、产品 REQ/AC、专业规则或系统条款；工程缺陷可以直接引用现有合同并说明产品语义不变。
+2. **身份与边界**：现行 Task UID/owner readback、canonical worktree/PR chain、In scope、允许写入范围和 Out of scope。
+3. **固定输入**：产品/系统/工程输入的版本、digest、消费条款和当前消费资格；不只引用浮动路径。
+4. **交付义务**：本叶子必须实际交付的文档、代码、测试、验证或说明对象，以及其完成条件。
+5. **验收引用**：每项 `acceptance_refs` 对应的具体义务、前置条件、验证入口和明确未覆盖范围。
+6. **依赖与风险**：上游输出、消费版本、硬依赖或咨询关系、阻断影响、解除 owner、解除证据、触发器与剩余风险。
+7. **执行与协作**：有界步骤、专业 slice、写入许可、集成顺序与正式 evidence 引用。
+8. **实际交付与收尾**：实际 source/PR/integration identity、命令与退出码、产物定位、未交付义务、PR/非 PR 终态以及 workflow 收尾证据。
+
+计划按可验证结果拆分，不按“文档/代码/测试”比例估算。里程碑说明能力变化、范围、退出条件、交付义务、依赖、风险、日期类型和假设；关闭若干 Issue、合并若干 PR 或填写进度百分比都不能自动证明能力完成。一个叶子任务终态也不自动完成同一 `change_id` 的设计回写、联合验证或公开说明义务。
+
+## 5. 依赖、slice 与交接条件
+
+依赖分为硬依赖和咨询关系。硬依赖必须写出上游对象、具体消费内容/版本、是否阻断、解除条件、责任人和解除证据；另一个 Issue closed 不是能力存在的充分证明。独立任务是否并行由实际 write scope、合同、共享资源和集成风险决定，不设置由模板或 loop 名称推导的全局串行限制。
+
+专业 slice 的任务、输入和写入许可必须落在当前 task scope 与有效 policy 的交集内。默认交接顺序是：产品输入明确后交给系统承接；系统合同固定后交给代码叶子；局部实现证据达到适用依赖条件后组织组合验收。代码、验证或评论完成不会自动创建、启动或授权下一个任务；等待外部条件只改变可继续性，不能触发后台 scheduler、webhook 或常驻 loop。
+
+若上游语义不清、输入 digest 不匹配、scope 不足、依赖循环或证据身份漂移，slice 应返回缺口和停止条件，不能越权修改另一 authority。跨域反馈回到当前 GitHub Issue evidence，由 TPM 按现行 workflow 判断是否需要新任务或重新绑定。
+
+## 6. 项目记录中的义务与条件
+
+每项交付义务都要说明“要交付什么”和“在什么条件下可判定”。条件可包括固定产品/系统输入、权限有效、代码集成身份、配置、入口、环境、证据窗口、依赖 readback 和专业评审。把条件写在义务旁边，避免以一个笼统的“完成”吞掉失败路径、未覆盖环境或组合要求。
+
+推荐将义务分为：
+
+- **输入义务**：来源、版本、digest、批准/消费条款和变更影响；
+- **边界义务**：owner、write scope、out-of-scope、允许入口和禁止推导；
+- **实现义务**：设计、代码、测试、配置或操作材料实际交付的内容；
+- **验证义务**：命令/测试/观察、候选身份、环境、阈值来源、退出码和产物；
+- **组合义务**：跨组件、跨入口、失败恢复、权限一致性和每项产品 AC 的完整判断；
+- **交接义务**：下游准确消费的文档/合同/证据，以及仍需产品、QA 或其他专业 owner 判断的事项。
+
+接受、应用、持久化、发布、任务 done、PR merged 和能力可发布是不同事实。项目记录只能报告有证据支持的事实；未知、未运行、不适用和未证明范围必须保留，不以模板填满、CI 绿色或文本 `active` 互相推导。
+
+## 7. 证据身份、执行与边界
+
+正式 evidence MUST 让第三方判断声明的适用范围。最低信息为：
+
+| 证据项 | 内容 |
+| --- | --- |
+| 身份 | Task UID/变更关联、记录类型、执行或审读 role、时间/证据窗口 |
+| 输入与对象 | 产品/系统合同版本和消费条款、source HEAD、integration base/tested tree、配置与入口 |
+| 环境 | 本地、fixture/fake-GitHub、hosted CI、真实集成、Viewer/API/Agent、平台与隔离边界 |
+| 动作 | 实际命令、suite、操作、观察或评审范围 |
+| 结果 | 退出码、通过/失败/未运行/不适用、关键摘要、artifact/log/URL 和 digest |
+| 定位 | acceptance/REQ/DES 引用、代码或文档路径、anchor、产物定位 |
+| 边界 | 未覆盖链路、mock/替身、未验证阈值、剩余风险和需要的专业判断 |
+
+验证证据记录实际执行而不是预期行为；评审证据记录固定审读基线、发现、严重性、处置、复核和剩余风险。截图或终端摘录可以辅助，不能替代身份绑定和完整产物。结构检查只能证明结构范围；它不能单独证明产品正确、系统可实现、真实玩家体验、发布就绪或 runtime/provider 能力。
+
+验证命令和证据对象应与候选版本同一可比较范围。不能把不同提交、环境、配置或时间窗口的局部 green 拼成一个未实际运行过的候选。必要时按现有 workflow 保存 receipt、CI artifact、review packet 或 task evidence；不要创建新的“自签通过”格式。
+
+## 8. 三-loop 消费与交付边界
+
+本节只是文档和记录的兼容边界。三-loop 的 policy、schema、adapter、资格与手动启用状态由 workflow source of truth 管理；候选设计、代码合并和明确 enablement 是不同事件。未激活时按现行 legacy workflow 工作，不能仅填写 `loop` 就绕过现有门禁。
+
+| 交付类别 | 维护的权威内容 | 不得顺手修改 |
+| --- | --- | --- |
+| product | 产品价值、玩家承诺、玩法规则与体验验收 | 系统技术合同、实现代码 |
+| system | 专业技术要求、架构、接口、状态、恢复与验证设计 | 产品承诺、实现代码 |
+| code | 源码、测试、协议/配置、脚本与可执行适配面 | 正式产品和系统文档 |
+| combination | 选定候选上的跨入口/跨模块证据与产品/QA判断 | 用子任务关闭或局部 mock 代签完整能力 |
+
+沿用有效 binding 中的 `task_uid`、`change_id`、`loop`、`owner_role`、`write_scope`、`out_of_scope`、`input_contracts`、`acceptance_refs`、`dependencies`、`target_delivery`、`policy_commit` 和 `policy_digest`。`change_id` 只关联有限交付义务，不取代 Task UID；`manual_request_ref`、`request_key`、`bootstrap_epoch` 和准入资格只能由有效 harness/workflow 提供，模板不能创造它们。
+
+跨 loop 反馈不是自动任务创建授权。多个 code 叶子可以在共享合同固定后并行；组合验收由获授权的协调/集成任务组织相应 QA 与专业 slice，但它不是第四 loop。测试设计、代码测试、产品结论和发行判断仍归各自 owner。一个 code leaf done 不等于整个变更完成。
+
+## 9. 组合验收
+
+组合验收必须绑定同一候选：产品要求集合、产品/系统合同及消费条款、代码集成身份、配置、正式入口、环境和证据窗口。它逐项判断每个必要 AC、系统义务和跨入口失败路径，并保留局部证据与未证明范围。
+
+推荐记录：
+
+| 验收引用 | 独立义务与条件 | 实际测试/观察 | 候选版本与环境 | 结果 | 证据定位 | 未证明范围 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `path#AC/DES` | 本次必须证明的具体部分 | 准确命令、suite 或真实入口观察 | source/integration/config/environment | 通过/失败/未运行/不适用 | Issue/artifact/receipt | 不能外推的链路 |
+
+“不适用”必须说明范围理由并由适用 owner 审查；happy path、单元测试、fixture 或 mock 只能关闭其实际覆盖的义务。子任务都关闭、一个入口通过或一条绿色 CI 不能代签跨模块调用、共享状态、权限、恢复、产品价值或发行权限。组合结论应明确需要 product、system、runtime、Viewer、Agent、QA 或 LiveOps/community 哪些专业判断，不能由 TPM 或本文替代。
+
+## 10. 变更影响与维护
+
+源、合同、权限、验收或候选身份变化时，先做有界影响评审；普通排版修订不应无理由使所有下游失效。影响评审至少回答：
+
+| 问题 | 必须记录 |
+| --- | --- |
+| 发生了什么 | 文件/anchor、旧/新版本、变化性质（编辑、行为、权限、合同、兼容或公开承诺） |
+| 谁受影响 | 直接设计/测试/任务消费者与间接跨域/组合消费者 |
+| 旧输入是否仍可用 | 新任务、在途任务、验收与发行各自的资格和限制 |
+| 如何处置 | 保留旧基线、暂停、缩小 scope、按现行规则重新绑定/迁移或补充兼容 |
+| 需要重验什么 | 受影响义务、入口、环境、候选 identity、证据与评审 |
+| 什么不受影响 | 明确范围与理由，不做无差别全仓重跑 |
+| 谁批准并实施 | 有权 owner、真实记录、实施结果；不得由候选 policy 自授权 |
+
+稳定架构风险留在设计，动态风险和阻断留在当前 Issue；二者通过明确引用关联。风险至少包含触发条件、影响、owner、缓解/接受依据、复核触发和剩余风险。superseded 文档指向后继并退出默认首读入口；历史 evidence 和 source snapshot 保持可检索，不通过改写历史制造当前能力。
+
+新增 PM/系统内容目前按人工内容规则和现有结构/link checks 维护；没有新增 metadata parser、semantic checker、Project field 或 required gate。后续只有在代表性文档和明确 owner/授权到位后，才可由 source-of-truth-first 变更实现机械校验，并补充正反例与迁移边界。
+
+## 11. 可复用记录模板
+
+以下模板是内容骨架，不是第二份 schema。使用时填入现行 helper/readback 提供的身份与字段；没有实际值时写明未验证或不适用，不自造 UID、状态、资格或批准。
+
+### 11.1 有限变更协调记录
+
+```markdown
+## 本次变更目标
+<一个可验证且有限的结果>
+
+## 身份与范围
+- Change ID：<有效关联标识，若适用>
+- 产品/专业范围：<REQ/AC/规则/设计引用>
+- 工程范围：<实际模块与允许写入范围>
+- 不在本次范围：<明确排除>
+- 用户授权与约束：<真实请求、hold 与允许动作>
+
+## 固定输入与关键依赖
+<来源、revision/digest、consumed clauses、解除条件和 evidence>
+
+## 必要交付义务
+| 交付义务 | 真实 Task/Issue | 交付对象 | 满足条件 |
+| --- | --- | --- | --- |
+| <义务> | <身份> | <文档/代码/验证> | <可判定条件> |
+
+## 组合验收
+- 候选版本、入口、环境、配置：<实际身份>
+- 必需 AC/系统义务：<精确集合>
+- 组织者与专业判断：<真实 owner>
+- 证据位置：<Issue/artifact/receipt>
+- 完成条件与未证明范围：<逐项结果>
+```
+
+### 11.2 叶子任务内容卡
+
+```markdown
+## 交付目标与来源
+<可验证结果；用户请求、REQ/AC、规则或 DES 引用>
+
+## 固定输入
+<产品/系统/工程来源、revision/digest、消费条款与 readback>
+
+## 写入边界
+- owner/scope：<现行绑定提供的值>
+- In scope：<允许路径与义务>
+- Out of scope：<排除项与不可修改 authority>
+
+## 依赖与条件
+<上游对象、硬/咨询关系、解除证据、阻断 owner>
+
+## 验收范围
+| 验收引用 | 本叶子证明的义务 | 明确未覆盖 | 验证入口 |
+| --- | --- | --- | --- |
+| <path#AC/DES> | <具体部分> | <组合/入口/环境限制> | <命令/测试/观察> |
+
+## 执行、交付与收尾
+<原子步骤、slice、集成顺序、真实产物、source/PR identity、workflow evidence>
+
+## 异常处理
+<输入失效、语义不清或 scope 不足时的停止条件与回流 owner>
+```
+
+### 11.3 专业 slice 交接卡
+
+```text
+任务：真实 Task UID、Issue、worktree、HEAD/epoch（如由有效 workflow 提供）
+专业角色：实际 role
+固定输入：产品/系统合同、revision/digest 与具体消费条款
+目标：本 slice 必须返回的判断或有界实现
+写入许可：task scope 与有效 policy 的交集
+允许读取：理解合同和边界所需的上下游资料
+返回内容：结果、路径、条款承接、命令/证据、缺口和未证明范围
+集成前置：必须等谁的哪些结果
+跨域发现：回到当前 Issue evidence；不得越权修改另一 authority
+```
+
+### 11.4 验证执行证据卡
+
+```markdown
+## 验证对象
+- Task UID/变更关联：<真实身份>
+- 产品/系统合同：<版本、digest、consumed clauses>
+- Source HEAD 与 integration base/tested tree：<实际值>
+- 入口、环境、配置与证据窗口：<实际值>
+
+## 执行事实
+- 方法/命令：<实际执行；未运行写未运行>
+- 退出码与结果：<实际值>
+- 产物：<路径/URL、摘要、digest>
+- 替身或模拟：<mock 与真实入口的边界>
+
+## 逐项判定
+| 验收引用 | 独立义务/前置 | 测试/观察 | 结果 | 证据定位 | 未证明范围 |
+| --- | --- | --- | --- | --- | --- |
+| <AC/DES> | <条件> | <准确测试> | <通过/失败/未运行/不适用> | <定位> | <限制> |
+
+## 结论边界
+<支持哪个叶子义务；哪些组合、产品、运行或发行判断仍需专业 owner>
+```
+
+### 11.5 阶段目标与交付验收记录
+
+```markdown
+# <阶段目标或能力增量>
+
+目标：<产生什么可验证变化>
+范围与非目标：<边界>
+负责角色：<协调责任与专业交付责任>
+目标日期：<日期/未设定；假设及是否对外承诺>
+
+## 必要交付义务
+| 义务 | 验收条件 | 真实 Task/evidence 引用 |
+| --- | --- | --- |
+| <义务> | <可判定条件> | <定位> |
+
+## 硬依赖与风险
+<解除条件、owner、复核触发和范围变更记录>
+
+## 验收结论
+核对时间：<带时区时间>
+已确认结果：<附证据>
+未完成义务：<不可因叶子结束而省略>
+剩余风险与接受依据：<正式记录>
+整体结论：<完成/部分/未验证；不替换 task 状态枚举>
+```
+
+### 11.6 跨 loop 合同差异反馈记录
+
+```markdown
+## 合同差异/跨 loop 反馈
+当前 Task UID 与交付类别：<正式绑定>
+消费合同：<准确 publication/revision/digest/条款>
+发现：<可复核事实>
+差异分类：<实现违反既有合同/需要修改合同/文档陈旧/未决>
+受影响范围：<接口、产品结果、测试、兼容、交付义务>
+建议：<保持现合同修复实现/由有权任务修订合同>
+当前可继续部分：<有界范围>
+当前阻断部分：<解除条件>
+权限说明：此反馈不创建或启动下一个任务。
+```
+
+### 11.7 组合验收记录
+
+```markdown
+## 本次候选
+<产品要求、产品/系统合同、代码集成身份、入口、配置、环境、窗口>
+
+## 必需交付对象
+<真实任务与证据；不以 closed 代替交付>
+
+## AC/义务汇总
+| 验收引用 | 必需义务与入口 | 同一候选证据 | 结论 | 缺口/阻塞 |
+| --- | --- | --- | --- | --- |
+| <AC/DES> | <范围> | <证据> | <实际判断> | <仍缺什么> |
+
+## 集成与产品边界
+<跨模块调用、权限、状态、失败恢复、mock 限制；产品/QA/发行判断的 owner>
+
+## 下一步
+<当前授权内的有限动作；新的 task 或继续须由相应 authority 授权>
+```
+
+### 11.8 变更影响评审卡
+
+```text
+发生变化的源：文件、anchor、旧/新版本、digest
+变化性质：纯编辑／行为／权限或损失／技术合同／兼容／公开承诺
+直接消费者：设计、测试、任务及其消费条款
+间接消费者：跨域调用、组合验收与发行说明
+旧合同资格：新任务、在途任务、验收、发行分别如何处理
+处置：保留旧基线／暂停／缩小 scope／按 workflow 重新绑定或迁移
+需要重验：受影响义务、入口、环境、候选身份和证据
+不受影响范围：依据与理由
+批准与实施：有权 owner、真实记录与复核结果
+```
+
+## 12. 采用与维护检查
+
+在审阅或收尾前核对：
+
+- 同一任务事实只有一个 GitHub/Project authority，`.pm` 只作生成映射或历史归档；
+- Task UID、owner、scope、固定输入、依赖、验收引用和实际证据能够互相定位；
+- 每个条件、失败路径和未证明范围都被单独表达；局部完成没有冒充组合完成；
+- 记录使用的状态和门禁来自现行 workflow，没有复制或发明枚举；
+- 文档、实现、测试、产品、QA、发布和公开说明的结论没有越过各自 owner；
+- 变更影响、历史证据和 superseded/retired 跳转保持可追溯；
+- 结构/link 检查的结果只被声明为结构证据；新的语义 checker 或 activation 未实现时明确写未实现。
+
+代表性 PM/系统文档迁移、第一批新字段需求、真实组合验收规模扩大或现有 checks 无法诊断固定输入/引用漂移时，应重新建立有界 owner task，先更新唯一 workflow/source authority，再实现兼容 checker 与正反例。这个触发器不创建自动 backlog，也不授权后台继续执行。
+
+## 参考与来源处置
+
+- 当前工作流：[`doc/engineering/workflow/source-of-truth.md`](../workflow/source-of-truth.md)。
+- 配套系统设计内容标准：[`system-design-writing-standard.design.md`](system-design-writing-standard.design.md)。
+- 当前 task/project 映射与归档路径：见 [`.pm/README.md`](../../../.pm/README.md) 及 workflow source 的 GitHub Project-backed PM contract。
+- 本规范吸收的系统设计/PM v1、贯通方案和模板均为本任务固定 proposal inputs；原文对照、哈希、历史 PR 状态与未采纳项保留在 GitHub Issue #3662 evidence 和任务 scratch，不把附件 metadata 当作当前 task truth。
+- 本规范采用其 PM sections 8–9、Appendices C–F、integration sections 5–8 和 templates B–F/H 的可复用内容语义；具体 lifecycle、schema、adapter、activation 与 release gate 继续由现行 workflow/专业 owner 管理。

--- a/doc/engineering/doc-governance/system-design-writing-standard.design.md
+++ b/doc/engineering/doc-governance/system-design-writing-standard.design.md
@@ -1,0 +1,238 @@
+# 系统设计写作规范
+
+- 状态：active
+- 适用范围：专业域的系统、架构、接口、状态、部署和验证设计文档
+- 当前入口：[engineering/doc-governance README](README.md)
+- 配套记录规范：[项目管理记录规范](project-management-record-standard.design.md)
+- 上游组织规范：[文档分工与组织规范](doc-structure-standard.design.md)
+- 任务生命周期权威：[workflow source of truth](../workflow/source-of-truth.md)
+
+本文是已落位的内容规范。它规定系统设计应表达什么、如何把上游要求交给专业设计、如何把设计条款映射到验证。本文不新增 workflow 状态、任务台账、权限模型、运行服务或产品承诺。
+
+产品 PRD 拥有产品价值、范围、玩家承诺和端到端结果；专业域 PRD 与 design 拥有该域的规则和技术合同；GitHub Issue/Project-backed task truth 拥有任务身份、范围、依赖、状态和过程证据；workflow source of truth 拥有生命周期、权限和门禁。发生冲突时，在当前 GitHub task evidence 中记录冲突和裁决，不在本文静默覆盖其他 authority。
+
+本文中的规范关键词具有以下强度：MUST/必须表示适用时的强制要求；MUST NOT/不得表示禁止行为；SHOULD/应表示默认要求，偏离时必须记录理由、影响和残余风险；MAY/可以表示在边界内的可选做法。普通评论、模板省略或作者声明不能豁免 MUST/MUST NOT。记录的例外必须写明受影响条款、理由、范围、批准 owner、失效/复核触发，并且不能覆盖上级产品、专业域或 workflow authority，也不能绕过门禁或权限。
+
+## 1. 问题、目标与非目标
+
+### 1.1 问题与目标
+
+系统设计必须让未读过聊天记录的消费者理解当前问题、目标、输入、输出、失败路径、恢复边界和验证方式。每份设计先写清：
+
+- 设计身份：稳定标题、专题或模块、owner role、适用范围和审读基线；
+- 问题、成功结果和可测目标；
+- 设计承担的技术责任；
+- 与产品需求、专业规则、实现和证据的链接。
+
+需要更强追溯时，可以在人工可读的身份块记录 id、title、status、owner_role、module、upstream_refs、source_baseline、last_reviewed_at、review_evidence_ref 和 superseded_by。它们目前是写作信息，不是本次新增的机器 schema；status 只描述文档生命周期，不赋予运行时、workflow 或合同消费资格。
+
+### 1.2 非目标
+
+系统设计不替代产品 PRD、源码、测试报告、操作 runbook 或任务状态。它不把 UI/request accepted 写成 world effect，不把 LLM 意图写成 authority，不把 applied 写成永久持久化或跨入口同步，也不把“已合并”写成能力已发布。
+
+仅涉及产品语义的设计继续使用现有 doc/product/ 配对 PRD/design 规范；本技术十二段骨架适用于专业技术设计，不强制产品设计改写为技术合同。
+
+### 1.3 按风险裁剪
+
+十二段是完整的技术设计视图。新建的长期设计和高风险变更 MUST 覆盖全部适用段落；跨域、协议/ABI、共识、存储、权限、迁移、恢复或状态模型变更 MUST 复核完整适用视图。小型、低风险且兼容的编辑 MAY 只更新受影响的条款、表格、需求承接和验证映射，不要求补写无关段落或填充空的 N/A 标题。任何省略都必须在当前 task evidence 中说明理由、未覆盖边界和 residual risk；裁剪不会豁免上级 authority、权限或 workflow gate。
+
+## 2. 上游约束与相关角色
+
+先列出消费者、输入 authority、专业 owner 和需要共同审读的角色。上游引用必须带路径和 fragment；固定输入还应带不可变提交、发布记录或当前 task contract 能提供的版本锚点。
+
+### 2.1 需求承接与分配表
+
+每一行 MUST 是一个真实的需求或专业接受关系，不能只写“支持 REQ”或类别名。路径和 fragment 要能定位到上游原文；纯工程变更没有产品 AC 时，填写专业规则/缺陷条款或用户请求的准确定位，并写明不适用产品 AC 的理由。
+
+| 上游 requirement / product AC / professional acceptance（path#fragment） | 具体 obligation 与适用条件 | 本设计条款（path#anchor） | 外部 owner / dependency | 明确排除或未覆盖范围 |
+| --- | --- | --- | --- | --- |
+| <真实上游路径#REQ/AC 或专业条款> | <本次必须承接的具体结果、前置条件和判定边界> | <本设计路径#DES 或 fragment> | <外部 authority、owner、固定输入或解除条件> | <不承诺的入口、环境、能力或未覆盖链路> |
+
+一条需求可以映射多个设计条款，一个设计条款也可以服务多个需求；每条关系都保留上述五列，不建立一对一文档或任务要求。外部 owner/dependency 不是本设计的隐含责任，排除范围也不能用空白代替。
+
+## 3. 当前状态、目标状态与差距
+
+必须把当前基线、目标、差距和假设分开。推荐使用下表；当前状态没有证据时写 unknown 或 未验证，不能以目标描述代替现状。
+
+| 对象/能力 | 当前状态（基线） | 目标状态 | 差距/假设 | 证据或 owner |
+| --- | --- | --- | --- | --- |
+|  |  |  |  |  |
+
+当前基线至少包含适用的提交、版本、配置、数据/快照、消费者和环境。若设计描述 partial、current、target、proven，必须说明它们分别代表文档、实现、测试还是发布事实。
+
+输入改变、消费者切换或基线失效时，不在正文中改写历史结论；通过当前 task 的变更记录和重新绑定处理，具体 eligibility/epoch 规则引用 workflow authority。
+
+## 4. 边界与结构
+
+说明组件、依赖、读写边界、authority、信任边界和不属于本设计的部分。至少回答：
+
+- 谁产生、拥有、读取和持久化每个事实；
+- 哪些输入是 advisory/intent，谁有权接受或拒绝；
+- 组件之间的同步、异步、重放或幂等边界；
+- 外部系统、WASM、LLM、节点、Viewer 和资源系统各自能证明什么；
+- 禁止哪些跨域修改或隐式回退。
+
+边界图、关系图或文字均可，图必须带图例、方向、版本/身份和失败语义。若产品输入包含控制权、draft、accepted、applied、stale 或 control-lost，技术设计要引用产品条款并保留这些状态的语义边界，不自行增加 UI 或协议字段。
+
+## 5. 关键运行流程
+
+用顺序图、状态转移或编号步骤表达成功、拒绝、超时、重试、并发冲突、恢复和取消。每条主流程要说明：
+
+1. 触发与前置条件；
+2. 输入身份、版本和幂等键；
+3. authority 作出的判定；
+4. 可观察结果和 receipt；
+5. 失败后是否重试、回滚、人工处理或终止。
+
+请求被接受不等于世界状态已应用；世界效果必须由 authoritative state、receipt 或明确的完成边界证明。没有该证据时，流程只可声明 request/validation outcome。
+
+## 6. 接口与数据合同
+
+每个跨组件接口说明 producer、consumer、身份、版本、顺序、兼容、错误、超时、重试和大小/资源边界。表格可采用：
+
+| 接口/条款 | producer → consumer | identity/version | ordering/idempotency | success/error | compatibility |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |
+
+任务输入合同沿用当前 binding 提供的 input_contracts、固定提交/发布记录和 acceptance references；本文不宣布这些字段已经由新的 parser 或 adapter 执行。不得只写不断变化的 main 路径作为 in-flight contract。
+
+接口字段、schema、ABI 或协议变化必须说明消费者兼容、版本切换、旧数据/快照处理和验证入口。缺少实现或运行证据时写明未验证范围，不用“设计上支持”替代事实。
+
+## 7. 状态、事务与持久化
+
+在完整适用的设计视图中，本节 MUST 单独出现；小型兼容编辑按 §1.3 只在受影响时更新本节相关条款和验证映射，不创建空的 N/A 标题。若状态、事务或持久化对该设计确实不适用，仍须写明理由以及负责的 authority。至少说明：
+
+- 状态集合、转移触发、拒绝条件和终态；
+- 事务原子性、提交点、并发冲突、重放和幂等；
+- 数据、快照、receipt、审计记录的 owner、生命周期和恢复方式；
+- accepted、applied、persisted、published 等词各自的证明条件。
+
+任务或文档生命周期不是运行时状态机。不要把 workflow done、文档 active、能力 proven 或产品 accepted 互相推导；它们分别回链自己的 authority。
+
+## 8. 部署、安全与运行约束
+
+写明部署拓扑、权限、信任边界、密钥/凭据使用、资源预算、超时、外部依赖、失败隔离、降级/禁用边界和环境差异。权限应说明“谁能在什么条件下做什么”，而不是只列角色名。
+
+运行、发布和恢复步骤留在相应 manual/runbook；本文只记录这些操作所依赖的设计约束和可验证接口。没有 hosted、真实网络、跨节点或浏览器证据时，不得从本地 fixture、同进程 demo 或可编译推断生产能力。
+
+## 9. 质量与容量
+
+每个质量目标采用“环境 / 输入或刺激 / 预期响应 / 判定指标 / 验证入口”格式。
+
+| 场景 | 环境、规模与资源 | 预期响应 | 指标/阈值来源 | 验证入口 | 当前范围 |
+| --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  | 未验证/已验证 |
+
+性能目标要给出数据规模、并发或节点数、硬件/资源边界、样本窗口、分位数和阈值来源。确定性、重放、故障恢复、权限和跨平台要求要注明是否覆盖。单条通路、fixture、feature 编译或文档检查只能证明相应范围。
+
+## 10. 兼容、迁移与回滚
+
+说明旧消费者、旧数据/快照、版本切换、启用/禁用、迁移顺序、双读/双写（如有）和回滚限制。回滚必须指出回到哪个已知基线、哪些副作用无法撤销、何时需要人工处置。
+
+输入合同、协议、schema 或权限资格发生实质变化时，必须在当前 task evidence 建立新基线并重新评估下游；新 draft 不自动使旧的有效合同失效。迁移示范不等于已完成全量迁移。
+
+## 11. 验证设计与可追溯性
+
+设计维护稳定的“要求—设计—验证方法”关系；任务维护本次实际实现、基线和证据。推荐追踪链：
+
+~~~
+产品成功标准（适用时）
+  -> 专业域 PRD-ID / 规则条款
+  -> 系统设计条款（路径 + fragment）
+  -> GitHub Task UID
+  -> PR + 固定源提交 / 实际测试基线
+  -> 测试、评审与交付证据
+~~~
+
+### 11.1 验证映射表
+
+该表是持久的设计验证计划，每行 MUST 把 AC 或专业接受条款、设计义务和准确的测试/手册入口连起来。实际通过/失败、退出码和产物仍写入当前 task evidence。
+
+| 上游 requirement / product AC / professional acceptance（path#fragment） | 本设计条款（path#anchor） | 独立 obligation 与适用条件 | 准确验证方法、test/manual source 或 ID、scenario/layer、固定 candidate/environment | evidence target | 未证明范围 |
+| --- | --- | --- | --- | --- | --- |
+| <真实上游路径#REQ/AC 或专业条款> | <本设计路径#DES 或 fragment> | <本次要证明的具体义务和前置条件> | <准确命令或观察、测试/手册路径与 ID、场景/层、版本/环境> | <Issue evidence、CI、artifact、receipt 或评审定位> | <未覆盖入口、失败路径、平台或阈值> |
+
+证据必须区分本地运行、fixture/fake-GitHub、hosted CI、真实集成和发布验证。结构检查通过只证明结构；不证明产品正确、专业语义、运行行为、独立审读或 release readiness。
+
+## 12. 决策、长期风险与未决问题
+
+记录替代方案、约束、选择理由、正负后果、适用/失效条件、残余风险、决策 owner 和触发器。未决问题必须能定位到条款、owner 和解除触发；活跃合同中不要留下没有责任人和边界的裸 TODO/TBD。日常进度、排期和任务状态留在 GitHub task evidence。
+
+重要模块边界、协议/ABI、存储/一致性、部署、安全权限、确定性或难以回退的迁移 SHOULD 有 ADR。实质反转用新的 ADR 替代并保留双向追溯，不伪造历史。
+
+### 12.1 交付边界
+
+本规范当前交付：专业技术设计的十二段骨架、需求承接表、当前/目标/差距表、接口/质量/验证映射、固定输入和证据边界，以及附录模板。
+
+本规范当前不激活：机器可执行的 oasis7.doc/v1 metadata schema、metadata/lifecycle checker、新的 PM 或 loop 状态、新 Project 字段、scheduler/service、自动下游任务和代表性技术 pilot。它们只有在各自 authority、adapter、检查范围和验证证据具备后才能单独采纳；这里的列举不是待办台账，也不改变当前 workflow。
+
+---
+
+## 附录 A：系统设计模板
+
+完整设计复制后保留适用的十二段，并用 N/A（理由）表示确实不适用。小型兼容编辑使用下方轻量修改卡，不要求创建空的十二段标题：
+
+~~~text
+# <topic> system design
+
+适用范围 / owner / 固定基线：
+关联 PRD、规则、任务和消费者：
+
+## 1. 问题、目标与非目标
+## 2. 上游约束与相关角色
+## 3. 当前状态、目标状态与差距
+## 4. 边界与结构
+## 5. 关键运行流程
+## 6. 接口与数据合同
+## 7. 状态、事务与持久化
+## 8. 部署、安全与运行约束
+## 9. 质量与容量
+## 10. 兼容、迁移与回滚
+## 11. 验证设计与可追溯性
+## 12. 决策、长期风险与未决问题
+
+附录：需求承接、接口/质量/验证映射、ADR、证据边界
+~~~
+
+### A.1 小型兼容编辑卡
+
+~~~text
+受影响条款/表格：
+上游 requirement 或专业 acceptance（path#fragment）：
+具体 obligation 与适用条件：
+本设计条款（path#anchor）：
+准确 test/manual source 或 ID、scenario/layer、固定 candidate/environment：
+外部 owner/dependency：
+明确排除、未覆盖范围与 residual risk：
+~~~
+
+## 附录 B：ADR 模板
+
+~~~text
+# ADR-<id>: <decision>
+
+状态 / 日期 / owner：
+问题与背景：
+约束：
+候选方案：
+选择及理由：
+正面与负面后果：
+适用与失效条件：
+替代关系与当前设计引用：
+验证与复核触发：
+~~~
+
+## 附录 C：设计审读与证据卡
+
+~~~text
+Task UID：
+记录类型：system-design-review
+角色与时间：
+固定 source/head、输入合同和环境：
+审读条款（path#fragment）：
+发现与严重性：
+处置与复核：
+验证命令/套件、退出码、artifact：
+结论：
+未覆盖边界与 residual risk：
+~~~

--- a/doc/engineering/prd.index.md
+++ b/doc/engineering/prd.index.md
@@ -14,6 +14,8 @@
 | --- | --- | --- |
 | `doc/engineering/doc-governance/doc-structure-standard.prd.md` | `doc/engineering/doc-governance/doc-structure-standard.design.md`；`documentation-governance.manual.md`（how-to） | GitHub task issue evidence comments |
 | `doc/engineering/doc-governance/product-documentation-standard.prd.md` | `doc/engineering/doc-governance/product-documentation-standard.design.md`；`product-documentation-standard.templates.md` | GitHub task issue evidence comments |
+| 系统设计写作规范（standalone content standard） | `doc/engineering/doc-governance/system-design-writing-standard.design.md` | GitHub task issue evidence comments |
+| 项目管理记录规范（standalone content standard） | `doc/engineering/doc-governance/project-management-record-standard.design.md` | GitHub task issue evidence comments |
 | `doc/engineering/rust-governance/rust-1200-line-root-cause-governance-2026-03-29.prd.md` | n/a（当前契约已收敛到 PRD） | n/a（执行证据归 GitHub task 与 git history） |
 | Production-supervisor workflow governance（normative source: [workflow source of truth](workflow/source-of-truth.md#capability-and-ownership)） | Target design: [production-supervisor-runtime.design.md](workflow/production-supervisor-runtime.design.md) | Evidence: GitHub task issue evidence comments |
 | Historical document-governance triplets | Current organization and consumption rules: `doc/engineering/doc-governance/doc-structure-standard.design.md`; inventory and maintenance-cost routing: `doc/engineering/governance/README.md` | Historical decision/rollout evidence: Git history and GitHub task issue evidence comments |
@@ -22,6 +24,7 @@
 ## 说明
 - 本索引用于保证模块专题文档在根入口文档树中可达。
 - 文档配对规则：`*.prd.md`、`*.design.md` 与同名 GitHub task issue evidence comments。
+- 上述两份 standalone content standard 没有另建 PRD 或本地 project ledger；它们的规范正文由 design 文件承接，任务与执行证据仍回到 GitHub task truth。
 - `doc/engineering/doc-governance/README.md` 是 doc-governance 簇级分流入口；本索引保留完整三件套可达性，不再要求读者从长表里判断治理问题归属。
 - `doc/engineering/rust-governance/README.md` 是 Rust 文件结构治理簇级分流入口；本索引保留单一当前契约的精确检索入口，不再复制已完成专题的 design / project。
 - `engineering` 根目录默认只保留 `README.md / prd.md / design.md / GitHub task issue evidence comments / prd.index.md` 五个模块入口；治理专题已分别下沉到 `doc-governance/`、`rust-governance/` 与 `governance/`。`doc-structure-standard` 负责组织、职责和消费层边界，`governance/README.md` 负责 inventory 和维护成本 follow-up 路由；workflow source of truth 与 `.agents/skills/README.md` 分别承接 self-evolution task/evidence boundary 与 skill reachability。已完成且规则已被这些 current authorities 承接的一次性专题不再作为 live 三件套暴露。`doc/devlog` 的当前入口是 `doc/devlog/README.md` compact archive summary，不再通过 active 专题三件套暴露。


### PR DESCRIPTION
产品要求进入系统设计与实现任务后，当前缺少统一的职责承接、固定输入与逐项验收记录内容约定。本次增加系统设计写作规范与项目管理记录规范，保留十二项技术内容骨架，将需求承接、验证映射、任务输入和组合验收模板接入现有文档治理入口。

规则继续使用现有产品与专业权威、GitHub task truth 和 workflow 生命周期。新文档不激活元数据解析器、三 loop policy 或检查器；Prompt 产品输入已有独立合并基线，技术合同与运行验证属于后续交付范围。

验证：doc-governance、readme-link、workflow-lint 和 staged diff 检查通过；QA 校验全部 7 个变更文档的 29 个本地链接与 8 个锚点。产品／系统语义复核发现的承接表、验证映射和风险裁剪问题已修正。现有检查不证明新规范的全部语义，也不证明运行或发行能力。

Task UID: task_93fabfeadb484b3ab15516ebf63d3850
Task: task_93fabfeadb484b3ab15516ebf63d3850
Refs #3662
