### PR TITLE
Implement runtime PromptControl results and authority fencing

### DIFF
--- a/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/oasis7_game_launcher_tests.rs
@@ -859,6 +859,7 @@ fn query_runtime_bound_players_reads_snapshot_bindings() {
                 capabilities: Vec::new(),
                 world_id: "test-world".to_string(),
                 control_profile: oasis7::viewer::ViewerControlProfile::Playback,
+                authority_epoch: None,
             },
         )
         .expect("write hello ack");

--- a/crates/oasis7/src/bin/oasis7_game_launcher/runtime_presence.rs
+++ b/crates/oasis7/src/bin/oasis7_game_launcher/runtime_presence.rs
@@ -245,6 +245,7 @@ mod tests {
                     capabilities: Vec::new(),
                     world_id: "test-world".to_string(),
                     control_profile: oasis7::viewer::ViewerControlProfile::Live,
+                    authority_epoch: None,
                 },
             );
             expect_request_type(&mut reader, |request| {
@@ -299,6 +300,7 @@ mod tests {
                         capabilities: Vec::new(),
                         world_id: "test-world".to_string(),
                         control_profile: oasis7::viewer::ViewerControlProfile::Live,
+                        authority_epoch: None,
                     },
                 );
                 expect_request_type(&mut reader, |request| {

--- a/crates/oasis7/src/bin/oasis7_pure_api_client/support.rs
+++ b/crates/oasis7/src/bin/oasis7_pure_api_client/support.rs
@@ -141,6 +141,10 @@ pub(super) fn build_signed_prompt_apply_request(
         system_prompt_override,
         short_term_goal_override,
         long_term_goal_override,
+        request_id: None,
+        session_epoch: None,
+        binding_epoch: None,
+        expected_authority_epoch: None,
     };
     let intent = if preview {
         PromptControlAuthIntent::Preview
@@ -180,6 +184,10 @@ pub(super) fn build_signed_prompt_rollback_request(
         to_version,
         expected_version,
         updated_by,
+        request_id: None,
+        session_epoch: None,
+        binding_epoch: None,
+        expected_authority_epoch: None,
     };
     let proof = sign_prompt_control_rollback_auth_proof(
         &request,

--- a/crates/oasis7/src/bin/oasis7_pure_api_client/tests.rs
+++ b/crates/oasis7/src/bin/oasis7_pure_api_client/tests.rs
@@ -150,6 +150,7 @@ fn collect_until_reports_timeout_when_peer_stays_open() {
             capabilities: Vec::new(),
             world_id: "test-world".to_string(),
             control_profile: oasis7::viewer::ViewerControlProfile::Live,
+            authority_epoch: None,
         };
         writeln!(
             writer,

--- a/crates/oasis7/src/simulator/async_agent_runner_actor_controls.rs
+++ b/crates/oasis7/src/simulator/async_agent_runner_actor_controls.rs
@@ -29,7 +29,7 @@ impl AsyncAgentRunner {
                 short_term_goal,
                 long_term_goal,
             })
-            .map_err(|error| error.with_feedback_agent(agent_id))
+            .map_err(|error| error.with_agent(agent_id))
     }
 
     /// Deliver player input to an actor without bypassing the shared Harness

--- a/crates/oasis7/src/simulator/tests/agent_cognition_live_actor.rs
+++ b/crates/oasis7/src/simulator/tests/agent_cognition_live_actor.rs
@@ -13,8 +13,8 @@ use crate::simulator::{
     ContinuousAgentTurnContextV1, Digest32, GoalSnapshotV1, MemoryContextSnapshotV1,
 };
 use serde_json::json;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 const AGENT_ID: &str = "agent-live-1";
@@ -195,6 +195,182 @@ fn mailbox_capacity_is_per_actor_and_does_not_cap_parallel_turns() {
         completed, 2,
         "both parallel turns must complete after release"
     );
+}
+
+#[derive(Clone)]
+struct RecordingLlmCompletionClient {
+    requests: Arc<Mutex<Vec<crate::simulator::llm_agent::LlmCompletionRequest>>>,
+}
+
+impl crate::simulator::llm_agent::LlmCompletionClient for RecordingLlmCompletionClient {
+    fn complete(
+        &self,
+        request: &crate::simulator::llm_agent::LlmCompletionRequest,
+    ) -> Result<crate::simulator::llm_agent::LlmCompletionResult, crate::simulator::LlmClientError>
+    {
+        self.requests
+            .lock()
+            .expect("recording client lock")
+            .push(request.clone());
+        Ok(crate::simulator::llm_agent::LlmCompletionResult {
+            turns: vec![crate::simulator::llm_agent::LlmCompletionTurn::Decision {
+                payload: json!({"decision": "wait"}),
+            }],
+            output: r#"{"decision":"wait"}"#.to_string(),
+            model: Some(request.model.clone()),
+            prompt_tokens: Some(1),
+            completion_tokens: Some(1),
+            total_tokens: Some(2),
+        })
+    }
+}
+
+fn recording_llm_config() -> crate::simulator::LlmAgentConfig {
+    crate::simulator::LlmAgentConfig {
+        model: "gpt-agent-consumption-test".to_string(),
+        base_url: "https://example.invalid/v1".to_string(),
+        api_key: "test-key".to_string(),
+        timeout_ms: 1_000,
+        system_prompt: "base-system".to_string(),
+        short_term_goal: "base-short-goal".to_string(),
+        long_term_goal: "base-long-goal".to_string(),
+        max_module_calls: 1,
+        max_decision_steps: 1,
+        max_repair_rounds: 0,
+        prompt_max_history_items: 4,
+        prompt_profile: crate::simulator::llm_agent::LlmPromptProfile::Balanced,
+        force_replan_after_same_action: 0,
+        harvest_max_amount_cap: 100,
+        execute_until_auto_reenter_ticks: 0,
+        llm_debug_mode: false,
+    }
+}
+
+#[test]
+fn native_async_override_is_consumed_by_the_next_recorded_completion_request() {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let behavior = crate::simulator::LlmAgentBehavior::new(
+        AGENT_ID,
+        recording_llm_config(),
+        RecordingLlmCompletionClient {
+            requests: Arc::clone(&requests),
+        },
+    );
+    let mut runner = AsyncAgentRunner::new(2).expect("create native actor runner");
+    runner
+        .register(behavior)
+        .expect("register native llm actor");
+
+    runner
+        .set_prompt_overrides(
+            AGENT_ID,
+            Some("runtime-system-override".to_string()),
+            Some("runtime-short-goal".to_string()),
+            Some("runtime-long-goal".to_string()),
+        )
+        .expect("enqueue prompt override before next decision");
+    let turn_id = runner.start_turn(AGENT_ID).expect("start next native turn");
+    let mut outcome = None;
+    for _ in 0..1024 {
+        outcome = runner
+            .poll_completed()
+            .expect("poll native actor")
+            .into_iter()
+            .find(|outcome| outcome.turn_id == turn_id);
+        if outcome.is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    let outcome = outcome.expect("the next native decision must complete within the poll bound");
+    assert_eq!(
+        outcome.decision,
+        Some(crate::simulator::AgentDecision::Wait)
+    );
+
+    let request = requests
+        .lock()
+        .expect("recording client lock")
+        .first()
+        .cloned()
+        .expect("the next native decision reaches the completion client");
+    assert!(request.system_prompt.contains("runtime-system-override"));
+    assert!(request.system_prompt.contains("runtime-short-goal"));
+    assert!(request.system_prompt.contains("runtime-long-goal"));
+    assert!(!request.system_prompt.contains("base-system"));
+    assert!(!request.system_prompt.contains("base-short-goal"));
+    assert!(!request.system_prompt.contains("base-long-goal"));
+}
+
+struct BlockingOverrideBehavior {
+    agent_id: String,
+    started: Arc<AtomicBool>,
+    release: Arc<AtomicBool>,
+}
+
+impl AgentBehavior for BlockingOverrideBehavior {
+    fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    fn decide(&mut self, _observation: &Observation) -> AgentDecision {
+        self.started.store(true, Ordering::Release);
+        while !self.release.load(Ordering::Acquire) {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        AgentDecision::Wait
+    }
+}
+
+#[test]
+fn native_prompt_override_enqueue_reports_mailbox_saturation() {
+    let started = Arc::new(AtomicBool::new(false));
+    let release = Arc::new(AtomicBool::new(false));
+    let mut runner = AsyncAgentRunner::new(1).expect("create one-slot actor runner");
+    let _release_guard = ReleaseOnDrop(Arc::clone(&release));
+    runner
+        .register(BlockingOverrideBehavior {
+            agent_id: AGENT_ID.to_string(),
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        })
+        .expect("register blocking actor");
+    runner.start_turn(AGENT_ID).expect("start blocking turn");
+    for _ in 0..1024 {
+        if started.load(Ordering::Acquire) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    assert!(started.load(Ordering::Acquire));
+
+    runner
+        .set_prompt_overrides(AGENT_ID, Some("queued".to_string()), None, None)
+        .expect("first override fits the bounded mailbox");
+    let error = runner
+        .set_prompt_overrides(AGENT_ID, Some("rejected".to_string()), None, None)
+        .expect_err("second override must fail while mailbox is saturated");
+    let legacy_error = runner
+        .notify_player_message(AGENT_ID, 0, "queued player message")
+        .expect_err("the legacy player-message path remains saturated");
+    assert_eq!(legacy_error.code(), "feedback_unavailable");
+    assert_eq!(error.code(), "mailbox_full");
+    assert!(matches!(
+        error,
+        crate::simulator::AsyncAgentRunnerError::MailboxFull
+    ));
+
+    release.store(true, Ordering::Release);
+    for _ in 0..1024 {
+        if !runner
+            .poll_completed()
+            .expect("poll released actor")
+            .is_empty()
+        {
+            break;
+        }
+        std::thread::yield_now();
+    }
 }
 
 #[test]

--- a/crates/oasis7/src/viewer/auth.rs
+++ b/crates/oasis7/src/viewer/auth.rs
@@ -931,14 +931,16 @@ fn prompt_field_patch_v1(value: &Option<Option<String>>) -> PromptFieldPatchV1 {
     }
 }
 
-fn has_enhanced_prompt_identity_apply(request: &PromptControlApplyRequest) -> bool {
+pub(crate) fn has_enhanced_prompt_identity_apply(request: &PromptControlApplyRequest) -> bool {
     request.request_id.is_some()
         || request.session_epoch.is_some()
         || request.binding_epoch.is_some()
         || request.expected_authority_epoch.is_some()
 }
 
-fn has_enhanced_prompt_identity_rollback(request: &PromptControlRollbackRequest) -> bool {
+pub(crate) fn has_enhanced_prompt_identity_rollback(
+    request: &PromptControlRollbackRequest,
+) -> bool {
     request.request_id.is_some()
         || request.session_epoch.is_some()
         || request.binding_epoch.is_some()

--- a/crates/oasis7/src/viewer/auth.rs
+++ b/crates/oasis7/src/viewer/auth.rs
@@ -10,6 +10,15 @@ use super::protocol::{
 
 mod collect_data;
 pub use collect_data::{sign_collect_data_auth_proof, verify_collect_data_auth_proof};
+#[path = "auth/prompt_control.rs"]
+mod prompt_control;
+pub use prompt_control::{
+    PromptControlAuthIntent, sign_hosted_prompt_control_strong_auth_grant,
+    sign_prompt_control_apply_auth_proof, sign_prompt_control_rollback_auth_proof,
+    verify_hosted_prompt_control_apply_strong_auth_grant,
+    verify_hosted_prompt_control_rollback_strong_auth_grant,
+    verify_prompt_control_apply_auth_proof, verify_prompt_control_rollback_auth_proof,
+};
 mod fragment_refill_preview;
 pub use fragment_refill_preview::{
     sign_fragment_refill_preview_auth_proof, verify_fragment_refill_preview_auth_proof,
@@ -92,12 +101,6 @@ pub const AGENT_CHAT_AUTHORITY_SCOPE: &str = "player_agent_chat";
 const VIEWER_HOSTED_STRONG_AUTH_GRANT_PAYLOAD_VERSION: u8 = 1;
 pub const VIEWER_HOSTED_STRONG_AUTH_GRANT_SIGNATURE_V1_PREFIX: &str = "awhostedgrant:v1:";
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PromptControlAuthIntent {
-    Preview,
-    Apply,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedPlayerAuth {
     pub player_id: String,
@@ -119,6 +122,51 @@ struct PromptFieldPatch<'a> {
     mode: PromptFieldMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PromptFieldPatchV1 {
+    Unchanged,
+    Clear,
+    Set(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct PromptControlOperationIdentityV1 {
+    operation: String,
+    preview: bool,
+    agent_id: String,
+    player_id: String,
+    session_epoch: u64,
+    binding_epoch: u64,
+    expected_authority_epoch: String,
+    expected_version: u64,
+    system_prompt: PromptFieldPatchV1,
+    short_term_goal: PromptFieldPatchV1,
+    long_term_goal: PromptFieldPatchV1,
+    rollback_target: Option<u64>,
+    updated_by: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct PromptControlEnhancedSigningPayload<'a> {
+    operation: &'static str,
+    preview: bool,
+    request_id: &'a str,
+    agent_id: &'a str,
+    player_id: &'a str,
+    public_key: &'a str,
+    nonce: u64,
+    session_epoch: u64,
+    binding_epoch: u64,
+    expected_authority_epoch: &'a str,
+    expected_version: u64,
+    system_prompt: PromptFieldPatchV1,
+    short_term_goal: PromptFieldPatchV1,
+    long_term_goal: PromptFieldPatchV1,
+    rollback_target: Option<u64>,
+    updated_by: Option<&'a str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -273,283 +321,6 @@ where
 {
     version: u8,
     payload: T,
-}
-
-pub fn sign_prompt_control_apply_auth_proof(
-    intent: PromptControlAuthIntent,
-    request: &PromptControlApplyRequest,
-    nonce: u64,
-    signer_public_key_hex: &str,
-    signer_private_key_hex: &str,
-) -> Result<PlayerAuthProof, String> {
-    if nonce == 0 {
-        return Err("auth nonce must be greater than zero".to_string());
-    }
-    let player_id =
-        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
-    let request_public_key = normalize_required_optional_public_key(
-        request.public_key.as_deref(),
-        "prompt_control public_key",
-    )?;
-    let signer_public_key =
-        normalize_public_key_field(signer_public_key_hex, "prompt_control signer public key")?;
-    if signer_public_key != request_public_key {
-        return Err("prompt_control public_key does not match signer public key".to_string());
-    }
-
-    let signing_key =
-        signing_key_from_hex(signer_private_key_hex, "prompt_control signer private key")?;
-    verify_keypair_match(
-        &signing_key,
-        signer_public_key.as_str(),
-        "prompt_control signer public key",
-    )?;
-
-    let signing_payload = build_prompt_control_apply_signing_payload(
-        intent,
-        request,
-        player_id.as_str(),
-        request_public_key.as_str(),
-        nonce,
-    )?;
-    sign_player_auth_proof(
-        signing_key,
-        player_id,
-        signer_public_key,
-        nonce,
-        signing_payload,
-    )
-}
-
-pub fn verify_prompt_control_apply_auth_proof(
-    intent: PromptControlAuthIntent,
-    request: &PromptControlApplyRequest,
-    proof: &PlayerAuthProof,
-) -> Result<VerifiedPlayerAuth, String> {
-    verify_proof_scheme(proof)?;
-    let request_player_id =
-        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
-    let request_public_key = normalize_required_optional_public_key(
-        request.public_key.as_deref(),
-        "prompt_control public_key",
-    )?;
-    let proof_player_id =
-        normalize_required_field(proof.player_id.as_str(), "auth proof player_id")?;
-    let proof_public_key =
-        normalize_public_key_field(proof.public_key.as_str(), "auth proof public key")?;
-    if request_player_id != proof_player_id {
-        return Err("auth proof player_id does not match request player_id".to_string());
-    }
-    if request_public_key != proof_public_key {
-        return Err("auth proof public_key does not match request public_key".to_string());
-    }
-    if proof.nonce == 0 {
-        return Err("auth nonce must be greater than zero".to_string());
-    }
-    let signing_payload = build_prompt_control_apply_signing_payload(
-        intent,
-        request,
-        proof_player_id.as_str(),
-        proof_public_key.as_str(),
-        proof.nonce,
-    )?;
-    verify_player_auth_signature(
-        proof_public_key.as_str(),
-        proof.signature.as_str(),
-        signing_payload.as_slice(),
-    )?;
-    Ok(VerifiedPlayerAuth {
-        player_id: proof_player_id,
-        public_key: proof_public_key,
-        nonce: proof.nonce,
-        hosted_registration_nonce: None,
-    })
-}
-
-pub fn sign_prompt_control_rollback_auth_proof(
-    request: &PromptControlRollbackRequest,
-    nonce: u64,
-    signer_public_key_hex: &str,
-    signer_private_key_hex: &str,
-) -> Result<PlayerAuthProof, String> {
-    if nonce == 0 {
-        return Err("auth nonce must be greater than zero".to_string());
-    }
-    let player_id =
-        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
-    let request_public_key = normalize_required_optional_public_key(
-        request.public_key.as_deref(),
-        "prompt_control public_key",
-    )?;
-    let signer_public_key =
-        normalize_public_key_field(signer_public_key_hex, "prompt_control signer public key")?;
-    if signer_public_key != request_public_key {
-        return Err("prompt_control public_key does not match signer public key".to_string());
-    }
-
-    let signing_key =
-        signing_key_from_hex(signer_private_key_hex, "prompt_control signer private key")?;
-    verify_keypair_match(
-        &signing_key,
-        signer_public_key.as_str(),
-        "prompt_control signer public key",
-    )?;
-
-    let signing_payload = build_prompt_control_rollback_signing_payload(
-        request,
-        player_id.as_str(),
-        request_public_key.as_str(),
-        nonce,
-    )?;
-    sign_player_auth_proof(
-        signing_key,
-        player_id,
-        signer_public_key,
-        nonce,
-        signing_payload,
-    )
-}
-
-pub fn verify_prompt_control_rollback_auth_proof(
-    request: &PromptControlRollbackRequest,
-    proof: &PlayerAuthProof,
-) -> Result<VerifiedPlayerAuth, String> {
-    verify_proof_scheme(proof)?;
-    let request_player_id =
-        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
-    let request_public_key = normalize_required_optional_public_key(
-        request.public_key.as_deref(),
-        "prompt_control public_key",
-    )?;
-    let proof_player_id =
-        normalize_required_field(proof.player_id.as_str(), "auth proof player_id")?;
-    let proof_public_key =
-        normalize_public_key_field(proof.public_key.as_str(), "auth proof public key")?;
-    if request_player_id != proof_player_id {
-        return Err("auth proof player_id does not match request player_id".to_string());
-    }
-    if request_public_key != proof_public_key {
-        return Err("auth proof public_key does not match request public_key".to_string());
-    }
-    if proof.nonce == 0 {
-        return Err("auth nonce must be greater than zero".to_string());
-    }
-    let signing_payload = build_prompt_control_rollback_signing_payload(
-        request,
-        proof_player_id.as_str(),
-        proof_public_key.as_str(),
-        proof.nonce,
-    )?;
-    verify_player_auth_signature(
-        proof_public_key.as_str(),
-        proof.signature.as_str(),
-        signing_payload.as_slice(),
-    )?;
-    Ok(VerifiedPlayerAuth {
-        player_id: proof_player_id,
-        public_key: proof_public_key,
-        nonce: proof.nonce,
-        hosted_registration_nonce: None,
-    })
-}
-
-pub fn sign_hosted_prompt_control_strong_auth_grant(
-    action_id: &str,
-    player_id: &str,
-    player_public_key: &str,
-    agent_id: &str,
-    issued_at_unix_ms: u64,
-    expires_at_unix_ms: u64,
-    signer_public_key_hex: &str,
-    signer_private_key_hex: &str,
-) -> Result<HostedStrongAuthGrant, String> {
-    if issued_at_unix_ms == 0 {
-        return Err(
-            "hosted strong-auth grant issued_at_unix_ms must be greater than zero".to_string(),
-        );
-    }
-    if expires_at_unix_ms <= issued_at_unix_ms {
-        return Err(
-            "hosted strong-auth grant expires_at_unix_ms must be greater than issued_at_unix_ms"
-                .to_string(),
-        );
-    }
-    let operation = normalize_prompt_control_grant_operation(action_id)?;
-    let player_id = normalize_required_field(player_id, "hosted strong-auth player_id")?;
-    let player_public_key =
-        normalize_public_key_field(player_public_key, "hosted strong-auth player_public_key")?;
-    let agent_id = normalize_required_field(agent_id, "hosted strong-auth agent_id")?;
-    let signer_public_key = normalize_public_key_field(
-        signer_public_key_hex,
-        "hosted strong-auth signer public key",
-    )?;
-    let signing_key = signing_key_from_hex(
-        signer_private_key_hex,
-        "hosted strong-auth signer private key",
-    )?;
-    verify_keypair_match(
-        &signing_key,
-        signer_public_key.as_str(),
-        "hosted strong-auth signer public key",
-    )?;
-    let signing_payload = build_hosted_prompt_control_strong_auth_grant_payload(
-        operation,
-        player_id.as_str(),
-        player_public_key.as_str(),
-        agent_id.as_str(),
-        issued_at_unix_ms,
-        expires_at_unix_ms,
-    )?;
-    let signature = signing_key.sign(signing_payload.as_slice());
-    Ok(HostedStrongAuthGrant {
-        version: VIEWER_HOSTED_STRONG_AUTH_GRANT_PAYLOAD_VERSION,
-        action_id: operation.to_string(),
-        player_id,
-        player_public_key,
-        agent_id,
-        issued_at_unix_ms,
-        expires_at_unix_ms,
-        signer_public_key,
-        signature: format!(
-            "{VIEWER_HOSTED_STRONG_AUTH_GRANT_SIGNATURE_V1_PREFIX}{}",
-            hex::encode(signature.to_bytes())
-        ),
-    })
-}
-
-pub fn verify_hosted_prompt_control_apply_strong_auth_grant(
-    intent: PromptControlAuthIntent,
-    request: &PromptControlApplyRequest,
-    grant: &HostedStrongAuthGrant,
-    required_signer_public_key: &str,
-    now_unix_ms: u64,
-) -> Result<(), String> {
-    verify_hosted_prompt_control_strong_auth_grant(
-        prompt_control_intent_operation(intent),
-        request.agent_id.as_str(),
-        request.player_id.as_str(),
-        request.public_key.as_deref(),
-        grant,
-        required_signer_public_key,
-        now_unix_ms,
-    )
-}
-
-pub fn verify_hosted_prompt_control_rollback_strong_auth_grant(
-    request: &PromptControlRollbackRequest,
-    grant: &HostedStrongAuthGrant,
-    required_signer_public_key: &str,
-    now_unix_ms: u64,
-) -> Result<(), String> {
-    verify_hosted_prompt_control_strong_auth_grant(
-        "prompt_control_rollback",
-        request.agent_id.as_str(),
-        request.player_id.as_str(),
-        request.public_key.as_deref(),
-        grant,
-        required_signer_public_key,
-        now_unix_ms,
-    )
 }
 
 pub fn sign_gameplay_action_auth_proof(
@@ -838,6 +609,52 @@ fn build_prompt_control_apply_signing_payload(
     public_key: &str,
     nonce: u64,
 ) -> Result<Vec<u8>, String> {
+    if has_enhanced_prompt_identity_apply(request) {
+        let request_id = normalize_required_field(
+            request
+                .request_id
+                .as_deref()
+                .ok_or_else(|| "prompt_control request_id is required".to_string())?,
+            "prompt_control request_id",
+        )?;
+        if request_id.len() > 128 {
+            return Err("prompt_control request_id exceeds 128 UTF-8 bytes".to_string());
+        }
+        let identity = normalize_prompt_control_operation_identity(
+            prompt_control_intent_operation(intent),
+            matches!(intent, PromptControlAuthIntent::Preview),
+            request.agent_id.as_str(),
+            player_id,
+            request.session_epoch,
+            request.binding_epoch,
+            request.expected_authority_epoch.as_deref(),
+            request.expected_version,
+            &request.system_prompt_override,
+            &request.short_term_goal_override,
+            &request.long_term_goal_override,
+            None,
+            request.updated_by.as_deref(),
+        )?;
+        let payload = PromptControlEnhancedSigningPayload {
+            operation: prompt_control_intent_operation(intent),
+            preview: matches!(intent, PromptControlAuthIntent::Preview),
+            request_id: request_id.as_str(),
+            agent_id: identity.agent_id.as_str(),
+            player_id: identity.player_id.as_str(),
+            public_key,
+            nonce,
+            session_epoch: identity.session_epoch,
+            binding_epoch: identity.binding_epoch,
+            expected_authority_epoch: identity.expected_authority_epoch.as_str(),
+            expected_version: identity.expected_version,
+            system_prompt: identity.system_prompt,
+            short_term_goal: identity.short_term_goal,
+            long_term_goal: identity.long_term_goal,
+            rollback_target: identity.rollback_target,
+            updated_by: identity.updated_by.as_deref(),
+        };
+        return encode_signing_payload(payload);
+    }
     let payload = PromptControlApplySigningPayload {
         operation: prompt_control_intent_operation(intent),
         agent_id: request.agent_id.as_str(),
@@ -859,6 +676,52 @@ fn build_prompt_control_rollback_signing_payload(
     public_key: &str,
     nonce: u64,
 ) -> Result<Vec<u8>, String> {
+    if has_enhanced_prompt_identity_rollback(request) {
+        let request_id = normalize_required_field(
+            request
+                .request_id
+                .as_deref()
+                .ok_or_else(|| "prompt_control request_id is required".to_string())?,
+            "prompt_control request_id",
+        )?;
+        if request_id.len() > 128 {
+            return Err("prompt_control request_id exceeds 128 UTF-8 bytes".to_string());
+        }
+        let identity = normalize_prompt_control_operation_identity(
+            "rollback",
+            false,
+            request.agent_id.as_str(),
+            player_id,
+            request.session_epoch,
+            request.binding_epoch,
+            request.expected_authority_epoch.as_deref(),
+            request.expected_version,
+            &None,
+            &None,
+            &None,
+            Some(request.to_version),
+            request.updated_by.as_deref(),
+        )?;
+        let payload = PromptControlEnhancedSigningPayload {
+            operation: "prompt_control_rollback",
+            preview: false,
+            request_id: request_id.as_str(),
+            agent_id: identity.agent_id.as_str(),
+            player_id: identity.player_id.as_str(),
+            public_key,
+            nonce,
+            session_epoch: identity.session_epoch,
+            binding_epoch: identity.binding_epoch,
+            expected_authority_epoch: identity.expected_authority_epoch.as_str(),
+            expected_version: identity.expected_version,
+            system_prompt: identity.system_prompt,
+            short_term_goal: identity.short_term_goal,
+            long_term_goal: identity.long_term_goal,
+            rollback_target: identity.rollback_target,
+            updated_by: identity.updated_by.as_deref(),
+        };
+        return encode_signing_payload(payload);
+    }
     let payload = PromptControlRollbackSigningPayload {
         operation: "prompt_control_rollback",
         agent_id: request.agent_id.as_str(),
@@ -1051,6 +914,86 @@ fn prompt_field_patch(value: &Option<Option<String>>) -> PromptFieldPatch<'_> {
             value: Some(next.as_str()),
         },
     }
+}
+
+fn prompt_field_patch_v1(value: &Option<Option<String>>) -> PromptFieldPatchV1 {
+    match value {
+        None => PromptFieldPatchV1::Unchanged,
+        Some(None) => PromptFieldPatchV1::Clear,
+        Some(Some(raw)) => {
+            let value = raw.trim();
+            if value.is_empty() {
+                PromptFieldPatchV1::Clear
+            } else {
+                PromptFieldPatchV1::Set(value.to_string())
+            }
+        }
+    }
+}
+
+fn has_enhanced_prompt_identity_apply(request: &PromptControlApplyRequest) -> bool {
+    request.request_id.is_some()
+        || request.session_epoch.is_some()
+        || request.binding_epoch.is_some()
+        || request.expected_authority_epoch.is_some()
+}
+
+fn has_enhanced_prompt_identity_rollback(request: &PromptControlRollbackRequest) -> bool {
+    request.request_id.is_some()
+        || request.session_epoch.is_some()
+        || request.binding_epoch.is_some()
+        || request.expected_authority_epoch.is_some()
+}
+
+pub(crate) fn normalize_prompt_control_operation_identity(
+    operation: &str,
+    preview: bool,
+    agent_id: &str,
+    player_id: &str,
+    session_epoch: Option<u64>,
+    binding_epoch: Option<u64>,
+    expected_authority_epoch: Option<&str>,
+    expected_version: Option<u64>,
+    system_prompt: &Option<Option<String>>,
+    short_term_goal: &Option<Option<String>>,
+    long_term_goal: &Option<Option<String>>,
+    rollback_target: Option<u64>,
+    updated_by: Option<&str>,
+) -> Result<PromptControlOperationIdentityV1, String> {
+    let agent_id = normalize_required_field(agent_id, "prompt_control agent_id")?;
+    let player_id = normalize_required_field(player_id, "prompt_control player_id")?;
+    let expected_authority_epoch = normalize_required_field(
+        expected_authority_epoch
+            .ok_or_else(|| "prompt_control expected_authority_epoch is required".to_string())?,
+        "prompt_control expected_authority_epoch",
+    )?;
+    let updated_by = updated_by
+        .map(|value| normalize_required_field(value, "prompt_control updated_by"))
+        .transpose()?;
+    Ok(PromptControlOperationIdentityV1 {
+        operation: operation.to_string(),
+        preview,
+        agent_id,
+        player_id,
+        session_epoch: session_epoch
+            .ok_or_else(|| "prompt_control session_epoch is required".to_string())?,
+        binding_epoch: binding_epoch
+            .ok_or_else(|| "prompt_control binding_epoch is required".to_string())?,
+        expected_authority_epoch,
+        expected_version: expected_version
+            .ok_or_else(|| "prompt_control expected_version is required".to_string())?,
+        system_prompt: prompt_field_patch_v1(system_prompt),
+        short_term_goal: prompt_field_patch_v1(short_term_goal),
+        long_term_goal: prompt_field_patch_v1(long_term_goal),
+        rollback_target,
+        updated_by,
+    })
+}
+
+pub(crate) fn prompt_control_operation_digest(
+    identity: &PromptControlOperationIdentityV1,
+) -> String {
+    crate::simulator::h_v1("oasis7.viewer.prompt-control.operation.v1", identity).to_string()
 }
 
 fn sign_player_auth_proof(

--- a/crates/oasis7/src/viewer/auth/prompt_control.rs
+++ b/crates/oasis7/src/viewer/auth/prompt_control.rs
@@ -1,0 +1,285 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptControlAuthIntent {
+    Preview,
+    Apply,
+}
+
+pub fn sign_prompt_control_apply_auth_proof(
+    intent: PromptControlAuthIntent,
+    request: &PromptControlApplyRequest,
+    nonce: u64,
+    signer_public_key_hex: &str,
+    signer_private_key_hex: &str,
+) -> Result<PlayerAuthProof, String> {
+    if nonce == 0 {
+        return Err("auth nonce must be greater than zero".to_string());
+    }
+    let player_id =
+        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
+    let request_public_key = normalize_required_optional_public_key(
+        request.public_key.as_deref(),
+        "prompt_control public_key",
+    )?;
+    let signer_public_key =
+        normalize_public_key_field(signer_public_key_hex, "prompt_control signer public key")?;
+    if signer_public_key != request_public_key {
+        return Err("prompt_control public_key does not match signer public key".to_string());
+    }
+
+    let signing_key =
+        signing_key_from_hex(signer_private_key_hex, "prompt_control signer private key")?;
+    verify_keypair_match(
+        &signing_key,
+        signer_public_key.as_str(),
+        "prompt_control signer public key",
+    )?;
+
+    let signing_payload = super::build_prompt_control_apply_signing_payload(
+        intent,
+        request,
+        player_id.as_str(),
+        request_public_key.as_str(),
+        nonce,
+    )?;
+    sign_player_auth_proof(
+        signing_key,
+        player_id,
+        signer_public_key,
+        nonce,
+        signing_payload,
+    )
+}
+
+pub fn verify_prompt_control_apply_auth_proof(
+    intent: PromptControlAuthIntent,
+    request: &PromptControlApplyRequest,
+    proof: &PlayerAuthProof,
+) -> Result<VerifiedPlayerAuth, String> {
+    verify_proof_scheme(proof)?;
+    let request_player_id =
+        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
+    let request_public_key = normalize_required_optional_public_key(
+        request.public_key.as_deref(),
+        "prompt_control public_key",
+    )?;
+    let proof_player_id =
+        normalize_required_field(proof.player_id.as_str(), "auth proof player_id")?;
+    let proof_public_key =
+        normalize_public_key_field(proof.public_key.as_str(), "auth proof public key")?;
+    if request_player_id != proof_player_id {
+        return Err("auth proof player_id does not match request player_id".to_string());
+    }
+    if request_public_key != proof_public_key {
+        return Err("auth proof public_key does not match request public_key".to_string());
+    }
+    if proof.nonce == 0 {
+        return Err("auth nonce must be greater than zero".to_string());
+    }
+    let signing_payload = super::build_prompt_control_apply_signing_payload(
+        intent,
+        request,
+        proof_player_id.as_str(),
+        proof_public_key.as_str(),
+        proof.nonce,
+    )?;
+    verify_player_auth_signature(
+        proof_public_key.as_str(),
+        proof.signature.as_str(),
+        signing_payload.as_slice(),
+    )?;
+    Ok(VerifiedPlayerAuth {
+        player_id: proof_player_id,
+        public_key: proof_public_key,
+        nonce: proof.nonce,
+        hosted_registration_nonce: None,
+    })
+}
+
+pub fn sign_prompt_control_rollback_auth_proof(
+    request: &PromptControlRollbackRequest,
+    nonce: u64,
+    signer_public_key_hex: &str,
+    signer_private_key_hex: &str,
+) -> Result<PlayerAuthProof, String> {
+    if nonce == 0 {
+        return Err("auth nonce must be greater than zero".to_string());
+    }
+    let player_id =
+        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
+    let request_public_key = normalize_required_optional_public_key(
+        request.public_key.as_deref(),
+        "prompt_control public_key",
+    )?;
+    let signer_public_key =
+        normalize_public_key_field(signer_public_key_hex, "prompt_control signer public key")?;
+    if signer_public_key != request_public_key {
+        return Err("prompt_control public_key does not match signer public key".to_string());
+    }
+
+    let signing_key =
+        signing_key_from_hex(signer_private_key_hex, "prompt_control signer private key")?;
+    verify_keypair_match(
+        &signing_key,
+        signer_public_key.as_str(),
+        "prompt_control signer public key",
+    )?;
+
+    let signing_payload = super::build_prompt_control_rollback_signing_payload(
+        request,
+        player_id.as_str(),
+        request_public_key.as_str(),
+        nonce,
+    )?;
+    sign_player_auth_proof(
+        signing_key,
+        player_id,
+        signer_public_key,
+        nonce,
+        signing_payload,
+    )
+}
+
+pub fn verify_prompt_control_rollback_auth_proof(
+    request: &PromptControlRollbackRequest,
+    proof: &PlayerAuthProof,
+) -> Result<VerifiedPlayerAuth, String> {
+    verify_proof_scheme(proof)?;
+    let request_player_id =
+        normalize_required_field(request.player_id.as_str(), "prompt_control player_id")?;
+    let request_public_key = normalize_required_optional_public_key(
+        request.public_key.as_deref(),
+        "prompt_control public_key",
+    )?;
+    let proof_player_id =
+        normalize_required_field(proof.player_id.as_str(), "auth proof player_id")?;
+    let proof_public_key =
+        normalize_public_key_field(proof.public_key.as_str(), "auth proof public key")?;
+    if request_player_id != proof_player_id {
+        return Err("auth proof player_id does not match request player_id".to_string());
+    }
+    if request_public_key != proof_public_key {
+        return Err("auth proof public_key does not match request public_key".to_string());
+    }
+    if proof.nonce == 0 {
+        return Err("auth nonce must be greater than zero".to_string());
+    }
+    let signing_payload = super::build_prompt_control_rollback_signing_payload(
+        request,
+        proof_player_id.as_str(),
+        proof_public_key.as_str(),
+        proof.nonce,
+    )?;
+    verify_player_auth_signature(
+        proof_public_key.as_str(),
+        proof.signature.as_str(),
+        signing_payload.as_slice(),
+    )?;
+    Ok(VerifiedPlayerAuth {
+        player_id: proof_player_id,
+        public_key: proof_public_key,
+        nonce: proof.nonce,
+        hosted_registration_nonce: None,
+    })
+}
+
+pub fn sign_hosted_prompt_control_strong_auth_grant(
+    action_id: &str,
+    player_id: &str,
+    player_public_key: &str,
+    agent_id: &str,
+    issued_at_unix_ms: u64,
+    expires_at_unix_ms: u64,
+    signer_public_key_hex: &str,
+    signer_private_key_hex: &str,
+) -> Result<HostedStrongAuthGrant, String> {
+    if issued_at_unix_ms == 0 {
+        return Err(
+            "hosted strong-auth grant issued_at_unix_ms must be greater than zero".to_string(),
+        );
+    }
+    if expires_at_unix_ms <= issued_at_unix_ms {
+        return Err(
+            "hosted strong-auth grant expires_at_unix_ms must be greater than issued_at_unix_ms"
+                .to_string(),
+        );
+    }
+    let operation = super::normalize_prompt_control_grant_operation(action_id)?;
+    let player_id = normalize_required_field(player_id, "hosted strong-auth player_id")?;
+    let player_public_key =
+        normalize_public_key_field(player_public_key, "hosted strong-auth player_public_key")?;
+    let agent_id = normalize_required_field(agent_id, "hosted strong-auth agent_id")?;
+    let signer_public_key = normalize_public_key_field(
+        signer_public_key_hex,
+        "hosted strong-auth signer public key",
+    )?;
+    let signing_key = signing_key_from_hex(
+        signer_private_key_hex,
+        "hosted strong-auth signer private key",
+    )?;
+    verify_keypair_match(
+        &signing_key,
+        signer_public_key.as_str(),
+        "hosted strong-auth signer public key",
+    )?;
+    let signing_payload = super::build_hosted_prompt_control_strong_auth_grant_payload(
+        operation,
+        player_id.as_str(),
+        player_public_key.as_str(),
+        agent_id.as_str(),
+        issued_at_unix_ms,
+        expires_at_unix_ms,
+    )?;
+    let signature = signing_key.sign(signing_payload.as_slice());
+    Ok(HostedStrongAuthGrant {
+        version: super::VIEWER_HOSTED_STRONG_AUTH_GRANT_PAYLOAD_VERSION,
+        action_id: operation.to_string(),
+        player_id,
+        player_public_key,
+        agent_id,
+        issued_at_unix_ms,
+        expires_at_unix_ms,
+        signer_public_key,
+        signature: format!(
+            "{}{}",
+            super::VIEWER_HOSTED_STRONG_AUTH_GRANT_SIGNATURE_V1_PREFIX,
+            hex::encode(signature.to_bytes())
+        ),
+    })
+}
+
+pub fn verify_hosted_prompt_control_apply_strong_auth_grant(
+    intent: PromptControlAuthIntent,
+    request: &PromptControlApplyRequest,
+    grant: &HostedStrongAuthGrant,
+    required_signer_public_key: &str,
+    now_unix_ms: u64,
+) -> Result<(), String> {
+    super::verify_hosted_prompt_control_strong_auth_grant(
+        super::prompt_control_intent_operation(intent),
+        request.agent_id.as_str(),
+        request.player_id.as_str(),
+        request.public_key.as_deref(),
+        grant,
+        required_signer_public_key,
+        now_unix_ms,
+    )
+}
+
+pub fn verify_hosted_prompt_control_rollback_strong_auth_grant(
+    request: &PromptControlRollbackRequest,
+    grant: &HostedStrongAuthGrant,
+    required_signer_public_key: &str,
+    now_unix_ms: u64,
+) -> Result<(), String> {
+    super::verify_hosted_prompt_control_strong_auth_grant(
+        "prompt_control_rollback",
+        request.agent_id.as_str(),
+        request.player_id.as_str(),
+        request.public_key.as_deref(),
+        grant,
+        required_signer_public_key,
+        now_unix_ms,
+    )
+}

--- a/crates/oasis7/src/viewer/auth_tests.rs
+++ b/crates/oasis7/src/viewer/auth_tests.rs
@@ -101,6 +101,7 @@ fn prompt_control_apply_auth_sign_and_verify_roundtrip() {
         system_prompt_override: Some(Some("system".to_string())),
         short_term_goal_override: Some(None),
         long_term_goal_override: None,
+        ..Default::default()
     };
     let proof = sign_prompt_control_apply_auth_proof(
         PromptControlAuthIntent::Apply,
@@ -132,6 +133,7 @@ fn prompt_control_apply_auth_verify_rejects_tamper() {
         system_prompt_override: Some(Some("system".to_string())),
         short_term_goal_override: None,
         long_term_goal_override: None,
+        ..Default::default()
     };
     let proof = sign_prompt_control_apply_auth_proof(
         PromptControlAuthIntent::Apply,
@@ -151,6 +153,97 @@ fn prompt_control_apply_auth_verify_rejects_tamper() {
 }
 
 #[test]
+fn prompt_control_enhanced_auth_binds_epochs_and_operation_identity() {
+    let (public_key, private_key) = test_signer();
+    let request = PromptControlApplyRequest {
+        agent_id: "agent-0".to_string(),
+        player_id: "player-a".to_string(),
+        request_id: Some("request-a".to_string()),
+        session_epoch: Some(4),
+        binding_epoch: Some(9),
+        expected_authority_epoch: Some("authority-a".to_string()),
+        public_key: Some(public_key.clone()),
+        auth: None,
+        strong_auth_grant: None,
+        expected_version: Some(3),
+        updated_by: Some("player-a".to_string()),
+        system_prompt_override: Some(Some("system".to_string())),
+        short_term_goal_override: Some(None),
+        long_term_goal_override: None,
+    };
+    let proof = sign_prompt_control_apply_auth_proof(
+        PromptControlAuthIntent::Apply,
+        &request,
+        11,
+        public_key.as_str(),
+        private_key.as_str(),
+    )
+    .expect("sign enhanced proof");
+    verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &request, &proof)
+        .expect("verify enhanced proof");
+
+    let mut tampered = request.clone();
+    tampered.request_id = Some("request-b".to_string());
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+    tampered = request.clone();
+    tampered.session_epoch = Some(5);
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+    tampered = request.clone();
+    tampered.binding_epoch = Some(10);
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+    tampered = request.clone();
+    tampered.expected_authority_epoch = Some("authority-b".to_string());
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+    tampered = request.clone();
+    tampered.expected_version = Some(4);
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+    tampered = request.clone();
+    tampered.updated_by = Some("player-b".to_string());
+    assert!(
+        verify_prompt_control_apply_auth_proof(PromptControlAuthIntent::Apply, &tampered, &proof)
+            .is_err()
+    );
+
+    let identity_a = normalize_prompt_control_operation_identity(
+        "apply",
+        false,
+        "agent-0",
+        "player-a",
+        Some(4),
+        Some(9),
+        Some("authority-a"),
+        Some(3),
+        &request.system_prompt_override,
+        &request.short_term_goal_override,
+        &request.long_term_goal_override,
+        None,
+        request.updated_by.as_deref(),
+    )
+    .expect("normalize identity");
+    let identity_b = identity_a.clone();
+    assert_eq!(
+        prompt_control_operation_digest(&identity_a),
+        prompt_control_operation_digest(&identity_b),
+        "typed operation digest is stable and independent of request id"
+    );
+}
+
+#[test]
 fn hosted_prompt_control_strong_auth_grant_roundtrip() {
     let (player_public_key, _) = test_signer();
     let (backend_public_key, backend_private_key) = test_signer_with_seed(9);
@@ -165,6 +258,7 @@ fn hosted_prompt_control_strong_auth_grant_roundtrip() {
         system_prompt_override: Some(Some("system".to_string())),
         short_term_goal_override: None,
         long_term_goal_override: None,
+        ..Default::default()
     };
     let grant = sign_hosted_prompt_control_strong_auth_grant(
         "prompt_control_apply",
@@ -275,6 +369,7 @@ fn hosted_prompt_control_strong_auth_grant_rejects_request_mismatch() {
         system_prompt_override: Some(Some("system".to_string())),
         short_term_goal_override: None,
         long_term_goal_override: None,
+        ..Default::default()
     };
     let grant = sign_hosted_prompt_control_strong_auth_grant(
         "prompt_control_apply",

--- a/crates/oasis7/src/viewer/live/live_auth_prompt.rs
+++ b/crates/oasis7/src/viewer/live/live_auth_prompt.rs
@@ -43,6 +43,7 @@ impl LiveWorld {
             applied_fields,
             digest: prompt_profile_digest(&candidate),
             rolled_back_to_version: None,
+            ..PromptControlAck::default_legacy()
         })
     }
 
@@ -90,6 +91,7 @@ impl LiveWorld {
                 applied_fields,
                 digest,
                 rolled_back_to_version: None,
+                ..PromptControlAck::default_legacy()
             });
         }
 
@@ -121,6 +123,7 @@ impl LiveWorld {
             applied_fields,
             digest,
             rolled_back_to_version: None,
+            ..PromptControlAck::default_legacy()
         })
     }
 
@@ -162,6 +165,7 @@ impl LiveWorld {
                     ),
                     agent_id: Some(request.agent_id.clone()),
                     current_version: Some(current.version),
+                    ..PromptControlError::default_legacy()
                 })?
         };
 
@@ -179,6 +183,7 @@ impl LiveWorld {
                 ),
                 agent_id: Some(request.agent_id),
                 current_version: Some(current.version),
+                ..PromptControlError::default_legacy()
             });
         }
 
@@ -210,6 +215,7 @@ impl LiveWorld {
             applied_fields,
             digest,
             rolled_back_to_version: Some(request.to_version),
+            ..PromptControlAck::default_legacy()
         })
     }
 
@@ -304,6 +310,7 @@ impl LiveWorld {
                 message: "prompt_control requires auth proof".to_string(),
                 agent_id: Some(request.agent_id.clone()),
                 current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
             });
         };
         let verified =
@@ -313,6 +320,7 @@ impl LiveWorld {
                     message,
                     agent_id: Some(request.agent_id.clone()),
                     current_version: self.current_prompt_version(request.agent_id.as_str()),
+                    ..PromptControlError::default_legacy()
                 }
             })?;
         self.kernel
@@ -322,6 +330,7 @@ impl LiveWorld {
                 message,
                 agent_id: Some(request.agent_id.clone()),
                 current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
             })?;
         Ok(())
     }
@@ -336,6 +345,7 @@ impl LiveWorld {
                 message: "prompt_control rollback requires auth proof".to_string(),
                 agent_id: Some(request.agent_id.clone()),
                 current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
             });
         };
         let verified =
@@ -345,6 +355,7 @@ impl LiveWorld {
                     message,
                     agent_id: Some(request.agent_id.clone()),
                     current_version: self.current_prompt_version(request.agent_id.as_str()),
+                    ..PromptControlError::default_legacy()
                 }
             })?;
         self.kernel
@@ -354,6 +365,7 @@ impl LiveWorld {
                 message,
                 agent_id: Some(request.agent_id.clone()),
                 current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
             })?;
         Ok(())
     }
@@ -403,6 +415,7 @@ impl LiveWorld {
                 message: format!("agent not found: {agent_id}"),
                 agent_id: Some(agent_id.to_string()),
                 current_version: None,
+                ..PromptControlError::default_legacy()
             });
         }
         Ok(self
@@ -452,6 +465,7 @@ impl LiveWorld {
                     .agent_prompt_profiles
                     .get(&profile.agent_id)
                     .map(|entry| entry.version),
+                ..PromptControlError::default_legacy()
             }),
             LiveDriver::Llm(runner) => {
                 let Some(agent) = runner.get_mut(profile.agent_id.as_str()) else {
@@ -466,8 +480,9 @@ impl LiveWorld {
                             .kernel
                             .model()
                             .agent_prompt_profiles
-                            .get(&profile.agent_id)
-                            .map(|entry| entry.version),
+                        .get(&profile.agent_id)
+                        .map(|entry| entry.version),
+                        ..PromptControlError::default_legacy()
                     });
                 };
                 agent.behavior.apply_prompt_overrides(
@@ -503,6 +518,7 @@ impl LiveWorld {
                         .agent_prompt_profiles
                         .get(agent_id)
                         .map(|profile| profile.version),
+                    ..PromptControlError::default_legacy()
                 })?;
         }
         Ok(())

--- a/crates/oasis7/src/viewer/live/live_helpers.rs
+++ b/crates/oasis7/src/viewer/live/live_helpers.rs
@@ -28,6 +28,7 @@ pub(super) fn normalize_required_player_id(
             ),
             agent_id: Some(agent_id.to_string()),
             current_version: None,
+            ..PromptControlError::default_legacy()
         });
     }
     Ok(normalized.to_string())
@@ -59,6 +60,7 @@ pub(super) fn ensure_updated_by_matches_player(
         ),
         agent_id: Some(agent_id.to_string()),
         current_version: None,
+        ..PromptControlError::default_legacy()
     })
 }
 
@@ -74,6 +76,7 @@ pub(super) fn ensure_agent_player_access(
             message: format!("agent not found: {agent_id}"),
             agent_id: Some(agent_id.to_string()),
             current_version: None,
+            ..PromptControlError::default_legacy()
         });
     }
     let Some(bound_player_id) = kernel.player_binding_for_agent(agent_id) else {
@@ -107,6 +110,7 @@ pub(super) fn ensure_agent_player_access(
                 .agent_prompt_profiles
                 .get(agent_id)
                 .map(|profile| profile.version),
+            ..PromptControlError::default_legacy()
         });
     }
     Err(PromptControlError {
@@ -121,6 +125,7 @@ pub(super) fn ensure_agent_player_access(
             .agent_prompt_profiles
             .get(agent_id)
             .map(|profile| profile.version),
+        ..PromptControlError::default_legacy()
     })
 }
 
@@ -190,6 +195,7 @@ pub(super) fn ensure_expected_prompt_version(
                 ),
                 agent_id: Some(agent_id.to_string()),
                 current_version: Some(current_version),
+                ..PromptControlError::default_legacy()
             });
         }
     }

--- a/crates/oasis7/src/viewer/live/tests_auth.rs
+++ b/crates/oasis7/src/viewer/live/tests_auth.rs
@@ -20,6 +20,7 @@ fn prompt_control_preview_reports_fields_and_next_version() {
                 system_prompt_override: Some(Some("系统提示".to_string())),
                 short_term_goal_override: None,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             PromptControlAuthIntent::Preview,
             1,
@@ -58,6 +59,7 @@ fn prompt_control_apply_requires_llm_mode() {
                 system_prompt_override: Some(Some("system".to_string())),
                 short_term_goal_override: None,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             PromptControlAuthIntent::Apply,
             2,
@@ -119,6 +121,7 @@ fn prompt_control_preview_requires_non_empty_player_id() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         })
         .expect_err("empty player id should be rejected");
 
@@ -144,6 +147,7 @@ fn prompt_control_preview_requires_auth_proof() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         })
         .expect_err("missing proof should be rejected");
 
@@ -169,6 +173,7 @@ fn prompt_control_preview_rejects_tampered_auth_signature() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         PromptControlAuthIntent::Preview,
         7,
@@ -202,6 +207,7 @@ fn prompt_control_preview_rejects_replayed_nonce() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         PromptControlAuthIntent::Preview,
         8,
@@ -246,6 +252,7 @@ fn prompt_control_preview_rejects_unbound_player_when_agent_already_bound() {
                 system_prompt_override: Some(Some("system".to_string())),
                 short_term_goal_override: None,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             PromptControlAuthIntent::Preview,
             3,
@@ -287,6 +294,7 @@ fn prompt_control_preview_requires_matching_public_key_when_agent_is_key_bound()
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         })
         .expect_err("missing public key should be rejected");
     assert_eq!(missing_key.code, "auth_proof_required");
@@ -304,6 +312,7 @@ fn prompt_control_preview_requires_matching_public_key_when_agent_is_key_bound()
                 system_prompt_override: Some(Some("system".to_string())),
                 short_term_goal_override: None,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             PromptControlAuthIntent::Preview,
             4,
@@ -326,6 +335,7 @@ fn prompt_control_preview_requires_matching_public_key_when_agent_is_key_bound()
                 system_prompt_override: Some(Some("system".to_string())),
                 short_term_goal_override: None,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             PromptControlAuthIntent::Preview,
             5,

--- a/crates/oasis7/src/viewer/live_controls.rs
+++ b/crates/oasis7/src/viewer/live_controls.rs
@@ -490,6 +490,7 @@ impl ViewerLiveSession {
                     capabilities: Vec::new(),
                     world_id: world_id.to_string(),
                     control_profile: ViewerControlProfile::Live,
+                    authority_epoch: None,
                 };
                 send_response(writer, &response)?;
             }

--- a/crates/oasis7/src/viewer/protocol.rs
+++ b/crates/oasis7/src/viewer/protocol.rs
@@ -53,13 +53,15 @@ pub use proto::{
     GOVERNED_ROLLBACK_REPLAY_CAPABILITY, GameplayActionError, GameplayActionRequest,
     GovernanceVoteQuotePreflight, GovernanceVoteQuoteRequest, HostedStrongAuthGrant, LiveControl,
     MarketQuoteDecisionPreflight, MarketQuoteDecisionRequest, MarketQuoteMaterialContribution,
-    MarketQuoteMaterialRequest, NegotiatedViewerProtocol, PlaybackControl, PlayerActionDisposition,
-    PlayerAuthProof, PlayerAuthScheme, PlayerCompensationState, PlayerCompensationStatus,
-    PlayerRollbackDisposition, PowerSaleQuotePreflight, PowerSaleQuoteRequest,
-    PowerSurvivalQuotePreflight, PowerSurvivalQuoteRequest, PowerSurvivalRecoveryAction,
-    ProductValidationQuotePreflight, ProductValidationQuoteRequest, PromptControlApplyRequest,
-    PromptControlCommand, PromptControlError, PromptControlOperation, PromptControlRollbackRequest,
-    PublishSocialFactQuotePreflight, PublishSocialFactQuoteRequest, PublishSocialFactQuoteStake,
+    MarketQuoteMaterialRequest, NegotiatedViewerProtocol, PROMPT_CONTROL_RESULT_CAPABILITY,
+    PlaybackControl, PlayerActionDisposition, PlayerAuthProof, PlayerAuthScheme,
+    PlayerCompensationState, PlayerCompensationStatus, PlayerRollbackDisposition,
+    PowerSaleQuotePreflight, PowerSaleQuoteRequest, PowerSurvivalQuotePreflight,
+    PowerSurvivalQuoteRequest, PowerSurvivalRecoveryAction, ProductValidationQuotePreflight,
+    ProductValidationQuoteRequest, PromptControlApplicationScope, PromptControlApplyRequest,
+    PromptControlCommand, PromptControlError, PromptControlOperation, PromptControlResultStatus,
+    PromptControlRollbackRequest, PromptControlValueVisibility, PublishSocialFactQuotePreflight,
+    PublishSocialFactQuoteRequest, PublishSocialFactQuoteStake,
     REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY, RefineQuotePreflight, RefineQuoteRequest,
     RevokeSocialFactQuotePreflight, RevokeSocialFactQuoteRequest, RollbackApprovalSignature,
     RollbackAttributionResolution, RollbackAttributionResolutionRequest, RollbackAuthorityRole,
@@ -97,6 +99,14 @@ pub fn viewer_protocol_supports_revoke_social_fact_quote(
             .capabilities
             .iter()
             .any(|value| value == REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY)
+}
+
+pub fn viewer_protocol_supports_prompt_control_result(protocol: &NegotiatedViewerProtocol) -> bool {
+    protocol.version >= VIEWER_PROTOCOL_VERSION
+        && protocol
+            .capabilities
+            .iter()
+            .any(|value| value == PROMPT_CONTROL_RESULT_CAPABILITY)
 }
 
 /// A signed, read-only request for the current chunk's fragment-replenishment forecast.

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -9,9 +9,10 @@ use super::protocol::{
     AuthoritativeRollbackRequest, AuthoritativeRollbackV2Request,
     AuthoritativeSessionRegisterRequest, AuthoritativeSessionRevokeRequest,
     AuthoritativeSessionRotateRequest, ControlCompletionAck, ControlCompletionStatus,
-    GameplayActionError, REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY, RollbackAuthorizationEnvelope,
-    RollbackIntent, VIEWER_PROTOCOL_VERSION, ViewerControl, ViewerControlProfile, ViewerEventKind,
-    ViewerRequest, ViewerResponse, ViewerStream, viewer_event_kind_matches,
+    GameplayActionError, PROMPT_CONTROL_RESULT_CAPABILITY, REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY,
+    RollbackAuthorizationEnvelope, RollbackIntent, VIEWER_PROTOCOL_VERSION, ViewerControl,
+    ViewerControlProfile, ViewerEventKind, ViewerRequest, ViewerResponse, ViewerStream,
+    viewer_event_kind_matches, viewer_protocol_supports_prompt_control_result,
     viewer_protocol_supports_revoke_social_fact_quote,
 };
 use crate::geometry::GeoPos;
@@ -82,6 +83,7 @@ mod player_gameplay;
 #[path = "runtime_live/power_projection.rs"]
 mod power_projection;
 mod power_sale_quote;
+mod prompt_control_result;
 mod recovery;
 mod recovery_audit;
 mod recovery_compensation;
@@ -125,6 +127,7 @@ use gameplay_snapshot::{
     player_gameplay_feedback_from_control_ack,
 };
 use mapping::{map_runtime_event, runtime_state_to_simulator_model};
+use prompt_control_result::PromptControlRuntimeAuthority;
 use runtime_script::RuntimeLiveScript;
 use session_policy::{
     RuntimeSessionPolicy, RuntimeSessionRevokeMetadata, location_id_for_pos,
@@ -167,6 +170,7 @@ pub struct ViewerRuntimeLiveServer {
     latest_player_gameplay_causality: Option<PlayerGameplayCausalitySignal>,
     runtime_action_players: BTreeMap<u64, String>,
     consumed_rollback_operator_nonces: BTreeSet<String>,
+    prompt_control_authority: PromptControlRuntimeAuthority,
     authoritative_recovery_write_fence: Option<String>,
     smelter_affordability_debug_agent_id: Option<String>,
     governance_vote_quote_debug_agent_id: Option<String>,
@@ -179,6 +183,14 @@ impl ViewerRuntimeLiveServer {
     pub fn new(
         config: ViewerRuntimeLiveServerConfig,
     ) -> Result<Self, ViewerRuntimeLiveServerError> {
+        config
+            .validate_prompt_result_limits()
+            .map_err(ViewerRuntimeLiveServerError::Init)?;
+        let prompt_control_authority = PromptControlRuntimeAuthority::new(
+            config.prompt_result_cache_capacity,
+            config.prompt_result_receipt_max_bytes,
+        )
+        .map_err(ViewerRuntimeLiveServerError::Init)?;
         let (mut world, snapshot_config, seed_model, chunk_runtime) =
             bootstrap_runtime_live_world(&config).map_err(ViewerRuntimeLiveServerError::Init)?;
         let mut recovered_generation = None;
@@ -358,6 +370,7 @@ impl ViewerRuntimeLiveServer {
                 .as_ref()
                 .map(|generation| generation.consumed_rollback_operator_nonces.clone())
                 .unwrap_or_default(),
+            prompt_control_authority,
             authoritative_recovery_write_fence: None,
             smelter_affordability_debug_agent_id: None,
             governance_vote_quote_debug_agent_id: None,
@@ -596,6 +609,7 @@ impl ViewerRuntimeLiveServer {
                         capabilities,
                         world_id: self.config.world_id.clone(),
                         control_profile: ViewerControlProfile::Live,
+                        authority_epoch: None,
                     },
                 )?;
             }
@@ -623,6 +637,12 @@ impl ViewerRuntimeLiveServer {
                     {
                         selected.push(REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY.to_string());
                     }
+                    if offered
+                        .iter()
+                        .any(|capability| capability == PROMPT_CONTROL_RESULT_CAPABILITY)
+                    {
+                        selected.push(PROMPT_CONTROL_RESULT_CAPABILITY.to_string());
+                    }
                 }
                 session.negotiated_protocol = crate::viewer::protocol::NegotiatedViewerProtocol {
                     version,
@@ -638,6 +658,13 @@ impl ViewerRuntimeLiveServer {
                         capabilities: selected,
                         world_id: self.config.world_id.clone(),
                         control_profile: ViewerControlProfile::Live,
+                        authority_epoch: if viewer_protocol_supports_prompt_control_result(
+                            &session.negotiated_protocol,
+                        ) {
+                            Some(self.prompt_control_authority.authority_epoch.clone())
+                        } else {
+                            None
+                        },
                     },
                 )?;
             }
@@ -689,6 +716,7 @@ impl ViewerRuntimeLiveServer {
                                 session_pubkey: None,
                                 replaced_by_pubkey: None,
                                 session_epoch: None,
+                                binding_epoch: None,
                                 message: Some("snapshot_sync_metadata".to_string()),
                                 revoke_reason: None,
                                 revoked_by: None,
@@ -737,7 +765,9 @@ impl ViewerRuntimeLiveServer {
                 self.apply_control_mode(mode, request_id, session, writer)?;
             }
             ViewerRequest::PromptControl { command } => {
-                match self.handle_prompt_control(*command) {
+                match self
+                    .handle_prompt_control_for_protocol(*command, &session.negotiated_protocol)
+                {
                     Ok(ack) => {
                         send_response(writer, &ViewerResponse::PromptControlAck { ack })?;
                     }

--- a/crates/oasis7/src/viewer/runtime_live.rs
+++ b/crates/oasis7/src/viewer/runtime_live.rs
@@ -637,9 +637,10 @@ impl ViewerRuntimeLiveServer {
                     {
                         selected.push(REVOKE_SOCIAL_FACT_QUOTE_CAPABILITY.to_string());
                     }
-                    if offered
-                        .iter()
-                        .any(|capability| capability == PROMPT_CONTROL_RESULT_CAPABILITY)
+                    if self.llm_sidecar.supports_prompt_control_result()
+                        && offered
+                            .iter()
+                            .any(|capability| capability == PROMPT_CONTROL_RESULT_CAPABILITY)
                     {
                         selected.push(PROMPT_CONTROL_RESULT_CAPABILITY.to_string());
                     }

--- a/crates/oasis7/src/viewer/runtime_live/config.rs
+++ b/crates/oasis7/src/viewer/runtime_live/config.rs
@@ -5,6 +5,9 @@ use std::time::Duration;
 use super::{RuntimeWorldError, ViewerLiveDecisionMode, WorldScenario};
 use crate::runtime::MajorWorldEventVisibilityPermission;
 
+pub(crate) const DEFAULT_PROMPT_RESULT_CACHE_CAPACITY: usize = 256;
+pub(crate) const DEFAULT_PROMPT_RESULT_RECEIPT_MAX_BYTES: usize = 65_536;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChainLinkPolicy {
     Enforcing,
@@ -55,8 +58,24 @@ pub struct ViewerRuntimeLiveServerConfig {
     /// default beside their sidecar; formal/synthetic worlds must opt into a
     /// stable operator-owned path explicitly.
     pub provider_lineage_store: Option<PathBuf>,
+    /// Runtime-only idempotency ledger capacity. A zero value is invalid.
+    pub prompt_result_cache_capacity: usize,
+    /// Maximum serialized result receipt size. A zero value is invalid.
+    pub prompt_result_receipt_max_bytes: usize,
     #[cfg(test)]
     pub(crate) test_cognition_runtime_binding: Option<(String, u64, Option<String>, String, u64)>,
+}
+
+impl ViewerRuntimeLiveServerConfig {
+    pub(crate) fn validate_prompt_result_limits(&self) -> Result<(), String> {
+        if self.prompt_result_cache_capacity == 0 {
+            return Err("prompt result cache capacity must be greater than zero".to_string());
+        }
+        if self.prompt_result_receipt_max_bytes == 0 {
+            return Err("prompt result receipt max bytes must be greater than zero".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug)]

--- a/crates/oasis7/src/viewer/runtime_live/control_plane.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane.rs
@@ -2,14 +2,17 @@ use super::*;
 
 use super::super::auth::{
     AGENT_CHAT_AUTHORITY_SCOPE, PromptControlAuthIntent, VerifiedPlayerAuth,
+    normalize_prompt_control_operation_identity, prompt_control_operation_digest,
     verify_agent_chat_auth_proof_with_authority,
     verify_hosted_prompt_control_apply_strong_auth_grant,
     verify_hosted_prompt_control_rollback_strong_auth_grant,
     verify_prompt_control_apply_auth_proof, verify_prompt_control_rollback_auth_proof,
 };
 use super::super::protocol::{
-    AgentChatAck, AgentChatError, AgentChatRequest, PromptControlAck, PromptControlApplyRequest,
-    PromptControlCommand, PromptControlError, PromptControlOperation, PromptControlRollbackRequest,
+    AgentChatAck, AgentChatError, AgentChatRequest, PromptControlAck,
+    PromptControlApplicationScope, PromptControlApplyRequest, PromptControlCommand,
+    PromptControlError, PromptControlOperation, PromptControlResultStatus,
+    PromptControlRollbackRequest, PromptControlValueVisibility,
 };
 use crate::runtime::{
     AgentIntentAuthorityContext, AgentIntentProviderFailureDisposition, AgentIntentV2,
@@ -24,10 +27,15 @@ mod agent_chat_intent;
 #[path = "control_plane/auth_helpers.rs"]
 mod auth_helpers;
 mod llm_sidecar;
+#[path = "control_plane/prompt_control_enhanced.rs"]
+mod prompt_control_enhanced;
+#[path = "control_plane/prompt_control_legacy.rs"]
+mod prompt_control_legacy;
 #[path = "control_plane/prompt_profile.rs"]
 mod prompt_profile;
 #[path = "control_plane/provider_action.rs"]
 mod provider_action;
+use super::prompt_control_result::{PromptControlLedgerInsertError, PromptControlLedgerLookup};
 pub(in crate::viewer::runtime_live) use agent_chat_intent::RuntimePrimaryIntent;
 use agent_chat_intent::{apply_accepted_primary_intent, resolve_agent_chat_intent};
 pub(super) use auth_helpers::map_auth_verify_error_code;
@@ -36,7 +44,6 @@ pub(super) use llm_sidecar::{
     RuntimeChatIntentAckRecord, RuntimeLlmSidecar, RuntimePlayerBindingPlan,
     simulator_action_label, simulator_action_to_runtime,
 };
-
 const RUNTIME_AGENT_CHAT_ECHO_ENV: &str = "OASIS7_RUNTIME_AGENT_CHAT_ECHO";
 const RUNTIME_AGENT_CHAT_ECHO_PREFIX: &str = "[local-mock-receipt]";
 const RUNTIME_AGENT_CHAT_ECHO_NOTICE: &str =
@@ -81,507 +88,6 @@ fn provider_reply_matches_current_intent(
 }
 
 impl ViewerRuntimeLiveServer {
-    pub(super) fn handle_prompt_control(
-        &mut self,
-        command: PromptControlCommand,
-    ) -> Result<PromptControlAck, PromptControlError> {
-        if self.hosted_public_join_mode() {
-            match &command {
-                PromptControlCommand::Preview { request } => {
-                    self.verify_hosted_prompt_control_apply_strong_auth(
-                        PromptControlAuthIntent::Preview,
-                        request,
-                    )?;
-                }
-                PromptControlCommand::Apply { request } => {
-                    self.verify_hosted_prompt_control_apply_strong_auth(
-                        PromptControlAuthIntent::Apply,
-                        request,
-                    )?;
-                }
-                PromptControlCommand::Rollback { request } => {
-                    self.verify_hosted_prompt_control_rollback_strong_auth(request)?;
-                }
-            }
-        }
-        if !self.llm_sidecar.is_llm_mode() {
-            let (agent_id, message) = match command {
-                PromptControlCommand::Preview { request }
-                | PromptControlCommand::Apply { request } => (
-                    request.agent_id,
-                    "prompt_control requires runtime live server running with --llm".to_string(),
-                ),
-                PromptControlCommand::Rollback { request } => (
-                    request.agent_id,
-                    "prompt_control rollback requires runtime live server running with --llm"
-                        .to_string(),
-                ),
-            };
-            return Err(PromptControlError {
-                code: "llm_mode_required".to_string(),
-                message,
-                agent_id: Some(agent_id.clone()),
-                current_version: self.current_prompt_version(agent_id.as_str()),
-            });
-        }
-        if !self.llm_sidecar.supports_prompt_control() {
-            let (agent_id, current_version) = match &command {
-                PromptControlCommand::Preview { request }
-                | PromptControlCommand::Apply { request } => (
-                    request.agent_id.clone(),
-                    self.current_prompt_version(request.agent_id.as_str()),
-                ),
-                PromptControlCommand::Rollback { request } => (
-                    request.agent_id.clone(),
-                    self.current_prompt_version(request.agent_id.as_str()),
-                ),
-            };
-            return Err(PromptControlError {
-                code: "agent_provider_prompt_control_unsupported".to_string(),
-                message:
-                    "prompt_control is not yet supported when runtime live uses ProviderBacked(Local HTTP)"
-                        .to_string(),
-                agent_id: Some(agent_id),
-                current_version,
-            });
-        }
-
-        match command {
-            PromptControlCommand::Preview { request } => self.prompt_control_preview(request),
-            PromptControlCommand::Apply { request } => self.prompt_control_apply(request),
-            PromptControlCommand::Rollback { request } => self.prompt_control_rollback(request),
-        }
-    }
-
-    fn prompt_control_preview(
-        &mut self,
-        request: PromptControlApplyRequest,
-    ) -> Result<PromptControlAck, PromptControlError> {
-        let player_id =
-            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
-        let public_key = normalize_optional_public_key(request.public_key.as_deref());
-        self.verify_and_consume_prompt_control_apply_auth(
-            PromptControlAuthIntent::Preview,
-            &request,
-        )?;
-        ensure_agent_player_access_runtime(
-            &self.world,
-            &self.llm_sidecar,
-            request.agent_id.as_str(),
-            player_id.as_str(),
-            public_key.as_deref(),
-        )?;
-        let current = self.current_prompt_profile(request.agent_id.as_str())?;
-        ensure_expected_prompt_version_runtime(
-            request.agent_id.as_str(),
-            current.version,
-            request.expected_version,
-        )?;
-
-        let mut candidate = current.clone();
-        apply_prompt_patch_runtime(&mut candidate, &request);
-        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
-        let preview_version = if applied_fields.is_empty() {
-            current.version
-        } else {
-            current.version.saturating_add(1)
-        };
-
-        Ok(PromptControlAck {
-            agent_id: request.agent_id,
-            operation: PromptControlOperation::Apply,
-            preview: true,
-            version: preview_version,
-            updated_at_tick: self.world.state().time,
-            applied_fields,
-            digest: prompt_profile_digest_runtime(&candidate),
-            rolled_back_to_version: None,
-        })
-    }
-
-    fn prompt_control_apply(
-        &mut self,
-        request: PromptControlApplyRequest,
-    ) -> Result<PromptControlAck, PromptControlError> {
-        let player_id =
-            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
-        let public_key = normalize_optional_public_key(request.public_key.as_deref());
-        self.verify_and_consume_prompt_control_apply_auth(
-            PromptControlAuthIntent::Apply,
-            &request,
-        )?;
-        ensure_agent_player_access_runtime(
-            &self.world,
-            &self.llm_sidecar,
-            request.agent_id.as_str(),
-            player_id.as_str(),
-            public_key.as_deref(),
-        )?;
-        let current = self.current_prompt_profile(request.agent_id.as_str())?;
-        ensure_expected_prompt_version_runtime(
-            request.agent_id.as_str(),
-            current.version,
-            request.expected_version,
-        )?;
-        ensure_updated_by_matches_player_runtime(
-            request.updated_by.as_deref(),
-            player_id.as_str(),
-            request.agent_id.as_str(),
-        )?;
-
-        let mut candidate = current.clone();
-        apply_prompt_patch_runtime(&mut candidate, &request);
-        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
-        let digest = prompt_profile_digest_runtime(&candidate);
-        if request.short_term_goal_override.is_some() {
-            self.record_primary_intent_from_short_term_goal(
-                request.agent_id.as_str(),
-                candidate.short_term_goal_override.as_deref(),
-            );
-        }
-        if applied_fields.is_empty() {
-            return Ok(PromptControlAck {
-                agent_id: request.agent_id,
-                operation: PromptControlOperation::Apply,
-                preview: false,
-                version: current.version,
-                updated_at_tick: current.updated_at_tick,
-                applied_fields,
-                digest,
-                rolled_back_to_version: None,
-            });
-        }
-
-        candidate.version = current.version.saturating_add(1);
-        candidate.updated_at_tick = self.world.state().time;
-        candidate.updated_by = player_id.clone();
-        self.llm_sidecar.upsert_prompt_profile(candidate.clone());
-        self.llm_sidecar.apply_prompt_profile_to_driver(&candidate);
-        self.bind_agent_player_access(
-            request.agent_id.as_str(),
-            player_id.as_str(),
-            public_key.as_deref(),
-        )?;
-        let digest = prompt_profile_digest_runtime(&candidate);
-        self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
-            profile: candidate.clone(),
-            operation: PromptUpdateOperation::Apply,
-            applied_fields: applied_fields.clone(),
-            digest: digest.clone(),
-            rolled_back_to_version: None,
-        });
-        self.llm_sidecar.request_decision();
-        self.set_latest_player_gameplay_feedback(PlayerGameplayRecentFeedback {
-            action: "prompt_control.apply".to_string(),
-            stage: "completed_advanced".to_string(),
-            effect: format!(
-                "updated prompt guidance for {} to version {}",
-                request.agent_id, candidate.version
-            ),
-            intent_summary: Some(format!("apply updated prompt guidance for {}", request.agent_id)),
-            target_agent_id: Some(request.agent_id.clone()),
-            reason: None,
-            hint: Some(
-                "continue the world and watch whether the new prompt guidance changes the agent's next decision"
-                    .to_string(),
-            ),
-            delta_logical_time: 0,
-            delta_event_seq: 0,
-        });
-
-        Ok(PromptControlAck {
-            agent_id: request.agent_id,
-            operation: PromptControlOperation::Apply,
-            preview: false,
-            version: candidate.version,
-            updated_at_tick: candidate.updated_at_tick,
-            applied_fields,
-            digest,
-            rolled_back_to_version: None,
-        })
-    }
-
-    fn prompt_control_rollback(
-        &mut self,
-        request: PromptControlRollbackRequest,
-    ) -> Result<PromptControlAck, PromptControlError> {
-        let player_id =
-            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
-        let public_key = normalize_optional_public_key(request.public_key.as_deref());
-        self.verify_and_consume_prompt_control_rollback_auth(&request)?;
-        ensure_agent_player_access_runtime(
-            &self.world,
-            &self.llm_sidecar,
-            request.agent_id.as_str(),
-            player_id.as_str(),
-            public_key.as_deref(),
-        )?;
-        let current = self.current_prompt_profile(request.agent_id.as_str())?;
-        ensure_expected_prompt_version_runtime(
-            request.agent_id.as_str(),
-            current.version,
-            request.expected_version,
-        )?;
-        ensure_updated_by_matches_player_runtime(
-            request.updated_by.as_deref(),
-            player_id.as_str(),
-            request.agent_id.as_str(),
-        )?;
-
-        let target = if request.to_version == 0 {
-            AgentPromptProfile::for_agent(request.agent_id.clone())
-        } else {
-            self.lookup_prompt_profile_version(request.agent_id.as_str(), request.to_version)
-                .ok_or_else(|| PromptControlError {
-                    code: "target_version_not_found".to_string(),
-                    message: format!(
-                        "prompt profile version {} not found for {}",
-                        request.to_version, request.agent_id
-                    ),
-                    agent_id: Some(request.agent_id.clone()),
-                    current_version: Some(current.version),
-                })?
-        };
-        let target_short_term_goal = target.short_term_goal_override.clone();
-        let mut candidate = current.clone();
-        candidate.system_prompt_override = target.system_prompt_override;
-        candidate.short_term_goal_override = target.short_term_goal_override;
-        candidate.long_term_goal_override = target.long_term_goal_override;
-        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
-        if applied_fields.is_empty() {
-            return Err(PromptControlError {
-                code: "rollback_noop".to_string(),
-                message: format!(
-                    "rollback target version {} yields no prompt changes for {}",
-                    request.to_version, request.agent_id
-                ),
-                agent_id: Some(request.agent_id),
-                current_version: Some(current.version),
-            });
-        }
-
-        self.record_primary_intent_from_short_term_goal(
-            request.agent_id.as_str(),
-            target_short_term_goal.as_deref(),
-        );
-
-        candidate.version = current.version.saturating_add(1);
-        candidate.updated_at_tick = self.world.state().time;
-        candidate.updated_by = player_id.clone();
-        self.llm_sidecar.upsert_prompt_profile(candidate.clone());
-        self.llm_sidecar.apply_prompt_profile_to_driver(&candidate);
-        self.bind_agent_player_access(
-            request.agent_id.as_str(),
-            player_id.as_str(),
-            public_key.as_deref(),
-        )?;
-        let digest = prompt_profile_digest_runtime(&candidate);
-        self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
-            profile: candidate.clone(),
-            operation: PromptUpdateOperation::Rollback,
-            applied_fields: applied_fields.clone(),
-            digest: digest.clone(),
-            rolled_back_to_version: Some(request.to_version),
-        });
-        self.llm_sidecar.request_decision();
-        self.set_latest_player_gameplay_feedback(PlayerGameplayRecentFeedback {
-            action: "prompt_control.rollback".to_string(),
-            stage: "completed_advanced".to_string(),
-            effect: format!(
-                "rolled back prompt guidance for {} to base version {} via version {}",
-                request.agent_id, request.to_version, candidate.version
-            ),
-            intent_summary: Some(format!(
-                "roll back prompt guidance for {}",
-                request.agent_id
-            )),
-            target_agent_id: Some(request.agent_id.clone()),
-            reason: None,
-            hint: Some(
-                "continue the world and confirm the agent now follows the restored guidance"
-                    .to_string(),
-            ),
-            delta_logical_time: 0,
-            delta_event_seq: 0,
-        });
-
-        Ok(PromptControlAck {
-            agent_id: request.agent_id,
-            operation: PromptControlOperation::Rollback,
-            preview: false,
-            version: candidate.version,
-            updated_at_tick: candidate.updated_at_tick,
-            applied_fields,
-            digest,
-            rolled_back_to_version: Some(request.to_version),
-        })
-    }
-
-    fn verify_and_consume_prompt_control_apply_auth(
-        &mut self,
-        intent: PromptControlAuthIntent,
-        request: &PromptControlApplyRequest,
-    ) -> Result<(), PromptControlError> {
-        let Some(auth) = request.auth.as_ref() else {
-            return Err(PromptControlError {
-                code: "auth_proof_required".to_string(),
-                message: "prompt_control requires auth proof".to_string(),
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            });
-        };
-        let verified =
-            verify_prompt_control_apply_auth_proof(intent, request, auth).map_err(|message| {
-                PromptControlError {
-                    code: map_auth_verify_error_code(message.as_str()).to_string(),
-                    message,
-                    agent_id: Some(request.agent_id.clone()),
-                    current_version: self.current_prompt_version(request.agent_id.as_str()),
-                }
-            })?;
-        self.session_policy
-            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
-            .map_err(|message| PromptControlError {
-                code: map_session_policy_error_code(message.as_str()).to_string(),
-                message,
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            })?;
-        self.llm_sidecar
-            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
-            .map_err(|message| PromptControlError {
-                code: "auth_nonce_replay".to_string(),
-                message,
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            })?;
-        Ok(())
-    }
-
-    fn verify_hosted_prompt_control_apply_strong_auth(
-        &self,
-        intent: PromptControlAuthIntent,
-        request: &PromptControlApplyRequest,
-    ) -> Result<(), PromptControlError> {
-        let Some(grant) = request.strong_auth_grant.as_ref() else {
-            return Err(self.hosted_prompt_control_strong_auth_error(
-                "strong_auth_required",
-                request.agent_id.as_str(),
-                "prompt_control requires hosted strong auth grant on hosted_public_join",
-            ));
-        };
-        let signer_public_key =
-            hosted_strong_auth_grant_public_key_from_env().map_err(|message| {
-                self.hosted_prompt_control_strong_auth_error(
-                    "strong_auth_required",
-                    request.agent_id.as_str(),
-                    message.as_str(),
-                )
-            })?;
-        verify_hosted_prompt_control_apply_strong_auth_grant(
-            intent,
-            request,
-            grant,
-            signer_public_key.as_str(),
-            hosted_strong_auth_now_unix_ms(),
-        )
-        .map_err(|message| {
-            self.hosted_prompt_control_strong_auth_error(
-                "strong_auth_grant_invalid",
-                request.agent_id.as_str(),
-                message.as_str(),
-            )
-        })
-    }
-
-    fn verify_and_consume_prompt_control_rollback_auth(
-        &mut self,
-        request: &PromptControlRollbackRequest,
-    ) -> Result<(), PromptControlError> {
-        let Some(auth) = request.auth.as_ref() else {
-            return Err(PromptControlError {
-                code: "auth_proof_required".to_string(),
-                message: "prompt_control rollback requires auth proof".to_string(),
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            });
-        };
-        let verified =
-            verify_prompt_control_rollback_auth_proof(request, auth).map_err(|message| {
-                PromptControlError {
-                    code: map_auth_verify_error_code(message.as_str()).to_string(),
-                    message,
-                    agent_id: Some(request.agent_id.clone()),
-                    current_version: self.current_prompt_version(request.agent_id.as_str()),
-                }
-            })?;
-        self.session_policy
-            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
-            .map_err(|message| PromptControlError {
-                code: map_session_policy_error_code(message.as_str()).to_string(),
-                message,
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            })?;
-        self.llm_sidecar
-            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
-            .map_err(|message| PromptControlError {
-                code: "auth_nonce_replay".to_string(),
-                message,
-                agent_id: Some(request.agent_id.clone()),
-                current_version: self.current_prompt_version(request.agent_id.as_str()),
-            })?;
-        Ok(())
-    }
-
-    fn verify_hosted_prompt_control_rollback_strong_auth(
-        &self,
-        request: &PromptControlRollbackRequest,
-    ) -> Result<(), PromptControlError> {
-        let Some(grant) = request.strong_auth_grant.as_ref() else {
-            return Err(self.hosted_prompt_control_strong_auth_error(
-                "strong_auth_required",
-                request.agent_id.as_str(),
-                "prompt_control rollback requires hosted strong auth grant on hosted_public_join",
-            ));
-        };
-        let signer_public_key =
-            hosted_strong_auth_grant_public_key_from_env().map_err(|message| {
-                self.hosted_prompt_control_strong_auth_error(
-                    "strong_auth_required",
-                    request.agent_id.as_str(),
-                    message.as_str(),
-                )
-            })?;
-        verify_hosted_prompt_control_rollback_strong_auth_grant(
-            request,
-            grant,
-            signer_public_key.as_str(),
-            hosted_strong_auth_now_unix_ms(),
-        )
-        .map_err(|message| {
-            self.hosted_prompt_control_strong_auth_error(
-                "strong_auth_grant_invalid",
-                request.agent_id.as_str(),
-                message.as_str(),
-            )
-        })
-    }
-
-    fn hosted_prompt_control_strong_auth_error(
-        &self,
-        code: &str,
-        agent_id: &str,
-        message: &str,
-    ) -> PromptControlError {
-        PromptControlError {
-            code: code.to_string(),
-            message: message.to_string(),
-            agent_id: Some(agent_id.to_string()),
-            current_version: self.current_prompt_version(agent_id),
-        }
-    }
-
     fn verify_agent_chat_auth(
         &mut self,
         request: &AgentChatRequest,
@@ -629,8 +135,16 @@ impl ViewerRuntimeLiveServer {
                 message,
                 agent_id: Some(agent_id.to_string()),
                 current_version: self.current_prompt_version(agent_id),
+                ..PromptControlError::default_legacy()
             })?;
         for event in events {
+            if matches!(
+                &event,
+                WorldEventKind::AgentPlayerBound { .. } | WorldEventKind::AgentPlayerUnbound { .. }
+            ) {
+                self.prompt_control_authority
+                    .advance_binding_epoch(agent_id);
+            }
             self.enqueue_virtual_event(event);
         }
         Ok(())
@@ -866,9 +380,125 @@ pub(super) fn normalize_required_player_id(
             ),
             agent_id: Some(agent_id.to_string()),
             current_version: None,
+            ..PromptControlError::default_legacy()
         });
     }
     Ok(normalized.to_string())
+}
+
+fn prompt_control_enhanced_error(
+    code: &str,
+    message: &str,
+    request_id: Option<String>,
+    operation: PromptControlOperation,
+    preview: bool,
+    agent_id: Option<String>,
+    player_id: Option<String>,
+    status: PromptControlResultStatus,
+) -> PromptControlError {
+    let mut error = PromptControlError::default_legacy();
+    error.code = code.to_string();
+    error.message = message.to_string();
+    error.request_id = request_id;
+    error.operation = Some(operation);
+    error.preview = Some(preview);
+    error.status = Some(status);
+    if status == PromptControlResultStatus::Blocked {
+        error.value_visibility = Some(PromptControlValueVisibility::Hidden);
+        error.next_step = Some("reauthenticate_and_retry".to_string());
+    }
+    error.agent_id = agent_id;
+    error.player_id = player_id;
+    error.reason_code = Some(code.to_string());
+    error
+}
+
+fn prompt_control_control_lost_error(
+    request_id: &str,
+    operation: PromptControlOperation,
+    preview: bool,
+    agent_id: Option<String>,
+) -> PromptControlError {
+    let mut error = prompt_control_enhanced_error(
+        "control_lost",
+        "prompt control authorization is no longer current",
+        Some(request_id.to_string()),
+        operation,
+        preview,
+        agent_id,
+        None,
+        PromptControlResultStatus::Blocked,
+    );
+    error.next_step = Some("reauthenticate_and_refresh_binding".to_string());
+    error
+}
+
+fn prompt_control_access_error(
+    error: PromptControlError,
+    request_id: &str,
+    operation: PromptControlOperation,
+    preview: bool,
+    agent_id: &str,
+    player_id: &str,
+) -> PromptControlError {
+    if error.code == "agent_not_found" {
+        return prompt_control_enhanced_error(
+            "agent_not_found",
+            "prompt control target Agent was not found",
+            Some(request_id.to_string()),
+            operation,
+            preview,
+            Some(agent_id.to_string()),
+            Some(player_id.to_string()),
+            PromptControlResultStatus::Rejected,
+        );
+    }
+    prompt_control_control_lost_error(request_id, operation, preview, Some(agent_id.to_string()))
+}
+
+fn prompt_control_result_unknown_error(request_id: &str) -> PromptControlError {
+    let mut error = PromptControlError::default_legacy();
+    error.code = "prompt_control_result_unknown".to_string();
+    error.message = "prompt control result is unknown for the current authority epoch".to_string();
+    error.request_id = Some(request_id.to_string());
+    error.status = Some(PromptControlResultStatus::Blocked);
+    error.value_visibility = Some(PromptControlValueVisibility::Hidden);
+    error.reason_code = Some("result_unknown".to_string());
+    error.next_step = Some("refresh_authority_and_retry_with_new_request_id".to_string());
+    error
+}
+
+fn prompt_control_ledger_error(
+    error: PromptControlLedgerInsertError,
+    request_id: &str,
+) -> PromptControlError {
+    let (code, message, status) = match error {
+        PromptControlLedgerInsertError::Full => (
+            "result_cache_full".to_string(),
+            "prompt control result cache is full".to_string(),
+            PromptControlResultStatus::Blocked,
+        ),
+        PromptControlLedgerInsertError::ReceiptTooLarge { actual, limit } => (
+            "result_receipt_too_large".to_string(),
+            format!("prompt control result receipt is {actual} bytes; limit is {limit}"),
+            PromptControlResultStatus::Rejected,
+        ),
+        PromptControlLedgerInsertError::Serialize(message) => (
+            "result_receipt_encode_failed".to_string(),
+            message,
+            PromptControlResultStatus::Blocked,
+        ),
+    };
+    let mut result = PromptControlError::default_legacy();
+    result.code = code.clone();
+    result.message = message;
+    result.request_id = Some(request_id.to_string());
+    result.status = Some(status);
+    if status == PromptControlResultStatus::Blocked {
+        result.value_visibility = Some(PromptControlValueVisibility::Hidden);
+    }
+    result.reason_code = Some(code);
+    result
 }
 
 pub(super) fn normalize_optional_public_key(public_key: Option<&str>) -> Option<String> {
@@ -897,6 +527,7 @@ pub(super) fn ensure_updated_by_matches_player_runtime(
         ),
         agent_id: Some(agent_id.to_string()),
         current_version: None,
+        ..PromptControlError::default_legacy()
     })
 }
 
@@ -934,6 +565,7 @@ fn ensure_agent_player_access_runtime_inner(
             message: format!("agent not found: {agent_id}"),
             agent_id: Some(agent_id.to_string()),
             current_version: None,
+            ..PromptControlError::default_legacy()
         });
     }
     let Some(bound_player_id) = sidecar.agent_player_bindings.get(agent_id) else {
@@ -948,6 +580,7 @@ fn ensure_agent_player_access_runtime_inner(
                 .prompt_profiles
                 .get(agent_id)
                 .map(|entry| entry.version),
+            ..PromptControlError::default_legacy()
         });
     };
     if bound_player_id == player_id {
@@ -977,6 +610,7 @@ fn ensure_agent_player_access_runtime_inner(
                 .prompt_profiles
                 .get(agent_id)
                 .map(|entry| entry.version),
+            ..PromptControlError::default_legacy()
         });
     }
     Err(PromptControlError {
@@ -990,6 +624,7 @@ fn ensure_agent_player_access_runtime_inner(
             .prompt_profiles
             .get(agent_id)
             .map(|entry| entry.version),
+        ..PromptControlError::default_legacy()
     })
 }
 
@@ -1059,6 +694,7 @@ pub(super) fn ensure_expected_prompt_version_runtime(
                 ),
                 agent_id: Some(agent_id.to_string()),
                 current_version: Some(current_version),
+                ..PromptControlError::default_legacy()
             });
         }
     }

--- a/crates/oasis7/src/viewer/runtime_live/control_plane.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane.rs
@@ -2,6 +2,7 @@ use super::*;
 
 use super::super::auth::{
     AGENT_CHAT_AUTHORITY_SCOPE, PromptControlAuthIntent, VerifiedPlayerAuth,
+    has_enhanced_prompt_identity_apply, has_enhanced_prompt_identity_rollback,
     normalize_prompt_control_operation_identity, prompt_control_operation_digest,
     verify_agent_chat_auth_proof_with_authority,
     verify_hosted_prompt_control_apply_strong_auth_grant,
@@ -35,7 +36,9 @@ mod prompt_control_legacy;
 mod prompt_profile;
 #[path = "control_plane/provider_action.rs"]
 mod provider_action;
-use super::prompt_control_result::{PromptControlLedgerInsertError, PromptControlLedgerLookup};
+use super::prompt_control_result::{
+    PromptControlLedgerInsertError, PromptControlLedgerLookup, PromptControlLedgerReceipt,
+};
 pub(in crate::viewer::runtime_live) use agent_chat_intent::RuntimePrimaryIntent;
 use agent_chat_intent::{apply_accepted_primary_intent, resolve_agent_chat_intent};
 pub(super) use auth_helpers::map_auth_verify_error_code;

--- a/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_enhanced.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_enhanced.rs
@@ -6,30 +6,57 @@ impl ViewerRuntimeLiveServer {
         command: PromptControlCommand,
         negotiated: &crate::viewer::protocol::NegotiatedViewerProtocol,
     ) -> Result<PromptControlAck, PromptControlError> {
+        let capability_selected =
+            crate::viewer::protocol::viewer_protocol_supports_prompt_control_result(negotiated);
         let enhanced = match &command {
             PromptControlCommand::Preview { request } | PromptControlCommand::Apply { request } => {
-                request.request_id.is_some()
-                    || request.session_epoch.is_some()
-                    || request.binding_epoch.is_some()
-                    || request.expected_authority_epoch.is_some()
+                has_enhanced_prompt_identity_apply(request)
             }
             PromptControlCommand::Rollback { request } => {
-                request.request_id.is_some()
-                    || request.session_epoch.is_some()
-                    || request.binding_epoch.is_some()
-                    || request.expected_authority_epoch.is_some()
+                has_enhanced_prompt_identity_rollback(request)
             }
         };
-        if !enhanced {
-            return self.handle_prompt_control(command);
-        }
-        if !crate::viewer::protocol::viewer_protocol_supports_prompt_control_result(negotiated) {
+        if capability_selected {
+            let missing_field = match &command {
+                PromptControlCommand::Preview { request }
+                | PromptControlCommand::Apply { request } => {
+                    Self::missing_enhanced_apply_field(request)
+                }
+                PromptControlCommand::Rollback { request } => {
+                    Self::missing_enhanced_rollback_field(request)
+                }
+            };
+            if let Some(field) = missing_field {
+                let (request_id, operation, preview) = match &command {
+                    PromptControlCommand::Preview { request } => (
+                        request.request_id.clone(),
+                        PromptControlOperation::Apply,
+                        true,
+                    ),
+                    PromptControlCommand::Apply { request } => (
+                        request.request_id.clone(),
+                        PromptControlOperation::Apply,
+                        false,
+                    ),
+                    PromptControlCommand::Rollback { request } => (
+                        request.request_id.clone(),
+                        PromptControlOperation::Rollback,
+                        false,
+                    ),
+                };
+                return Err(Self::prompt_control_field_required_error(
+                    request_id, operation, preview, field,
+                ));
+            }
+        } else if enhanced {
             return Err(PromptControlError {
                 code: "prompt_control_capability_required".to_string(),
                 message: "prompt_control result capability is required for enhanced requests"
                     .to_string(),
                 ..PromptControlError::default_legacy()
             });
+        } else {
+            return self.handle_prompt_control(command);
         }
         match command {
             PromptControlCommand::Preview { request } => {
@@ -42,6 +69,80 @@ impl ViewerRuntimeLiveServer {
                 self.handle_enhanced_prompt_rollback(request)
             }
         }
+    }
+
+    fn missing_enhanced_apply_field(request: &PromptControlApplyRequest) -> Option<&'static str> {
+        if request
+            .request_id
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Some("request_id");
+        }
+        if request.session_epoch.is_none() {
+            return Some("session_epoch");
+        }
+        if request.binding_epoch.is_none() {
+            return Some("binding_epoch");
+        }
+        if request
+            .expected_authority_epoch
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Some("expected_authority_epoch");
+        }
+        if request.expected_version.is_none() {
+            return Some("expected_version");
+        }
+        None
+    }
+
+    fn missing_enhanced_rollback_field(
+        request: &PromptControlRollbackRequest,
+    ) -> Option<&'static str> {
+        if request
+            .request_id
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Some("request_id");
+        }
+        if request.session_epoch.is_none() {
+            return Some("session_epoch");
+        }
+        if request.binding_epoch.is_none() {
+            return Some("binding_epoch");
+        }
+        if request
+            .expected_authority_epoch
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            return Some("expected_authority_epoch");
+        }
+        if request.expected_version.is_none() {
+            return Some("expected_version");
+        }
+        None
+    }
+
+    fn prompt_control_field_required_error(
+        request_id: Option<String>,
+        operation: PromptControlOperation,
+        preview: bool,
+        field: &str,
+    ) -> PromptControlError {
+        prompt_control_enhanced_error(
+            "prompt_control_field_required",
+            &format!("prompt_control {field} is required when the result capability is selected"),
+            request_id,
+            operation,
+            preview,
+            None,
+            None,
+            PromptControlResultStatus::Rejected,
+        )
     }
 
     fn handle_enhanced_prompt_apply(
@@ -77,32 +178,6 @@ impl ViewerRuntimeLiveServer {
                 ));
             }
         };
-        if self.hosted_public_join_mode() {
-            self.verify_hosted_prompt_control_apply_strong_auth(
-                if preview {
-                    PromptControlAuthIntent::Preview
-                } else {
-                    PromptControlAuthIntent::Apply
-                },
-                &request,
-            )
-            .map_err(|error| {
-                prompt_control_enhanced_error(
-                    if error.code == "strong_auth_required" {
-                        "auth_required"
-                    } else {
-                        "auth_invalid"
-                    },
-                    "prompt_control authentication failed",
-                    Some(request_id.clone()),
-                    operation,
-                    preview,
-                    None,
-                    None,
-                    PromptControlResultStatus::Blocked,
-                )
-            })?;
-        }
         let agent_id = request.agent_id.trim().to_string();
         let player_id =
             normalize_required_player_id(request.player_id.as_str(), agent_id.as_str())?;
@@ -310,9 +385,13 @@ impl ViewerRuntimeLiveServer {
             request_id.as_str(),
             operation_digest.as_str(),
         ) {
-            PromptControlLedgerLookup::Replay(mut ack) => {
+            PromptControlLedgerLookup::Replay(PromptControlLedgerReceipt::Ack(mut ack)) => {
                 ack.idempotent_replay = true;
                 return Ok(ack);
+            }
+            PromptControlLedgerLookup::Replay(PromptControlLedgerReceipt::Error(mut error)) => {
+                error.idempotent_replay = true;
+                return Err(error);
             }
             PromptControlLedgerLookup::Conflict => {
                 return Err(prompt_control_enhanced_error(
@@ -340,6 +419,32 @@ impl ViewerRuntimeLiveServer {
                 PromptControlResultStatus::Blocked,
             ));
         }
+        if self.hosted_public_join_mode() {
+            self.verify_hosted_prompt_control_apply_strong_auth(
+                if preview {
+                    PromptControlAuthIntent::Preview
+                } else {
+                    PromptControlAuthIntent::Apply
+                },
+                &request,
+            )
+            .map_err(|error| {
+                prompt_control_enhanced_error(
+                    if error.code == "strong_auth_required" {
+                        "auth_required"
+                    } else {
+                        "auth_invalid"
+                    },
+                    "prompt control authentication failed",
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Blocked,
+                )
+            })?;
+        }
         let current = self
             .current_prompt_profile(agent_id.as_str())
             .map_err(|_| {
@@ -355,16 +460,54 @@ impl ViewerRuntimeLiveServer {
                 )
             })?;
         if current.version != expected_version {
-            return Err(prompt_control_enhanced_error(
+            let mut stale = prompt_control_enhanced_error(
                 "version_conflict",
                 "prompt control expected_version does not match current version",
-                Some(request_id),
+                Some(request_id.clone()),
                 operation,
                 preview,
                 Some(agent_id.clone()),
-                Some(player_id),
+                Some(player_id.clone()),
                 PromptControlResultStatus::Stale,
-            ));
+            );
+            stale.authority_epoch = Some(self.prompt_control_authority.authority_epoch.clone());
+            stale.session_epoch = request.session_epoch;
+            stale.binding_epoch = request.binding_epoch;
+            stale.expected_version = Some(expected_version);
+            stale.current_version = Some(current.version);
+            stale.version = Some(current.version);
+            stale.value_visibility = Some(PromptControlValueVisibility::LatestAllowed);
+            stale.next_step = Some("refresh_prompt_version".to_string());
+            stale.operation_digest = Some(operation_digest.clone());
+            self.prompt_control_authority
+                .result_ledger
+                .validate_error(&stale)
+                .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+            self.llm_sidecar
+                .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+                .map_err(|_message| {
+                    prompt_control_enhanced_error(
+                        "auth_invalid",
+                        "prompt control authentication failed",
+                        Some(request_id.clone()),
+                        operation,
+                        preview,
+                        None,
+                        None,
+                        PromptControlResultStatus::Blocked,
+                    )
+                })?;
+            self.prompt_control_authority
+                .result_ledger
+                .insert_error(
+                    self.prompt_control_authority.authority_epoch.as_str(),
+                    player_id.as_str(),
+                    request_id.as_str(),
+                    operation_digest,
+                    stale.clone(),
+                )
+                .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+            return Err(stale);
         }
         let mut candidate = current.clone();
         apply_prompt_patch_runtime(&mut candidate, &request);
@@ -538,25 +681,6 @@ impl ViewerRuntimeLiveServer {
                 ));
             }
         };
-        if self.hosted_public_join_mode() {
-            self.verify_hosted_prompt_control_rollback_strong_auth(&request)
-                .map_err(|error| {
-                    prompt_control_enhanced_error(
-                        if error.code == "strong_auth_required" {
-                            "auth_required"
-                        } else {
-                            "auth_invalid"
-                        },
-                        "prompt_control authentication failed",
-                        Some(request_id.clone()),
-                        operation,
-                        false,
-                        None,
-                        None,
-                        PromptControlResultStatus::Blocked,
-                    )
-                })?;
-        }
         let agent_id = request.agent_id.trim().to_string();
         let player_id =
             normalize_required_player_id(request.player_id.as_str(), agent_id.as_str())?;
@@ -735,9 +859,13 @@ impl ViewerRuntimeLiveServer {
             request_id.as_str(),
             operation_digest.as_str(),
         ) {
-            PromptControlLedgerLookup::Replay(mut ack) => {
+            PromptControlLedgerLookup::Replay(PromptControlLedgerReceipt::Ack(mut ack)) => {
                 ack.idempotent_replay = true;
                 return Ok(ack);
+            }
+            PromptControlLedgerLookup::Replay(PromptControlLedgerReceipt::Error(mut error)) => {
+                error.idempotent_replay = true;
+                return Err(error);
             }
             PromptControlLedgerLookup::Conflict => {
                 return Err(prompt_control_enhanced_error(
@@ -765,6 +893,25 @@ impl ViewerRuntimeLiveServer {
                 PromptControlResultStatus::Blocked,
             ));
         }
+        if self.hosted_public_join_mode() {
+            self.verify_hosted_prompt_control_rollback_strong_auth(&request)
+                .map_err(|error| {
+                    prompt_control_enhanced_error(
+                        if error.code == "strong_auth_required" {
+                            "auth_required"
+                        } else {
+                            "auth_invalid"
+                        },
+                        "prompt_control authentication failed",
+                        Some(request_id.clone()),
+                        operation,
+                        false,
+                        None,
+                        None,
+                        PromptControlResultStatus::Blocked,
+                    )
+                })?;
+        }
         let current = self
             .current_prompt_profile(agent_id.as_str())
             .map_err(|_| {
@@ -780,16 +927,54 @@ impl ViewerRuntimeLiveServer {
                 )
             })?;
         if current.version != expected_version {
-            return Err(prompt_control_enhanced_error(
+            let mut stale = prompt_control_enhanced_error(
                 "version_conflict",
                 "prompt control expected_version does not match current version",
-                Some(request_id),
+                Some(request_id.clone()),
                 operation,
                 false,
-                Some(agent_id),
-                Some(player_id),
+                Some(agent_id.clone()),
+                Some(player_id.clone()),
                 PromptControlResultStatus::Stale,
-            ));
+            );
+            stale.authority_epoch = Some(self.prompt_control_authority.authority_epoch.clone());
+            stale.session_epoch = request.session_epoch;
+            stale.binding_epoch = request.binding_epoch;
+            stale.expected_version = Some(expected_version);
+            stale.current_version = Some(current.version);
+            stale.version = Some(current.version);
+            stale.value_visibility = Some(PromptControlValueVisibility::LatestAllowed);
+            stale.next_step = Some("refresh_prompt_version".to_string());
+            stale.operation_digest = Some(operation_digest.clone());
+            self.prompt_control_authority
+                .result_ledger
+                .validate_error(&stale)
+                .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+            self.llm_sidecar
+                .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+                .map_err(|_message| {
+                    prompt_control_enhanced_error(
+                        "auth_invalid",
+                        "prompt control authentication failed",
+                        Some(request_id.clone()),
+                        operation,
+                        false,
+                        None,
+                        None,
+                        PromptControlResultStatus::Blocked,
+                    )
+                })?;
+            self.prompt_control_authority
+                .result_ledger
+                .insert_error(
+                    self.prompt_control_authority.authority_epoch.as_str(),
+                    player_id.as_str(),
+                    request_id.as_str(),
+                    operation_digest,
+                    stale.clone(),
+                )
+                .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+            return Err(stale);
         }
         let target = if request.to_version == 0 {
             AgentPromptProfile::for_agent(agent_id.clone())

--- a/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_enhanced.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_enhanced.rs
@@ -1,0 +1,932 @@
+use super::*;
+
+impl ViewerRuntimeLiveServer {
+    pub(in crate::viewer::runtime_live) fn handle_prompt_control_for_protocol(
+        &mut self,
+        command: PromptControlCommand,
+        negotiated: &crate::viewer::protocol::NegotiatedViewerProtocol,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let enhanced = match &command {
+            PromptControlCommand::Preview { request } | PromptControlCommand::Apply { request } => {
+                request.request_id.is_some()
+                    || request.session_epoch.is_some()
+                    || request.binding_epoch.is_some()
+                    || request.expected_authority_epoch.is_some()
+            }
+            PromptControlCommand::Rollback { request } => {
+                request.request_id.is_some()
+                    || request.session_epoch.is_some()
+                    || request.binding_epoch.is_some()
+                    || request.expected_authority_epoch.is_some()
+            }
+        };
+        if !enhanced {
+            return self.handle_prompt_control(command);
+        }
+        if !crate::viewer::protocol::viewer_protocol_supports_prompt_control_result(negotiated) {
+            return Err(PromptControlError {
+                code: "prompt_control_capability_required".to_string(),
+                message: "prompt_control result capability is required for enhanced requests"
+                    .to_string(),
+                ..PromptControlError::default_legacy()
+            });
+        }
+        match command {
+            PromptControlCommand::Preview { request } => {
+                self.handle_enhanced_prompt_apply(request, true)
+            }
+            PromptControlCommand::Apply { request } => {
+                self.handle_enhanced_prompt_apply(request, false)
+            }
+            PromptControlCommand::Rollback { request } => {
+                self.handle_enhanced_prompt_rollback(request)
+            }
+        }
+    }
+
+    fn handle_enhanced_prompt_apply(
+        &mut self,
+        request: PromptControlApplyRequest,
+        preview: bool,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let operation = PromptControlOperation::Apply;
+        let request_id = match request.request_id.as_deref().map(str::trim) {
+            Some(value) if !value.is_empty() && value.len() <= 128 => value.to_string(),
+            Some(value) if value.len() > 128 => {
+                return Err(prompt_control_enhanced_error(
+                    "prompt_control_request_id_invalid",
+                    "prompt_control request_id exceeds 128 UTF-8 bytes",
+                    None,
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+            _ => {
+                return Err(prompt_control_enhanced_error(
+                    "prompt_control_request_id_required",
+                    "prompt_control request_id is required",
+                    None,
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+        };
+        if self.hosted_public_join_mode() {
+            self.verify_hosted_prompt_control_apply_strong_auth(
+                if preview {
+                    PromptControlAuthIntent::Preview
+                } else {
+                    PromptControlAuthIntent::Apply
+                },
+                &request,
+            )
+            .map_err(|error| {
+                prompt_control_enhanced_error(
+                    if error.code == "strong_auth_required" {
+                        "auth_required"
+                    } else {
+                        "auth_invalid"
+                    },
+                    "prompt_control authentication failed",
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Blocked,
+                )
+            })?;
+        }
+        let agent_id = request.agent_id.trim().to_string();
+        let player_id =
+            normalize_required_player_id(request.player_id.as_str(), agent_id.as_str())?;
+        if !self.llm_sidecar.is_llm_mode() {
+            return Err(prompt_control_enhanced_error(
+                "llm_mode_required",
+                "prompt_control requires runtime live server running with --llm",
+                Some(request_id),
+                operation,
+                preview,
+                Some(agent_id.clone()),
+                Some(player_id),
+                PromptControlResultStatus::Blocked,
+            ));
+        }
+        if !self.llm_sidecar.supports_prompt_control() {
+            return Err(prompt_control_enhanced_error(
+                "agent_provider_prompt_control_unsupported",
+                "prompt_control is not supported when runtime live uses ProviderBacked(Local HTTP)",
+                Some(request_id),
+                operation,
+                preview,
+                Some(agent_id.clone()),
+                Some(player_id),
+                PromptControlResultStatus::Rejected,
+            ));
+        }
+        let Some(auth) = request.auth.as_ref() else {
+            return Err(prompt_control_enhanced_error(
+                "auth_required",
+                "prompt_control requires auth proof",
+                Some(request_id),
+                operation,
+                preview,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            ));
+        };
+        let verified = verify_prompt_control_apply_auth_proof(
+            if preview {
+                PromptControlAuthIntent::Preview
+            } else {
+                PromptControlAuthIntent::Apply
+            },
+            &request,
+            auth,
+        )
+        .map_err(|_| {
+            prompt_control_enhanced_error(
+                "auth_invalid",
+                "prompt_control authentication failed",
+                Some(request_id.clone()),
+                operation,
+                preview,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            )
+        })?;
+        let expected_authority_epoch = request
+            .expected_authority_epoch
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                prompt_control_enhanced_error(
+                    "expected_authority_epoch_required",
+                    "prompt_control expected_authority_epoch is required",
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                )
+            })?;
+        if expected_authority_epoch != self.prompt_control_authority.authority_epoch {
+            return Err(prompt_control_result_unknown_error(&request_id));
+        }
+        let current_session_epoch = self
+            .session_policy
+            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
+            .map_err(|_| {
+                prompt_control_control_lost_error(
+                    &request_id,
+                    operation,
+                    preview,
+                    Some(agent_id.clone()),
+                )
+            })?;
+        if request.session_epoch != Some(current_session_epoch) {
+            return Err(prompt_control_control_lost_error(
+                &request_id,
+                operation,
+                preview,
+                Some(agent_id.clone()),
+            ));
+        }
+        let current_binding_epoch = self
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str());
+        if request.binding_epoch != Some(current_binding_epoch) {
+            return Err(prompt_control_control_lost_error(
+                &request_id,
+                operation,
+                preview,
+                Some(agent_id.clone()),
+            ));
+        }
+        let public_key = normalize_optional_public_key(request.public_key.as_deref());
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )
+        .map_err(|error| {
+            prompt_control_access_error(
+                error,
+                &request_id,
+                operation,
+                preview,
+                agent_id.as_str(),
+                player_id.as_str(),
+            )
+        })?;
+        let expected_version = request.expected_version.ok_or_else(|| {
+            prompt_control_enhanced_error(
+                "expected_version_required",
+                "prompt_control expected_version is required",
+                Some(request_id.clone()),
+                operation,
+                preview,
+                Some(agent_id.clone()),
+                Some(player_id.clone()),
+                PromptControlResultStatus::Rejected,
+            )
+        })?;
+        if !preview {
+            let updated_by = request.updated_by.as_deref().map(str::trim).unwrap_or("");
+            if updated_by.is_empty() || updated_by != player_id {
+                return Err(prompt_control_enhanced_error(
+                    "updated_by_required",
+                    "mutating prompt_control requests require updated_by matching player_id",
+                    Some(request_id),
+                    operation,
+                    preview,
+                    Some(agent_id),
+                    Some(player_id),
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+        } else {
+            ensure_updated_by_matches_player_runtime(
+                request.updated_by.as_deref(),
+                player_id.as_str(),
+                agent_id.as_str(),
+            )
+            .map_err(|message| {
+                prompt_control_enhanced_error(
+                    "updated_by_invalid",
+                    message.message.as_str(),
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    Some(agent_id.clone()),
+                    Some(player_id.clone()),
+                    PromptControlResultStatus::Rejected,
+                )
+            })?;
+        }
+        let identity = normalize_prompt_control_operation_identity(
+            "apply",
+            preview,
+            agent_id.as_str(),
+            player_id.as_str(),
+            request.session_epoch,
+            request.binding_epoch,
+            Some(expected_authority_epoch),
+            request.expected_version,
+            &request.system_prompt_override,
+            &request.short_term_goal_override,
+            &request.long_term_goal_override,
+            None,
+            request.updated_by.as_deref(),
+        )
+        .map_err(|message| {
+            prompt_control_enhanced_error(
+                "prompt_control_identity_invalid",
+                message.as_str(),
+                Some(request_id.clone()),
+                operation,
+                preview,
+                Some(agent_id.clone()),
+                Some(player_id.clone()),
+                PromptControlResultStatus::Rejected,
+            )
+        })?;
+        let operation_digest = prompt_control_operation_digest(&identity);
+        match self.prompt_control_authority.result_ledger.lookup(
+            self.prompt_control_authority.authority_epoch.as_str(),
+            player_id.as_str(),
+            request_id.as_str(),
+            operation_digest.as_str(),
+        ) {
+            PromptControlLedgerLookup::Replay(mut ack) => {
+                ack.idempotent_replay = true;
+                return Ok(ack);
+            }
+            PromptControlLedgerLookup::Conflict => {
+                return Err(prompt_control_enhanced_error(
+                    "request_id_conflict",
+                    "request_id was already used for a different prompt operation",
+                    Some(request_id),
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+            PromptControlLedgerLookup::Missing => {}
+        }
+        if self.prompt_control_authority.result_ledger.is_full() {
+            return Err(prompt_control_enhanced_error(
+                "result_cache_full",
+                "prompt control result cache is full",
+                Some(request_id),
+                operation,
+                preview,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            ));
+        }
+        let current = self
+            .current_prompt_profile(agent_id.as_str())
+            .map_err(|_| {
+                prompt_control_enhanced_error(
+                    "agent_not_found",
+                    "prompt control target Agent was not found",
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    Some(agent_id.clone()),
+                    Some(player_id.clone()),
+                    PromptControlResultStatus::Rejected,
+                )
+            })?;
+        if current.version != expected_version {
+            return Err(prompt_control_enhanced_error(
+                "version_conflict",
+                "prompt control expected_version does not match current version",
+                Some(request_id),
+                operation,
+                preview,
+                Some(agent_id.clone()),
+                Some(player_id),
+                PromptControlResultStatus::Stale,
+            ));
+        }
+        let mut candidate = current.clone();
+        apply_prompt_patch_runtime(&mut candidate, &request);
+        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
+        let changed = !applied_fields.is_empty();
+        let version = if changed {
+            current.version.saturating_add(1)
+        } else {
+            current.version
+        };
+        if changed {
+            candidate.version = version;
+            candidate.updated_at_tick = self.world.state().time;
+            candidate.updated_by = player_id.clone();
+        }
+        let digest = prompt_profile_digest_runtime(&candidate);
+        let mut ack = PromptControlAck {
+            request_id: Some(request_id.clone()),
+            authority_epoch: Some(self.prompt_control_authority.authority_epoch.clone()),
+            agent_id: agent_id.clone(),
+            operation,
+            preview,
+            status: Some(if changed && !preview {
+                PromptControlResultStatus::Applied
+            } else {
+                PromptControlResultStatus::Accepted
+            }),
+            player_id: Some(player_id.clone()),
+            session_epoch: request.session_epoch,
+            binding_epoch: request.binding_epoch,
+            expected_version: Some(expected_version),
+            version,
+            updated_at_tick: candidate.updated_at_tick,
+            applied_fields: applied_fields.clone(),
+            digest: digest.clone(),
+            value_visibility: Some(PromptControlValueVisibility::LatestAllowed),
+            applied_scope: Some(if changed && !preview {
+                PromptControlApplicationScope::RuntimeInstance
+            } else {
+                PromptControlApplicationScope::None
+            }),
+            persistence_scope: Some(PromptControlApplicationScope::None),
+            sync_scope: Some(PromptControlApplicationScope::None),
+            reason_code: Some(if changed { "applied" } else { "no_change" }.to_string()),
+            next_step: Some(if changed {
+                "continue_runtime".to_string()
+            } else {
+                "no_action_required".to_string()
+            }),
+            operation_digest: Some(operation_digest.clone()),
+            idempotent_replay: false,
+            mutation_count: Some(u64::from(changed && !preview)),
+            rolled_back_to_version: None,
+        };
+        self.prompt_control_authority
+            .result_ledger
+            .validate_receipt(&ack)
+            .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+        self.llm_sidecar
+            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+            .map_err(|_message| {
+                prompt_control_enhanced_error(
+                    "auth_invalid",
+                    "prompt control authentication failed",
+                    Some(request_id.clone()),
+                    operation,
+                    preview,
+                    None,
+                    None,
+                    PromptControlResultStatus::Blocked,
+                )
+            })?;
+        if self.prompt_control_authority.authority_epoch != expected_authority_epoch
+            || self
+                .prompt_control_authority
+                .binding_epoch(agent_id.as_str())
+                != current_binding_epoch
+        {
+            return Err(prompt_control_result_unknown_error(&request_id));
+        }
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )
+        .map_err(|_| prompt_control_result_unknown_error(&request_id))?;
+        if !preview && changed {
+            self.llm_sidecar
+                .apply_prompt_profile_to_driver(&candidate)
+                .map_err(|message| PromptControlError {
+                    code: "prompt_override_enqueue_failed".to_string(),
+                    message,
+                    request_id: Some(request_id.clone()),
+                    authority_epoch: Some(self.prompt_control_authority.authority_epoch.clone()),
+                    operation: Some(operation),
+                    preview: Some(preview),
+                    status: Some(PromptControlResultStatus::Blocked),
+                    value_visibility: Some(PromptControlValueVisibility::Hidden),
+                    agent_id: Some(agent_id.clone()),
+                    player_id: Some(player_id.clone()),
+                    expected_version: Some(expected_version),
+                    current_version: Some(current.version),
+                    ..PromptControlError::default_legacy()
+                })?;
+            self.llm_sidecar.upsert_prompt_profile(candidate.clone());
+            self.bind_agent_player_access(
+                agent_id.as_str(),
+                player_id.as_str(),
+                public_key.as_deref(),
+            )?;
+            self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
+                profile: candidate.clone(),
+                operation: PromptUpdateOperation::Apply,
+                applied_fields: applied_fields.clone(),
+                digest: digest.clone(),
+                rolled_back_to_version: None,
+            });
+            if request.short_term_goal_override.is_some() {
+                self.record_primary_intent_from_short_term_goal(
+                    agent_id.as_str(),
+                    candidate.short_term_goal_override.as_deref(),
+                );
+            }
+            self.llm_sidecar.request_decision();
+        }
+        self.prompt_control_authority
+            .result_ledger
+            .insert(
+                self.prompt_control_authority.authority_epoch.as_str(),
+                player_id.as_str(),
+                request_id.as_str(),
+                operation_digest,
+                ack.clone(),
+            )
+            .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+        ack.idempotent_replay = false;
+        Ok(ack)
+    }
+
+    fn handle_enhanced_prompt_rollback(
+        &mut self,
+        request: PromptControlRollbackRequest,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let operation = PromptControlOperation::Rollback;
+        let request_id = match request.request_id.as_deref().map(str::trim) {
+            Some(value) if !value.is_empty() && value.len() <= 128 => value.to_string(),
+            Some(value) if value.len() > 128 => {
+                return Err(prompt_control_enhanced_error(
+                    "prompt_control_request_id_invalid",
+                    "prompt_control request_id exceeds 128 UTF-8 bytes",
+                    None,
+                    operation,
+                    false,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+            _ => {
+                return Err(prompt_control_enhanced_error(
+                    "prompt_control_request_id_required",
+                    "prompt_control request_id is required",
+                    None,
+                    operation,
+                    false,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+        };
+        if self.hosted_public_join_mode() {
+            self.verify_hosted_prompt_control_rollback_strong_auth(&request)
+                .map_err(|error| {
+                    prompt_control_enhanced_error(
+                        if error.code == "strong_auth_required" {
+                            "auth_required"
+                        } else {
+                            "auth_invalid"
+                        },
+                        "prompt_control authentication failed",
+                        Some(request_id.clone()),
+                        operation,
+                        false,
+                        None,
+                        None,
+                        PromptControlResultStatus::Blocked,
+                    )
+                })?;
+        }
+        let agent_id = request.agent_id.trim().to_string();
+        let player_id =
+            normalize_required_player_id(request.player_id.as_str(), agent_id.as_str())?;
+        if !self.llm_sidecar.is_llm_mode() {
+            return Err(prompt_control_enhanced_error(
+                "llm_mode_required",
+                "prompt_control rollback requires runtime live server running with --llm",
+                Some(request_id),
+                operation,
+                false,
+                Some(agent_id.clone()),
+                Some(player_id),
+                PromptControlResultStatus::Blocked,
+            ));
+        }
+        if !self.llm_sidecar.supports_prompt_control() {
+            return Err(prompt_control_enhanced_error(
+                "agent_provider_prompt_control_unsupported",
+                "prompt_control is not supported when runtime live uses ProviderBacked(Local HTTP)",
+                Some(request_id),
+                operation,
+                false,
+                Some(agent_id),
+                Some(player_id),
+                PromptControlResultStatus::Rejected,
+            ));
+        }
+        let Some(auth) = request.auth.as_ref() else {
+            return Err(prompt_control_enhanced_error(
+                "auth_required",
+                "prompt_control rollback requires auth proof",
+                Some(request_id),
+                operation,
+                false,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            ));
+        };
+        let verified = verify_prompt_control_rollback_auth_proof(&request, auth).map_err(|_| {
+            prompt_control_enhanced_error(
+                "auth_invalid",
+                "prompt_control authentication failed",
+                Some(request_id.clone()),
+                operation,
+                false,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            )
+        })?;
+        let expected_authority_epoch = request
+            .expected_authority_epoch
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                prompt_control_enhanced_error(
+                    "expected_authority_epoch_required",
+                    "prompt_control expected_authority_epoch is required",
+                    Some(request_id.clone()),
+                    operation,
+                    false,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                )
+            })?;
+        if expected_authority_epoch != self.prompt_control_authority.authority_epoch {
+            return Err(prompt_control_result_unknown_error(&request_id));
+        }
+        let current_session_epoch = self
+            .session_policy
+            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
+            .map_err(|_| {
+                prompt_control_control_lost_error(
+                    &request_id,
+                    operation,
+                    false,
+                    Some(agent_id.clone()),
+                )
+            })?;
+        if request.session_epoch != Some(current_session_epoch) {
+            return Err(prompt_control_control_lost_error(
+                &request_id,
+                operation,
+                false,
+                Some(agent_id.clone()),
+            ));
+        }
+        let current_binding_epoch = self
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str());
+        if request.binding_epoch != Some(current_binding_epoch) {
+            return Err(prompt_control_control_lost_error(
+                &request_id,
+                operation,
+                false,
+                Some(agent_id.clone()),
+            ));
+        }
+        let public_key = normalize_optional_public_key(request.public_key.as_deref());
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )
+        .map_err(|error| {
+            prompt_control_access_error(
+                error,
+                &request_id,
+                operation,
+                false,
+                agent_id.as_str(),
+                player_id.as_str(),
+            )
+        })?;
+        let expected_version = request.expected_version.ok_or_else(|| {
+            prompt_control_enhanced_error(
+                "expected_version_required",
+                "prompt_control expected_version is required",
+                Some(request_id.clone()),
+                operation,
+                false,
+                Some(agent_id.clone()),
+                Some(player_id.clone()),
+                PromptControlResultStatus::Rejected,
+            )
+        })?;
+        let updated_by = request.updated_by.as_deref().map(str::trim).unwrap_or("");
+        if updated_by.is_empty() || updated_by != player_id {
+            return Err(prompt_control_enhanced_error(
+                "updated_by_required",
+                "mutating prompt_control requests require updated_by matching player_id",
+                Some(request_id),
+                operation,
+                false,
+                Some(agent_id),
+                Some(player_id),
+                PromptControlResultStatus::Rejected,
+            ));
+        }
+        let identity = normalize_prompt_control_operation_identity(
+            "rollback",
+            false,
+            agent_id.as_str(),
+            player_id.as_str(),
+            request.session_epoch,
+            request.binding_epoch,
+            Some(expected_authority_epoch),
+            request.expected_version,
+            &None,
+            &None,
+            &None,
+            Some(request.to_version),
+            request.updated_by.as_deref(),
+        )
+        .map_err(|message| {
+            prompt_control_enhanced_error(
+                "prompt_control_identity_invalid",
+                message.as_str(),
+                Some(request_id.clone()),
+                operation,
+                false,
+                Some(agent_id.clone()),
+                Some(player_id.clone()),
+                PromptControlResultStatus::Rejected,
+            )
+        })?;
+        let operation_digest = prompt_control_operation_digest(&identity);
+        match self.prompt_control_authority.result_ledger.lookup(
+            self.prompt_control_authority.authority_epoch.as_str(),
+            player_id.as_str(),
+            request_id.as_str(),
+            operation_digest.as_str(),
+        ) {
+            PromptControlLedgerLookup::Replay(mut ack) => {
+                ack.idempotent_replay = true;
+                return Ok(ack);
+            }
+            PromptControlLedgerLookup::Conflict => {
+                return Err(prompt_control_enhanced_error(
+                    "request_id_conflict",
+                    "request_id was already used for a different prompt operation",
+                    Some(request_id),
+                    operation,
+                    false,
+                    None,
+                    None,
+                    PromptControlResultStatus::Rejected,
+                ));
+            }
+            PromptControlLedgerLookup::Missing => {}
+        }
+        if self.prompt_control_authority.result_ledger.is_full() {
+            return Err(prompt_control_enhanced_error(
+                "result_cache_full",
+                "prompt control result cache is full",
+                Some(request_id),
+                operation,
+                false,
+                None,
+                None,
+                PromptControlResultStatus::Blocked,
+            ));
+        }
+        let current = self
+            .current_prompt_profile(agent_id.as_str())
+            .map_err(|_| {
+                prompt_control_enhanced_error(
+                    "agent_not_found",
+                    "prompt control target Agent was not found",
+                    Some(request_id.clone()),
+                    operation,
+                    false,
+                    Some(agent_id.clone()),
+                    Some(player_id.clone()),
+                    PromptControlResultStatus::Rejected,
+                )
+            })?;
+        if current.version != expected_version {
+            return Err(prompt_control_enhanced_error(
+                "version_conflict",
+                "prompt control expected_version does not match current version",
+                Some(request_id),
+                operation,
+                false,
+                Some(agent_id),
+                Some(player_id),
+                PromptControlResultStatus::Stale,
+            ));
+        }
+        let target = if request.to_version == 0 {
+            AgentPromptProfile::for_agent(agent_id.clone())
+        } else {
+            self.lookup_prompt_profile_version(agent_id.as_str(), request.to_version)
+                .ok_or_else(|| {
+                    prompt_control_enhanced_error(
+                        "target_version_not_found",
+                        "prompt control rollback target version was not found",
+                        Some(request_id.clone()),
+                        operation,
+                        false,
+                        Some(agent_id.clone()),
+                        Some(player_id.clone()),
+                        PromptControlResultStatus::Rejected,
+                    )
+                })?
+        };
+        let mut candidate = current.clone();
+        candidate.system_prompt_override = target.system_prompt_override;
+        candidate.short_term_goal_override = target.short_term_goal_override;
+        candidate.long_term_goal_override = target.long_term_goal_override;
+        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
+        if applied_fields.is_empty() {
+            return Err(prompt_control_enhanced_error(
+                "rollback_noop",
+                "prompt control rollback would not change the current profile",
+                Some(request_id),
+                operation,
+                false,
+                Some(agent_id),
+                Some(player_id),
+                PromptControlResultStatus::Rejected,
+            ));
+        }
+        candidate.version = current.version.saturating_add(1);
+        candidate.updated_at_tick = self.world.state().time;
+        candidate.updated_by = player_id.clone();
+        let digest = prompt_profile_digest_runtime(&candidate);
+        let mut ack = PromptControlAck {
+            request_id: Some(request_id.clone()),
+            authority_epoch: Some(self.prompt_control_authority.authority_epoch.clone()),
+            agent_id: agent_id.clone(),
+            operation,
+            preview: false,
+            status: Some(PromptControlResultStatus::Applied),
+            player_id: Some(player_id.clone()),
+            session_epoch: request.session_epoch,
+            binding_epoch: request.binding_epoch,
+            expected_version: Some(expected_version),
+            version: candidate.version,
+            updated_at_tick: candidate.updated_at_tick,
+            applied_fields: applied_fields.clone(),
+            digest: digest.clone(),
+            value_visibility: Some(PromptControlValueVisibility::LatestAllowed),
+            applied_scope: Some(PromptControlApplicationScope::RuntimeInstance),
+            persistence_scope: Some(PromptControlApplicationScope::None),
+            sync_scope: Some(PromptControlApplicationScope::None),
+            reason_code: Some("rolled_back".to_string()),
+            next_step: Some("continue_runtime".to_string()),
+            operation_digest: Some(operation_digest.clone()),
+            idempotent_replay: false,
+            mutation_count: Some(1),
+            rolled_back_to_version: Some(request.to_version),
+        };
+        self.prompt_control_authority
+            .result_ledger
+            .validate_receipt(&ack)
+            .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+        self.llm_sidecar
+            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+            .map_err(|_message| {
+                prompt_control_enhanced_error(
+                    "auth_invalid",
+                    "prompt control authentication failed",
+                    Some(request_id.clone()),
+                    operation,
+                    false,
+                    None,
+                    None,
+                    PromptControlResultStatus::Blocked,
+                )
+            })?;
+        if self.prompt_control_authority.authority_epoch != expected_authority_epoch
+            || self
+                .prompt_control_authority
+                .binding_epoch(agent_id.as_str())
+                != current_binding_epoch
+        {
+            return Err(prompt_control_result_unknown_error(&request_id));
+        }
+        self.llm_sidecar
+            .apply_prompt_profile_to_driver(&candidate)
+            .map_err(|message| PromptControlError {
+                code: "prompt_override_enqueue_failed".to_string(),
+                message,
+                request_id: Some(request_id.clone()),
+                authority_epoch: Some(self.prompt_control_authority.authority_epoch.clone()),
+                operation: Some(operation),
+                preview: Some(false),
+                status: Some(PromptControlResultStatus::Blocked),
+                value_visibility: Some(PromptControlValueVisibility::Hidden),
+                agent_id: Some(agent_id.clone()),
+                player_id: Some(player_id.clone()),
+                expected_version: Some(expected_version),
+                current_version: Some(current.version),
+                ..PromptControlError::default_legacy()
+            })?;
+        self.llm_sidecar.upsert_prompt_profile(candidate.clone());
+        self.bind_agent_player_access(
+            agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
+            profile: candidate.clone(),
+            operation: PromptUpdateOperation::Rollback,
+            applied_fields: applied_fields.clone(),
+            digest: digest.clone(),
+            rolled_back_to_version: Some(request.to_version),
+        });
+        self.record_primary_intent_from_short_term_goal(
+            agent_id.as_str(),
+            candidate.short_term_goal_override.as_deref(),
+        );
+        self.llm_sidecar.request_decision();
+        self.prompt_control_authority
+            .result_ledger
+            .insert(
+                self.prompt_control_authority.authority_epoch.as_str(),
+                player_id.as_str(),
+                request_id.as_str(),
+                operation_digest,
+                ack.clone(),
+            )
+            .map_err(|error| prompt_control_ledger_error(error, &request_id))?;
+        ack.idempotent_replay = false;
+        Ok(ack)
+    }
+}

--- a/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_legacy.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_control_legacy.rs
@@ -1,0 +1,542 @@
+use super::*;
+
+impl ViewerRuntimeLiveServer {
+    pub(in crate::viewer::runtime_live) fn handle_prompt_control(
+        &mut self,
+        command: PromptControlCommand,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        if self.hosted_public_join_mode() {
+            match &command {
+                PromptControlCommand::Preview { request } => {
+                    self.verify_hosted_prompt_control_apply_strong_auth(
+                        PromptControlAuthIntent::Preview,
+                        request,
+                    )?;
+                }
+                PromptControlCommand::Apply { request } => {
+                    self.verify_hosted_prompt_control_apply_strong_auth(
+                        PromptControlAuthIntent::Apply,
+                        request,
+                    )?;
+                }
+                PromptControlCommand::Rollback { request } => {
+                    self.verify_hosted_prompt_control_rollback_strong_auth(request)?;
+                }
+            }
+        }
+        if !self.llm_sidecar.is_llm_mode() {
+            let (agent_id, message) = match command {
+                PromptControlCommand::Preview { request }
+                | PromptControlCommand::Apply { request } => (
+                    request.agent_id,
+                    "prompt_control requires runtime live server running with --llm".to_string(),
+                ),
+                PromptControlCommand::Rollback { request } => (
+                    request.agent_id,
+                    "prompt_control rollback requires runtime live server running with --llm"
+                        .to_string(),
+                ),
+            };
+            return Err(PromptControlError {
+                code: "llm_mode_required".to_string(),
+                message,
+                agent_id: Some(agent_id.clone()),
+                current_version: self.current_prompt_version(agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            });
+        }
+        if !self.llm_sidecar.supports_prompt_control() {
+            let (agent_id, current_version) = match &command {
+                PromptControlCommand::Preview { request }
+                | PromptControlCommand::Apply { request } => (
+                    request.agent_id.clone(),
+                    self.current_prompt_version(request.agent_id.as_str()),
+                ),
+                PromptControlCommand::Rollback { request } => (
+                    request.agent_id.clone(),
+                    self.current_prompt_version(request.agent_id.as_str()),
+                ),
+            };
+            return Err(PromptControlError {
+                code: "agent_provider_prompt_control_unsupported".to_string(),
+                message:
+                    "prompt_control is not yet supported when runtime live uses ProviderBacked(Local HTTP)"
+                        .to_string(),
+                agent_id: Some(agent_id),
+                current_version,
+                ..PromptControlError::default_legacy()
+            });
+        }
+
+        match command {
+            PromptControlCommand::Preview { request } => self.prompt_control_preview(request),
+            PromptControlCommand::Apply { request } => self.prompt_control_apply(request),
+            PromptControlCommand::Rollback { request } => self.prompt_control_rollback(request),
+        }
+    }
+
+    fn prompt_control_preview(
+        &mut self,
+        request: PromptControlApplyRequest,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let player_id =
+            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
+        let public_key = normalize_optional_public_key(request.public_key.as_deref());
+        self.verify_and_consume_prompt_control_apply_auth(
+            PromptControlAuthIntent::Preview,
+            &request,
+        )?;
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            request.agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        let current = self.current_prompt_profile(request.agent_id.as_str())?;
+        ensure_expected_prompt_version_runtime(
+            request.agent_id.as_str(),
+            current.version,
+            request.expected_version,
+        )?;
+
+        let mut candidate = current.clone();
+        apply_prompt_patch_runtime(&mut candidate, &request);
+        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
+        let preview_version = if applied_fields.is_empty() {
+            current.version
+        } else {
+            current.version.saturating_add(1)
+        };
+
+        Ok(PromptControlAck {
+            agent_id: request.agent_id,
+            operation: PromptControlOperation::Apply,
+            preview: true,
+            version: preview_version,
+            updated_at_tick: self.world.state().time,
+            applied_fields,
+            digest: prompt_profile_digest_runtime(&candidate),
+            rolled_back_to_version: None,
+            ..PromptControlAck::default_legacy()
+        })
+    }
+
+    fn prompt_control_apply(
+        &mut self,
+        request: PromptControlApplyRequest,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let player_id =
+            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
+        let public_key = normalize_optional_public_key(request.public_key.as_deref());
+        self.verify_and_consume_prompt_control_apply_auth(
+            PromptControlAuthIntent::Apply,
+            &request,
+        )?;
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            request.agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        let current = self.current_prompt_profile(request.agent_id.as_str())?;
+        ensure_expected_prompt_version_runtime(
+            request.agent_id.as_str(),
+            current.version,
+            request.expected_version,
+        )?;
+        ensure_updated_by_matches_player_runtime(
+            request.updated_by.as_deref(),
+            player_id.as_str(),
+            request.agent_id.as_str(),
+        )?;
+
+        let mut candidate = current.clone();
+        apply_prompt_patch_runtime(&mut candidate, &request);
+        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
+        let digest = prompt_profile_digest_runtime(&candidate);
+        if applied_fields.is_empty() {
+            if request.short_term_goal_override.is_some() {
+                self.record_primary_intent_from_short_term_goal(
+                    request.agent_id.as_str(),
+                    candidate.short_term_goal_override.as_deref(),
+                );
+            }
+            return Ok(PromptControlAck {
+                agent_id: request.agent_id,
+                operation: PromptControlOperation::Apply,
+                preview: false,
+                version: current.version,
+                updated_at_tick: current.updated_at_tick,
+                applied_fields,
+                digest,
+                rolled_back_to_version: None,
+                ..PromptControlAck::default_legacy()
+            });
+        }
+
+        candidate.version = current.version.saturating_add(1);
+        candidate.updated_at_tick = self.world.state().time;
+        candidate.updated_by = player_id.clone();
+        self.llm_sidecar
+            .apply_prompt_profile_to_driver(&candidate)
+            .map_err(|message| PromptControlError {
+                code: "prompt_override_enqueue_failed".to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: Some(current.version),
+                ..PromptControlError::default_legacy()
+            })?;
+        self.llm_sidecar.upsert_prompt_profile(candidate.clone());
+        self.bind_agent_player_access(
+            request.agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        let digest = prompt_profile_digest_runtime(&candidate);
+        self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
+            profile: candidate.clone(),
+            operation: PromptUpdateOperation::Apply,
+            applied_fields: applied_fields.clone(),
+            digest: digest.clone(),
+            rolled_back_to_version: None,
+        });
+        if request.short_term_goal_override.is_some() {
+            self.record_primary_intent_from_short_term_goal(
+                request.agent_id.as_str(),
+                candidate.short_term_goal_override.as_deref(),
+            );
+        }
+        self.llm_sidecar.request_decision();
+        self.set_latest_player_gameplay_feedback(PlayerGameplayRecentFeedback {
+            action: "prompt_control.apply".to_string(),
+            stage: "completed_advanced".to_string(),
+            effect: format!(
+                "updated prompt guidance for {} to version {}",
+                request.agent_id, candidate.version
+            ),
+            intent_summary: Some(format!("apply updated prompt guidance for {}", request.agent_id)),
+            target_agent_id: Some(request.agent_id.clone()),
+            reason: None,
+            hint: Some(
+                "continue the world and watch whether the new prompt guidance changes the agent's next decision"
+                    .to_string(),
+            ),
+            delta_logical_time: 0,
+            delta_event_seq: 0,
+        });
+
+        Ok(PromptControlAck {
+            agent_id: request.agent_id,
+            operation: PromptControlOperation::Apply,
+            preview: false,
+            version: candidate.version,
+            updated_at_tick: candidate.updated_at_tick,
+            applied_fields,
+            digest,
+            rolled_back_to_version: None,
+            ..PromptControlAck::default_legacy()
+        })
+    }
+
+    fn prompt_control_rollback(
+        &mut self,
+        request: PromptControlRollbackRequest,
+    ) -> Result<PromptControlAck, PromptControlError> {
+        let player_id =
+            normalize_required_player_id(request.player_id.as_str(), request.agent_id.as_str())?;
+        let public_key = normalize_optional_public_key(request.public_key.as_deref());
+        self.verify_and_consume_prompt_control_rollback_auth(&request)?;
+        ensure_agent_player_access_runtime(
+            &self.world,
+            &self.llm_sidecar,
+            request.agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        let current = self.current_prompt_profile(request.agent_id.as_str())?;
+        ensure_expected_prompt_version_runtime(
+            request.agent_id.as_str(),
+            current.version,
+            request.expected_version,
+        )?;
+        ensure_updated_by_matches_player_runtime(
+            request.updated_by.as_deref(),
+            player_id.as_str(),
+            request.agent_id.as_str(),
+        )?;
+
+        let target = if request.to_version == 0 {
+            AgentPromptProfile::for_agent(request.agent_id.clone())
+        } else {
+            self.lookup_prompt_profile_version(request.agent_id.as_str(), request.to_version)
+                .ok_or_else(|| PromptControlError {
+                    code: "target_version_not_found".to_string(),
+                    message: format!(
+                        "prompt profile version {} not found for {}",
+                        request.to_version, request.agent_id
+                    ),
+                    agent_id: Some(request.agent_id.clone()),
+                    current_version: Some(current.version),
+                    ..PromptControlError::default_legacy()
+                })?
+        };
+        let target_short_term_goal = target.short_term_goal_override.clone();
+        let mut candidate = current.clone();
+        candidate.system_prompt_override = target.system_prompt_override;
+        candidate.short_term_goal_override = target.short_term_goal_override;
+        candidate.long_term_goal_override = target.long_term_goal_override;
+        let applied_fields = changed_prompt_fields_runtime(&current, &candidate);
+        if applied_fields.is_empty() {
+            return Err(PromptControlError {
+                code: "rollback_noop".to_string(),
+                message: format!(
+                    "rollback target version {} yields no prompt changes for {}",
+                    request.to_version, request.agent_id
+                ),
+                agent_id: Some(request.agent_id),
+                current_version: Some(current.version),
+                ..PromptControlError::default_legacy()
+            });
+        }
+
+        candidate.version = current.version.saturating_add(1);
+        candidate.updated_at_tick = self.world.state().time;
+        candidate.updated_by = player_id.clone();
+        self.llm_sidecar
+            .apply_prompt_profile_to_driver(&candidate)
+            .map_err(|message| PromptControlError {
+                code: "prompt_override_enqueue_failed".to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: Some(current.version),
+                ..PromptControlError::default_legacy()
+            })?;
+        self.llm_sidecar.upsert_prompt_profile(candidate.clone());
+        self.bind_agent_player_access(
+            request.agent_id.as_str(),
+            player_id.as_str(),
+            public_key.as_deref(),
+        )?;
+        let digest = prompt_profile_digest_runtime(&candidate);
+        self.enqueue_virtual_event(WorldEventKind::AgentPromptUpdated {
+            profile: candidate.clone(),
+            operation: PromptUpdateOperation::Rollback,
+            applied_fields: applied_fields.clone(),
+            digest: digest.clone(),
+            rolled_back_to_version: Some(request.to_version),
+        });
+        self.record_primary_intent_from_short_term_goal(
+            request.agent_id.as_str(),
+            target_short_term_goal.as_deref(),
+        );
+        self.llm_sidecar.request_decision();
+        self.set_latest_player_gameplay_feedback(PlayerGameplayRecentFeedback {
+            action: "prompt_control.rollback".to_string(),
+            stage: "completed_advanced".to_string(),
+            effect: format!(
+                "rolled back prompt guidance for {} to base version {} via version {}",
+                request.agent_id, request.to_version, candidate.version
+            ),
+            intent_summary: Some(format!(
+                "roll back prompt guidance for {}",
+                request.agent_id
+            )),
+            target_agent_id: Some(request.agent_id.clone()),
+            reason: None,
+            hint: Some(
+                "continue the world and confirm the agent now follows the restored guidance"
+                    .to_string(),
+            ),
+            delta_logical_time: 0,
+            delta_event_seq: 0,
+        });
+
+        Ok(PromptControlAck {
+            agent_id: request.agent_id,
+            operation: PromptControlOperation::Rollback,
+            preview: false,
+            version: candidate.version,
+            updated_at_tick: candidate.updated_at_tick,
+            applied_fields,
+            digest,
+            rolled_back_to_version: Some(request.to_version),
+            ..PromptControlAck::default_legacy()
+        })
+    }
+
+    fn verify_and_consume_prompt_control_apply_auth(
+        &mut self,
+        intent: PromptControlAuthIntent,
+        request: &PromptControlApplyRequest,
+    ) -> Result<(), PromptControlError> {
+        let Some(auth) = request.auth.as_ref() else {
+            return Err(PromptControlError {
+                code: "auth_proof_required".to_string(),
+                message: "prompt_control requires auth proof".to_string(),
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            });
+        };
+        let verified =
+            verify_prompt_control_apply_auth_proof(intent, request, auth).map_err(|message| {
+                PromptControlError {
+                    code: map_auth_verify_error_code(message.as_str()).to_string(),
+                    message,
+                    agent_id: Some(request.agent_id.clone()),
+                    current_version: self.current_prompt_version(request.agent_id.as_str()),
+                    ..PromptControlError::default_legacy()
+                }
+            })?;
+        self.session_policy
+            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
+            .map_err(|message| PromptControlError {
+                code: map_session_policy_error_code(message.as_str()).to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            })?;
+        self.llm_sidecar
+            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+            .map_err(|message| PromptControlError {
+                code: "auth_nonce_replay".to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            })?;
+        Ok(())
+    }
+
+    pub(super) fn verify_hosted_prompt_control_apply_strong_auth(
+        &self,
+        intent: PromptControlAuthIntent,
+        request: &PromptControlApplyRequest,
+    ) -> Result<(), PromptControlError> {
+        let Some(grant) = request.strong_auth_grant.as_ref() else {
+            return Err(self.hosted_prompt_control_strong_auth_error(
+                "strong_auth_required",
+                request.agent_id.as_str(),
+                "prompt_control requires hosted strong auth grant on hosted_public_join",
+            ));
+        };
+        let signer_public_key =
+            hosted_strong_auth_grant_public_key_from_env().map_err(|message| {
+                self.hosted_prompt_control_strong_auth_error(
+                    "strong_auth_required",
+                    request.agent_id.as_str(),
+                    message.as_str(),
+                )
+            })?;
+        verify_hosted_prompt_control_apply_strong_auth_grant(
+            intent,
+            request,
+            grant,
+            signer_public_key.as_str(),
+            hosted_strong_auth_now_unix_ms(),
+        )
+        .map_err(|message| {
+            self.hosted_prompt_control_strong_auth_error(
+                "strong_auth_grant_invalid",
+                request.agent_id.as_str(),
+                message.as_str(),
+            )
+        })
+    }
+
+    fn verify_and_consume_prompt_control_rollback_auth(
+        &mut self,
+        request: &PromptControlRollbackRequest,
+    ) -> Result<(), PromptControlError> {
+        let Some(auth) = request.auth.as_ref() else {
+            return Err(PromptControlError {
+                code: "auth_proof_required".to_string(),
+                message: "prompt_control rollback requires auth proof".to_string(),
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            });
+        };
+        let verified =
+            verify_prompt_control_rollback_auth_proof(request, auth).map_err(|message| {
+                PromptControlError {
+                    code: map_auth_verify_error_code(message.as_str()).to_string(),
+                    message,
+                    agent_id: Some(request.agent_id.clone()),
+                    current_version: self.current_prompt_version(request.agent_id.as_str()),
+                    ..PromptControlError::default_legacy()
+                }
+            })?;
+        self.session_policy
+            .validate_known_session_key(verified.player_id.as_str(), verified.public_key.as_str())
+            .map_err(|message| PromptControlError {
+                code: map_session_policy_error_code(message.as_str()).to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            })?;
+        self.llm_sidecar
+            .consume_player_auth_nonce(verified.player_id.as_str(), verified.nonce)
+            .map_err(|message| PromptControlError {
+                code: "auth_nonce_replay".to_string(),
+                message,
+                agent_id: Some(request.agent_id.clone()),
+                current_version: self.current_prompt_version(request.agent_id.as_str()),
+                ..PromptControlError::default_legacy()
+            })?;
+        Ok(())
+    }
+
+    pub(super) fn verify_hosted_prompt_control_rollback_strong_auth(
+        &self,
+        request: &PromptControlRollbackRequest,
+    ) -> Result<(), PromptControlError> {
+        let Some(grant) = request.strong_auth_grant.as_ref() else {
+            return Err(self.hosted_prompt_control_strong_auth_error(
+                "strong_auth_required",
+                request.agent_id.as_str(),
+                "prompt_control rollback requires hosted strong auth grant on hosted_public_join",
+            ));
+        };
+        let signer_public_key =
+            hosted_strong_auth_grant_public_key_from_env().map_err(|message| {
+                self.hosted_prompt_control_strong_auth_error(
+                    "strong_auth_required",
+                    request.agent_id.as_str(),
+                    message.as_str(),
+                )
+            })?;
+        verify_hosted_prompt_control_rollback_strong_auth_grant(
+            request,
+            grant,
+            signer_public_key.as_str(),
+            hosted_strong_auth_now_unix_ms(),
+        )
+        .map_err(|message| {
+            self.hosted_prompt_control_strong_auth_error(
+                "strong_auth_grant_invalid",
+                request.agent_id.as_str(),
+                message.as_str(),
+            )
+        })
+    }
+
+    fn hosted_prompt_control_strong_auth_error(
+        &self,
+        code: &str,
+        agent_id: &str,
+        message: &str,
+    ) -> PromptControlError {
+        PromptControlError {
+            code: code.to_string(),
+            message: message.to_string(),
+            agent_id: Some(agent_id.to_string()),
+            current_version: self.current_prompt_version(agent_id),
+            ..PromptControlError::default_legacy()
+        }
+    }
+}

--- a/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_profile.rs
+++ b/crates/oasis7/src/viewer/runtime_live/control_plane/prompt_profile.rs
@@ -33,6 +33,7 @@ impl ViewerRuntimeLiveServer {
                 message: format!("agent not found: {agent_id}"),
                 agent_id: Some(agent_id.to_string()),
                 current_version: None,
+                ..PromptControlError::default_legacy()
             });
         }
         Ok(self

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -401,6 +401,9 @@ impl RuntimeLlmSidecar {
     pub(in crate::viewer::runtime_live) fn supports_prompt_control(&self) -> bool {
         !env_requests_provider_backend()
     }
+    pub(in crate::viewer::runtime_live) fn supports_prompt_control_result(&self) -> bool {
+        self.is_llm_mode() && self.supports_prompt_control()
+    }
     pub(in crate::viewer::runtime_live) fn supports_agent_chat(&self) -> bool {
         true
     }

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar.rs
@@ -295,6 +295,17 @@ pub(in crate::viewer::runtime_live) struct RuntimePlayerBindingPlan {
     agent_public_key_bindings: BTreeMap<String, String>,
     events: Vec<WorldEventKind>,
 }
+
+impl RuntimePlayerBindingPlan {
+    pub(in crate::viewer::runtime_live) fn has_binding_transition(&self) -> bool {
+        self.events.iter().any(|event| {
+            matches!(
+                event,
+                WorldEventKind::AgentPlayerBound { .. } | WorldEventKind::AgentPlayerUnbound { .. }
+            )
+        })
+    }
+}
 impl RuntimeLlmSidecar {
     pub(in crate::viewer::runtime_live) fn pending_actions_empty(&self) -> bool {
         self.pending_actions.is_empty()

--- a/crates/oasis7/src/viewer/runtime_live/llm_sidecar_runner.rs
+++ b/crates/oasis7/src/viewer/runtime_live/llm_sidecar_runner.rs
@@ -4,24 +4,33 @@ impl RuntimeLlmSidecar {
     pub(in crate::viewer::runtime_live) fn apply_prompt_profile_to_driver(
         &mut self,
         profile: &AgentPromptProfile,
-    ) {
+    ) -> Result<(), String> {
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(RuntimeDecisionRunner::Builtin(runner)) = self.runner.as_mut() {
-            let _ = runner.set_prompt_overrides(
-                profile.agent_id.as_str(),
-                profile.system_prompt_override.clone(),
-                profile.short_term_goal_override.clone(),
-                profile.long_term_goal_override.clone(),
-            );
-            return;
+            runner
+                .set_prompt_overrides(
+                    profile.agent_id.as_str(),
+                    profile.system_prompt_override.clone(),
+                    profile.short_term_goal_override.clone(),
+                    profile.long_term_goal_override.clone(),
+                )
+                .map_err(|error| format!("prompt override enqueue failed: {error}"))?;
+            return Ok(());
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(RuntimeDecisionRunner::ProviderBacked(_)) = self.runner.as_mut() {
+            return Err("prompt control is unsupported for ProviderBacked runtime".to_string());
         }
         #[cfg(target_arch = "wasm32")]
         let Some(RuntimeDecisionRunner::Builtin(runner)) = self.runner.as_mut() else {
-            return;
+            return Err("builtin llm runner is not initialized".to_string());
         };
         #[cfg(target_arch = "wasm32")]
         let Some(agent) = runner.get_mut(profile.agent_id.as_str()) else {
-            return;
+            return Err(format!(
+                "agent is not registered in llm runner: {}",
+                profile.agent_id
+            ));
         };
         #[cfg(target_arch = "wasm32")]
         agent.behavior.apply_prompt_overrides(
@@ -29,6 +38,7 @@ impl RuntimeLlmSidecar {
             profile.short_term_goal_override.clone(),
             profile.long_term_goal_override.clone(),
         );
+        Ok(())
     }
 
     pub(super) fn ensure_runner_initialized(&mut self) -> Result<(), String> {

--- a/crates/oasis7/src/viewer/runtime_live/prompt_control_result.rs
+++ b/crates/oasis7/src/viewer/runtime_live/prompt_control_result.rs
@@ -1,17 +1,23 @@
 use std::collections::BTreeMap;
 
-use crate::viewer::protocol::PromptControlAck;
+use crate::viewer::protocol::{PromptControlAck, PromptControlError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PromptControlLedgerReceipt {
+    Ack(PromptControlAck),
+    Error(PromptControlError),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct PromptControlResultLedgerEntry {
     pub(super) digest: String,
-    pub(super) ack: PromptControlAck,
+    pub(super) receipt: PromptControlLedgerReceipt,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum PromptControlLedgerLookup {
     Missing,
-    Replay(PromptControlAck),
+    Replay(PromptControlLedgerReceipt),
     Conflict,
 }
 
@@ -52,7 +58,7 @@ impl PromptControlResultLedger {
         match self.entries.get(&key) {
             None => PromptControlLedgerLookup::Missing,
             Some(entry) if entry.digest == digest => {
-                PromptControlLedgerLookup::Replay(entry.ack.clone())
+                PromptControlLedgerLookup::Replay(entry.receipt.clone())
             }
             Some(_) => PromptControlLedgerLookup::Conflict,
         }
@@ -66,7 +72,21 @@ impl PromptControlResultLedger {
         &self,
         ack: &PromptControlAck,
     ) -> Result<(), PromptControlLedgerInsertError> {
-        let receipt_size = serde_json::to_vec(ack)
+        self.validate_serialized_receipt(ack)
+    }
+
+    pub(super) fn validate_error(
+        &self,
+        error: &PromptControlError,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        self.validate_serialized_receipt(error)
+    }
+
+    fn validate_serialized_receipt<T: serde::Serialize>(
+        &self,
+        receipt: &T,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        let receipt_size = serde_json::to_vec(receipt)
             .map_err(|error| PromptControlLedgerInsertError::Serialize(error.to_string()))?
             .len();
         if receipt_size > self.receipt_max_bytes {
@@ -86,7 +106,44 @@ impl PromptControlResultLedger {
         digest: String,
         ack: PromptControlAck,
     ) -> Result<(), PromptControlLedgerInsertError> {
-        self.validate_receipt(&ack)?;
+        self.insert_receipt(
+            authority_epoch,
+            player_id,
+            request_id,
+            digest,
+            PromptControlLedgerReceipt::Ack(ack),
+        )
+    }
+
+    pub(super) fn insert_error(
+        &mut self,
+        authority_epoch: &str,
+        player_id: &str,
+        request_id: &str,
+        digest: String,
+        error: PromptControlError,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        self.insert_receipt(
+            authority_epoch,
+            player_id,
+            request_id,
+            digest,
+            PromptControlLedgerReceipt::Error(error),
+        )
+    }
+
+    fn insert_receipt(
+        &mut self,
+        authority_epoch: &str,
+        player_id: &str,
+        request_id: &str,
+        digest: String,
+        receipt: PromptControlLedgerReceipt,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        match &receipt {
+            PromptControlLedgerReceipt::Ack(ack) => self.validate_receipt(ack)?,
+            PromptControlLedgerReceipt::Error(error) => self.validate_error(error)?,
+        }
         if self.is_full() {
             return Err(PromptControlLedgerInsertError::Full);
         }
@@ -96,7 +153,7 @@ impl PromptControlResultLedger {
                 player_id.to_string(),
                 request_id.to_string(),
             ),
-            PromptControlResultLedgerEntry { digest, ack },
+            PromptControlResultLedgerEntry { digest, receipt },
         );
         Ok(())
     }

--- a/crates/oasis7/src/viewer/runtime_live/prompt_control_result.rs
+++ b/crates/oasis7/src/viewer/runtime_live/prompt_control_result.rs
@@ -1,0 +1,213 @@
+use std::collections::BTreeMap;
+
+use crate::viewer::protocol::PromptControlAck;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PromptControlResultLedgerEntry {
+    pub(super) digest: String,
+    pub(super) ack: PromptControlAck,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PromptControlLedgerLookup {
+    Missing,
+    Replay(PromptControlAck),
+    Conflict,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PromptControlResultLedger {
+    capacity: usize,
+    receipt_max_bytes: usize,
+    entries: BTreeMap<(String, String, String), PromptControlResultLedgerEntry>,
+}
+
+impl PromptControlResultLedger {
+    pub(super) fn new(capacity: usize, receipt_max_bytes: usize) -> Result<Self, String> {
+        if capacity == 0 {
+            return Err("prompt result cache capacity must be greater than zero".to_string());
+        }
+        if receipt_max_bytes == 0 {
+            return Err("prompt result receipt max bytes must be greater than zero".to_string());
+        }
+        Ok(Self {
+            capacity,
+            receipt_max_bytes,
+            entries: BTreeMap::new(),
+        })
+    }
+
+    pub(super) fn lookup(
+        &self,
+        authority_epoch: &str,
+        player_id: &str,
+        request_id: &str,
+        digest: &str,
+    ) -> PromptControlLedgerLookup {
+        let key = (
+            authority_epoch.to_string(),
+            player_id.to_string(),
+            request_id.to_string(),
+        );
+        match self.entries.get(&key) {
+            None => PromptControlLedgerLookup::Missing,
+            Some(entry) if entry.digest == digest => {
+                PromptControlLedgerLookup::Replay(entry.ack.clone())
+            }
+            Some(_) => PromptControlLedgerLookup::Conflict,
+        }
+    }
+
+    pub(super) fn is_full(&self) -> bool {
+        self.entries.len() >= self.capacity
+    }
+
+    pub(super) fn validate_receipt(
+        &self,
+        ack: &PromptControlAck,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        let receipt_size = serde_json::to_vec(ack)
+            .map_err(|error| PromptControlLedgerInsertError::Serialize(error.to_string()))?
+            .len();
+        if receipt_size > self.receipt_max_bytes {
+            return Err(PromptControlLedgerInsertError::ReceiptTooLarge {
+                actual: receipt_size,
+                limit: self.receipt_max_bytes,
+            });
+        }
+        Ok(())
+    }
+
+    pub(super) fn insert(
+        &mut self,
+        authority_epoch: &str,
+        player_id: &str,
+        request_id: &str,
+        digest: String,
+        ack: PromptControlAck,
+    ) -> Result<(), PromptControlLedgerInsertError> {
+        self.validate_receipt(&ack)?;
+        if self.is_full() {
+            return Err(PromptControlLedgerInsertError::Full);
+        }
+        self.entries.insert(
+            (
+                authority_epoch.to_string(),
+                player_id.to_string(),
+                request_id.to_string(),
+            ),
+            PromptControlResultLedgerEntry { digest, ack },
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PromptControlLedgerInsertError {
+    Full,
+    ReceiptTooLarge { actual: usize, limit: usize },
+    Serialize(String),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PromptControlRuntimeAuthority {
+    pub(super) authority_epoch: String,
+    pub(super) binding_epoch_by_agent: BTreeMap<String, u64>,
+    pub(super) result_ledger: PromptControlResultLedger,
+}
+
+impl PromptControlRuntimeAuthority {
+    pub(super) fn new(cache_capacity: usize, receipt_max_bytes: usize) -> Result<Self, String> {
+        let mut bytes = [0_u8; 16];
+        getrandom::fill(&mut bytes)
+            .map_err(|error| format!("generate prompt authority epoch failed: {error}"))?;
+        Ok(Self {
+            authority_epoch: hex::encode(bytes),
+            binding_epoch_by_agent: BTreeMap::new(),
+            result_ledger: PromptControlResultLedger::new(cache_capacity, receipt_max_bytes)?,
+        })
+    }
+
+    pub(super) fn binding_epoch(&self, agent_id: &str) -> u64 {
+        self.binding_epoch_by_agent
+            .get(agent_id)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub(super) fn advance_binding_epoch(&mut self, agent_id: &str) -> u64 {
+        let next = self.binding_epoch(agent_id).saturating_add(1);
+        self.binding_epoch_by_agent
+            .insert(agent_id.to_string(), next);
+        next
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ack(request_id: &str) -> PromptControlAck {
+        let mut ack = PromptControlAck::default_legacy();
+        ack.request_id = Some(request_id.to_string());
+        ack.agent_id = "agent-0".to_string();
+        ack.digest = "profile-digest".to_string();
+        ack
+    }
+
+    #[test]
+    fn result_ledger_is_fixed_and_distinguishes_replay_from_conflict() {
+        let mut ledger = PromptControlResultLedger::new(1, 4096).expect("ledger");
+        ledger
+            .insert(
+                "authority-1",
+                "player-a",
+                "request-1",
+                "operation-1".to_string(),
+                ack("request-1"),
+            )
+            .expect("first receipt");
+        assert!(matches!(
+            ledger.lookup("authority-1", "player-a", "request-1", "operation-1"),
+            PromptControlLedgerLookup::Replay(_)
+        ));
+        assert!(matches!(
+            ledger.lookup("authority-1", "player-a", "request-1", "operation-2"),
+            PromptControlLedgerLookup::Conflict
+        ));
+        assert!(matches!(
+            ledger.insert(
+                "authority-1",
+                "player-a",
+                "request-2",
+                "operation-2".to_string(),
+                ack("request-2"),
+            ),
+            Err(PromptControlLedgerInsertError::Full)
+        ));
+    }
+
+    #[test]
+    fn result_ledger_rejects_oversize_receipts_before_insert() {
+        let mut ledger = PromptControlResultLedger::new(2, 1).expect("ledger");
+        let error = ledger
+            .insert(
+                "authority-1",
+                "player-a",
+                "request-1",
+                "operation-1".to_string(),
+                ack("request-1"),
+            )
+            .expect_err("oversize receipt");
+        assert!(matches!(
+            error,
+            PromptControlLedgerInsertError::ReceiptTooLarge { .. }
+        ));
+        assert_eq!(ledger.len(), 0);
+    }
+}

--- a/crates/oasis7/src/viewer/runtime_live/recovery.rs
+++ b/crates/oasis7/src/viewer/runtime_live/recovery.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 
 #[cfg(test)]
 pub(super) use super::recovery_persistence::RuntimeRecoveryFaultInjection;
+use crate::simulator::WorldEventKind;
 use crate::viewer::{
     claim_registration_grant_nonce_for_recovery, consume_registration_grant_nonce,
 };
@@ -903,13 +904,27 @@ impl ViewerRuntimeLiveServer {
         if let Some(plan) = binding_plan {
             let binding_transition =
                 request.force_rebind || rotates_session_key || plan.has_binding_transition();
-            for event in self.llm_sidecar.apply_agent_player_binding_plan(plan) {
+            let binding_events = self.llm_sidecar.apply_agent_player_binding_plan(plan);
+            let mut affected_agents = BTreeSet::new();
+            for event in binding_events {
+                match &event {
+                    WorldEventKind::AgentPlayerBound { agent_id, .. }
+                    | WorldEventKind::AgentPlayerUnbound { agent_id, .. } => {
+                        affected_agents.insert(agent_id.clone());
+                    }
+                    _ => {}
+                }
                 self.enqueue_virtual_event(event);
             }
             if binding_transition {
-                if let Some(agent_id) = bound_agent_id.as_deref() {
+                if affected_agents.is_empty() {
+                    if let Some(agent_id) = bound_agent_id.as_deref() {
+                        affected_agents.insert(agent_id.to_string());
+                    }
+                }
+                for agent_id in affected_agents {
                     self.prompt_control_authority
-                        .advance_binding_epoch(agent_id);
+                        .advance_binding_epoch(agent_id.as_str());
                 }
             }
         }

--- a/crates/oasis7/src/viewer/runtime_live/recovery.rs
+++ b/crates/oasis7/src/viewer/runtime_live/recovery.rs
@@ -9,6 +9,9 @@ use crate::viewer::{
     claim_registration_grant_nonce_for_recovery, consume_registration_grant_nonce,
 };
 
+#[path = "recovery/session_mutations.rs"]
+mod session_mutations;
+
 impl ViewerRuntimeLiveServer {
     pub(super) fn handle_authoritative_recovery_for_protocol(
         &mut self,
@@ -617,6 +620,7 @@ impl ViewerRuntimeLiveServer {
             session_pubkey: None,
             replaced_by_pubkey: None,
             session_epoch: None,
+            binding_epoch: None,
             message: Some("rollback applied to stable checkpoint".to_string()),
             revoke_reason: None,
             revoked_by: None,
@@ -897,11 +901,19 @@ impl ViewerRuntimeLiveServer {
         self.llm_sidecar
             .commit_player_auth_nonce(verified.player_id.as_str(), verified.nonce);
         if let Some(plan) = binding_plan {
+            let binding_transition =
+                request.force_rebind || rotates_session_key || plan.has_binding_transition();
             for event in self.llm_sidecar.apply_agent_player_binding_plan(plan) {
                 self.enqueue_virtual_event(event);
             }
+            if binding_transition {
+                if let Some(agent_id) = bound_agent_id.as_deref() {
+                    self.prompt_control_authority
+                        .advance_binding_epoch(agent_id);
+                }
+            }
         }
-        let ack = AuthoritativeRecoveryAck {
+        let mut ack = AuthoritativeRecoveryAck {
             status: AuthoritativeRecoveryStatus::SessionRegistered,
             reorg_epoch: self.reorg_epoch,
             snapshot_height: cursor.snapshot_height,
@@ -909,10 +921,11 @@ impl ViewerRuntimeLiveServer {
             log_cursor: cursor.log_cursor,
             stable_batch_id: cursor.stable_batch_id,
             player_id: Some(verified.player_id),
-            agent_id: bound_agent_id,
+            agent_id: bound_agent_id.clone(),
             session_pubkey: Some(verified.public_key),
             replaced_by_pubkey: None,
             session_epoch: Some(session_epoch),
+            binding_epoch: None,
             message: Some("session_registered".to_string()),
             revoke_reason: None,
             revoked_by: None,
@@ -923,273 +936,9 @@ impl ViewerRuntimeLiveServer {
             self.restore_session_mutation_snapshot(mutation_snapshot);
             return Err(error);
         }
-        Ok(ack)
-    }
-
-    fn handle_reconnect_sync(
-        &mut self,
-        request: AuthoritativeReconnectSyncRequest,
-    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
-        let player_id = request.player_id.trim().to_string();
-        if player_id.is_empty() {
-            return Err(recovery_error(
-                "player_id_required",
-                "reconnect_sync requires non-empty player_id",
-                None,
-                None,
-                None,
-            ));
-        }
-
-        let session_pubkey = request
-            .session_pubkey
+        ack.binding_epoch = bound_agent_id
             .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned);
-        let mut session_epoch = None;
-        if let Some(pubkey) = session_pubkey.as_deref() {
-            let epoch = match self
-                .session_policy
-                .validate_known_session_key(player_id.as_str(), pubkey)
-            {
-                Ok(epoch) => epoch,
-                Err(message) => {
-                    return Err(self.recovery_error_from_session_policy(
-                        message,
-                        player_id.clone(),
-                        Some(pubkey.to_string()),
-                    ));
-                }
-            };
-            session_epoch = Some(epoch);
-        }
-
-        let cursor = self.current_recovery_cursor().map_err(|err| {
-            recovery_error(
-                "cursor_compute_failed",
-                format!("{err:?}"),
-                None,
-                Some(player_id.clone()),
-                session_pubkey.clone(),
-            )
-        })?;
-        let stable_cursor = self
-            .stable_checkpoints
-            .back()
-            .map(|entry| entry.log_cursor)
-            .unwrap_or(0);
-
-        let mut reasons = Vec::new();
-        if request
-            .expected_reorg_epoch
-            .is_some_and(|epoch| epoch != self.reorg_epoch)
-        {
-            reasons.push(format!(
-                "expected_reorg_epoch mismatch (client={}, server={})",
-                request.expected_reorg_epoch.unwrap_or_default(),
-                self.reorg_epoch
-            ));
-        }
-        if let Some(last_known_cursor) = request.last_known_log_cursor {
-            if last_known_cursor > cursor.log_cursor {
-                reasons.push(format!(
-                    "client cursor {} is ahead of server cursor {}",
-                    last_known_cursor, cursor.log_cursor
-                ));
-            }
-            if last_known_cursor < stable_cursor {
-                reasons.push(format!(
-                    "client cursor {} is behind stable cursor {}",
-                    last_known_cursor, stable_cursor
-                ));
-            }
-        }
-        let message = if reasons.is_empty() {
-            Some("delta_replay_allowed".to_string())
-        } else {
-            Some(format!("snapshot_reload_required: {}", reasons.join("; ")))
-        };
-
-        Ok(AuthoritativeRecoveryAck {
-            status: AuthoritativeRecoveryStatus::CatchUpReady,
-            reorg_epoch: self.reorg_epoch,
-            snapshot_height: cursor.snapshot_height,
-            snapshot_hash: cursor.snapshot_hash,
-            log_cursor: cursor.log_cursor,
-            stable_batch_id: cursor.stable_batch_id,
-            player_id: Some(player_id),
-            agent_id: self
-                .llm_sidecar
-                .bound_agent_for_player(request.player_id.as_str())
-                .map(ToOwned::to_owned),
-            session_pubkey,
-            replaced_by_pubkey: None,
-            session_epoch,
-            message,
-            revoke_reason: None,
-            revoked_by: None,
-            rollback_receipt: None,
-            acknowledged_at_tick: self.world.state().time,
-        })
-    }
-
-    fn revoke_session_key(
-        &mut self,
-        request: AuthoritativeSessionRevokeRequest,
-    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
-        let player_id = request.player_id.trim().to_string();
-        if player_id.is_empty() {
-            return Err(recovery_error(
-                "player_id_required",
-                "revoke_session requires non-empty player_id",
-                None,
-                None,
-                None,
-            ));
-        }
-
-        let mutation_snapshot = self.session_mutation_snapshot();
-        let (revoked_pubkey, session_epoch) = self
-            .session_policy
-            .revoke_session(player_id.as_str(), request.session_pubkey.as_deref())
-            .map_err(|message| {
-                recovery_error(
-                    map_session_policy_error_code(message.as_str()),
-                    message,
-                    None,
-                    Some(player_id.clone()),
-                    request.session_pubkey.clone(),
-                )
-            })?;
-        let revoke_metadata = RuntimeSessionRevokeMetadata {
-            revoke_reason: normalize_optional_string(Some(request.revoke_reason.as_str())),
-            revoked_by: normalize_optional_string(request.revoked_by.as_deref()),
-        };
-        self.record_session_revoke_metadata(
-            player_id.as_str(),
-            revoked_pubkey.as_str(),
-            revoke_metadata.clone(),
-        );
-        self.clear_player_auth_runtime_state(player_id.as_str());
-        self.apply_session_revoke_binding(player_id.as_str(), revoked_pubkey.as_str());
-
-        let cursor = self.current_recovery_cursor().map_err(|err| {
-            recovery_error(
-                "cursor_compute_failed",
-                format!("{err:?}"),
-                None,
-                Some(player_id.clone()),
-                Some(revoked_pubkey.clone()),
-            )
-        })?;
-        let ack = AuthoritativeRecoveryAck {
-            status: AuthoritativeRecoveryStatus::SessionRevoked,
-            reorg_epoch: self.reorg_epoch,
-            snapshot_height: cursor.snapshot_height,
-            snapshot_hash: cursor.snapshot_hash,
-            log_cursor: cursor.log_cursor,
-            stable_batch_id: cursor.stable_batch_id,
-            player_id: Some(player_id),
-            agent_id: None,
-            session_pubkey: Some(revoked_pubkey),
-            replaced_by_pubkey: None,
-            session_epoch: Some(session_epoch),
-            message: Some(request.revoke_reason.trim().to_string()),
-            revoke_reason: revoke_metadata.revoke_reason,
-            revoked_by: revoke_metadata.revoked_by,
-            rollback_receipt: None,
-            acknowledged_at_tick: self.world.state().time,
-        };
-        if let Err(error) = self.persist_current_recovery_generation(&ack) {
-            self.restore_session_mutation_snapshot(mutation_snapshot);
-            return Err(error);
-        }
-        Ok(ack)
-    }
-
-    fn rotate_session_key(
-        &mut self,
-        request: AuthoritativeSessionRotateRequest,
-    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
-        let player_id = request.player_id.trim().to_string();
-        if player_id.is_empty() {
-            return Err(recovery_error(
-                "player_id_required",
-                "rotate_session requires non-empty player_id",
-                None,
-                None,
-                None,
-            ));
-        }
-
-        let mutation_snapshot = self.session_mutation_snapshot();
-        let session_epoch = self
-            .session_policy
-            .rotate_session(
-                player_id.as_str(),
-                request.old_session_pubkey.as_str(),
-                request.new_session_pubkey.as_str(),
-            )
-            .map_err(|message| {
-                recovery_error(
-                    map_session_policy_error_code(message.as_str()),
-                    message,
-                    None,
-                    Some(player_id.clone()),
-                    Some(request.old_session_pubkey.clone()),
-                )
-            })?;
-        let rotation_metadata = RuntimeSessionRevokeMetadata {
-            revoke_reason: normalize_optional_string(Some(request.rotate_reason.as_str())),
-            revoked_by: normalize_optional_string(request.rotated_by.as_deref()),
-        };
-        self.record_session_revoke_metadata(
-            player_id.as_str(),
-            request.old_session_pubkey.as_str(),
-            rotation_metadata.clone(),
-        );
-        self.clear_player_auth_runtime_state(player_id.as_str());
-        self.apply_session_rotate_binding(
-            player_id.as_str(),
-            request.old_session_pubkey.as_str(),
-            request.new_session_pubkey.as_str(),
-        );
-
-        let cursor = self.current_recovery_cursor().map_err(|err| {
-            recovery_error(
-                "cursor_compute_failed",
-                format!("{err:?}"),
-                None,
-                Some(player_id.clone()),
-                Some(request.old_session_pubkey.clone()),
-            )
-        })?;
-        let ack = AuthoritativeRecoveryAck {
-            status: AuthoritativeRecoveryStatus::SessionRotated,
-            reorg_epoch: self.reorg_epoch,
-            snapshot_height: cursor.snapshot_height,
-            snapshot_hash: cursor.snapshot_hash,
-            log_cursor: cursor.log_cursor,
-            stable_batch_id: cursor.stable_batch_id,
-            player_id: Some(player_id),
-            agent_id: self
-                .llm_sidecar
-                .bound_agent_for_player(request.player_id.as_str())
-                .map(ToOwned::to_owned),
-            session_pubkey: Some(request.old_session_pubkey),
-            replaced_by_pubkey: Some(request.new_session_pubkey),
-            session_epoch: Some(session_epoch),
-            message: Some(request.rotate_reason.trim().to_string()),
-            revoke_reason: rotation_metadata.revoke_reason,
-            revoked_by: rotation_metadata.revoked_by,
-            rollback_receipt: None,
-            acknowledged_at_tick: self.world.state().time,
-        };
-        if let Err(error) = self.persist_current_recovery_generation(&ack) {
-            self.restore_session_mutation_snapshot(mutation_snapshot);
-            return Err(error);
-        }
+            .map(|agent_id| self.prompt_control_authority.binding_epoch(agent_id));
         Ok(ack)
     }
 }

--- a/crates/oasis7/src/viewer/runtime_live/recovery/session_mutations.rs
+++ b/crates/oasis7/src/viewer/runtime_live/recovery/session_mutations.rs
@@ -1,0 +1,273 @@
+use super::*;
+
+impl ViewerRuntimeLiveServer {
+    pub(super) fn handle_reconnect_sync(
+        &mut self,
+        request: AuthoritativeReconnectSyncRequest,
+    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
+        let player_id = request.player_id.trim().to_string();
+        if player_id.is_empty() {
+            return Err(recovery_error(
+                "player_id_required",
+                "reconnect_sync requires non-empty player_id",
+                None,
+                None,
+                None,
+            ));
+        }
+
+        let session_pubkey = request
+            .session_pubkey
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let mut session_epoch = None;
+        if let Some(pubkey) = session_pubkey.as_deref() {
+            let epoch = match self
+                .session_policy
+                .validate_known_session_key(player_id.as_str(), pubkey)
+            {
+                Ok(epoch) => epoch,
+                Err(message) => {
+                    return Err(self.recovery_error_from_session_policy(
+                        message,
+                        player_id.clone(),
+                        Some(pubkey.to_string()),
+                    ));
+                }
+            };
+            session_epoch = Some(epoch);
+        }
+
+        let cursor = self.current_recovery_cursor().map_err(|err| {
+            recovery_error(
+                "cursor_compute_failed",
+                format!("{err:?}"),
+                None,
+                Some(player_id.clone()),
+                session_pubkey.clone(),
+            )
+        })?;
+        let stable_cursor = self
+            .stable_checkpoints
+            .back()
+            .map(|entry| entry.log_cursor)
+            .unwrap_or(0);
+
+        let mut reasons = Vec::new();
+        if request
+            .expected_reorg_epoch
+            .is_some_and(|epoch| epoch != self.reorg_epoch)
+        {
+            reasons.push(format!(
+                "expected_reorg_epoch mismatch (client={}, server={})",
+                request.expected_reorg_epoch.unwrap_or_default(),
+                self.reorg_epoch
+            ));
+        }
+        if let Some(last_known_cursor) = request.last_known_log_cursor {
+            if last_known_cursor > cursor.log_cursor {
+                reasons.push(format!(
+                    "client cursor {} is ahead of server cursor {}",
+                    last_known_cursor, cursor.log_cursor
+                ));
+            }
+            if last_known_cursor < stable_cursor {
+                reasons.push(format!(
+                    "client cursor {} is behind stable cursor {}",
+                    last_known_cursor, stable_cursor
+                ));
+            }
+        }
+        let message = if reasons.is_empty() {
+            Some("delta_replay_allowed".to_string())
+        } else {
+            Some(format!("snapshot_reload_required: {}", reasons.join("; ")))
+        };
+
+        Ok(AuthoritativeRecoveryAck {
+            status: AuthoritativeRecoveryStatus::CatchUpReady,
+            reorg_epoch: self.reorg_epoch,
+            snapshot_height: cursor.snapshot_height,
+            snapshot_hash: cursor.snapshot_hash,
+            log_cursor: cursor.log_cursor,
+            stable_batch_id: cursor.stable_batch_id,
+            player_id: Some(player_id),
+            agent_id: self
+                .llm_sidecar
+                .bound_agent_for_player(request.player_id.as_str())
+                .map(ToOwned::to_owned),
+            session_pubkey,
+            replaced_by_pubkey: None,
+            session_epoch,
+            binding_epoch: None,
+            message,
+            revoke_reason: None,
+            revoked_by: None,
+            rollback_receipt: None,
+            acknowledged_at_tick: self.world.state().time,
+        })
+    }
+
+    pub(super) fn revoke_session_key(
+        &mut self,
+        request: AuthoritativeSessionRevokeRequest,
+    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
+        let player_id = request.player_id.trim().to_string();
+        if player_id.is_empty() {
+            return Err(recovery_error(
+                "player_id_required",
+                "revoke_session requires non-empty player_id",
+                None,
+                None,
+                None,
+            ));
+        }
+
+        let mutation_snapshot = self.session_mutation_snapshot();
+        let (revoked_pubkey, session_epoch) = self
+            .session_policy
+            .revoke_session(player_id.as_str(), request.session_pubkey.as_deref())
+            .map_err(|message| {
+                recovery_error(
+                    map_session_policy_error_code(message.as_str()),
+                    message,
+                    None,
+                    Some(player_id.clone()),
+                    request.session_pubkey.clone(),
+                )
+            })?;
+        let revoke_metadata = RuntimeSessionRevokeMetadata {
+            revoke_reason: normalize_optional_string(Some(request.revoke_reason.as_str())),
+            revoked_by: normalize_optional_string(request.revoked_by.as_deref()),
+        };
+        self.record_session_revoke_metadata(
+            player_id.as_str(),
+            revoked_pubkey.as_str(),
+            revoke_metadata.clone(),
+        );
+        self.clear_player_auth_runtime_state(player_id.as_str());
+        self.apply_session_revoke_binding(player_id.as_str(), revoked_pubkey.as_str());
+
+        let cursor = self.current_recovery_cursor().map_err(|err| {
+            recovery_error(
+                "cursor_compute_failed",
+                format!("{err:?}"),
+                None,
+                Some(player_id.clone()),
+                Some(revoked_pubkey.clone()),
+            )
+        })?;
+        let ack = AuthoritativeRecoveryAck {
+            status: AuthoritativeRecoveryStatus::SessionRevoked,
+            reorg_epoch: self.reorg_epoch,
+            snapshot_height: cursor.snapshot_height,
+            snapshot_hash: cursor.snapshot_hash,
+            log_cursor: cursor.log_cursor,
+            stable_batch_id: cursor.stable_batch_id,
+            player_id: Some(player_id),
+            agent_id: None,
+            session_pubkey: Some(revoked_pubkey),
+            replaced_by_pubkey: None,
+            session_epoch: Some(session_epoch),
+            binding_epoch: None,
+            message: Some(request.revoke_reason.trim().to_string()),
+            revoke_reason: revoke_metadata.revoke_reason,
+            revoked_by: revoke_metadata.revoked_by,
+            rollback_receipt: None,
+            acknowledged_at_tick: self.world.state().time,
+        };
+        if let Err(error) = self.persist_current_recovery_generation(&ack) {
+            self.restore_session_mutation_snapshot(mutation_snapshot);
+            return Err(error);
+        }
+        Ok(ack)
+    }
+
+    pub(super) fn rotate_session_key(
+        &mut self,
+        request: AuthoritativeSessionRotateRequest,
+    ) -> Result<AuthoritativeRecoveryAck<u64>, AuthoritativeRecoveryError> {
+        let player_id = request.player_id.trim().to_string();
+        if player_id.is_empty() {
+            return Err(recovery_error(
+                "player_id_required",
+                "rotate_session requires non-empty player_id",
+                None,
+                None,
+                None,
+            ));
+        }
+
+        let mutation_snapshot = self.session_mutation_snapshot();
+        let session_epoch = self
+            .session_policy
+            .rotate_session(
+                player_id.as_str(),
+                request.old_session_pubkey.as_str(),
+                request.new_session_pubkey.as_str(),
+            )
+            .map_err(|message| {
+                recovery_error(
+                    map_session_policy_error_code(message.as_str()),
+                    message,
+                    None,
+                    Some(player_id.clone()),
+                    Some(request.old_session_pubkey.clone()),
+                )
+            })?;
+        let rotation_metadata = RuntimeSessionRevokeMetadata {
+            revoke_reason: normalize_optional_string(Some(request.rotate_reason.as_str())),
+            revoked_by: normalize_optional_string(request.rotated_by.as_deref()),
+        };
+        self.record_session_revoke_metadata(
+            player_id.as_str(),
+            request.old_session_pubkey.as_str(),
+            rotation_metadata.clone(),
+        );
+        self.clear_player_auth_runtime_state(player_id.as_str());
+        self.apply_session_rotate_binding(
+            player_id.as_str(),
+            request.old_session_pubkey.as_str(),
+            request.new_session_pubkey.as_str(),
+        );
+
+        let cursor = self.current_recovery_cursor().map_err(|err| {
+            recovery_error(
+                "cursor_compute_failed",
+                format!("{err:?}"),
+                None,
+                Some(player_id.clone()),
+                Some(request.old_session_pubkey.clone()),
+            )
+        })?;
+        let ack = AuthoritativeRecoveryAck {
+            status: AuthoritativeRecoveryStatus::SessionRotated,
+            reorg_epoch: self.reorg_epoch,
+            snapshot_height: cursor.snapshot_height,
+            snapshot_hash: cursor.snapshot_hash,
+            log_cursor: cursor.log_cursor,
+            stable_batch_id: cursor.stable_batch_id,
+            player_id: Some(player_id),
+            agent_id: self
+                .llm_sidecar
+                .bound_agent_for_player(request.player_id.as_str())
+                .map(ToOwned::to_owned),
+            session_pubkey: Some(request.old_session_pubkey),
+            replaced_by_pubkey: Some(request.new_session_pubkey),
+            session_epoch: Some(session_epoch),
+            binding_epoch: None,
+            message: Some(request.rotate_reason.trim().to_string()),
+            revoke_reason: rotation_metadata.revoke_reason,
+            revoked_by: rotation_metadata.revoked_by,
+            rollback_receipt: None,
+            acknowledged_at_tick: self.world.state().time,
+        };
+        if let Err(error) = self.persist_current_recovery_generation(&ack) {
+            self.restore_session_mutation_snapshot(mutation_snapshot);
+            return Err(error);
+        }
+        Ok(ack)
+    }
+}

--- a/crates/oasis7/src/viewer/runtime_live/recovery_receipt.rs
+++ b/crates/oasis7/src/viewer/runtime_live/recovery_receipt.rs
@@ -332,6 +332,7 @@ impl ViewerRuntimeLiveServer {
             session_pubkey: None,
             replaced_by_pubkey: None,
             session_epoch: None,
+            binding_epoch: None,
             message: Some("persisted rollback receipt".to_string()),
             revoke_reason: None,
             revoked_by: None,

--- a/crates/oasis7/src/viewer/runtime_live/recovery_session.rs
+++ b/crates/oasis7/src/viewer/runtime_live/recovery_session.rs
@@ -1,6 +1,7 @@
 use super::authoritative::compute_runtime_snapshot_hash;
 use super::session_policy::RuntimeRecoveryCursor;
 use super::*;
+use crate::simulator::WorldEventKind;
 
 pub(super) struct RuntimeSessionMutationSnapshot {
     session_policy: RuntimeSessionPolicy,
@@ -12,6 +13,7 @@ pub(super) struct RuntimeSessionMutationSnapshot {
     player_chat_intent_acks:
         BTreeMap<(String, String, u64), super::control_plane::RuntimeChatIntentAckRecord>,
     primary_intents: BTreeMap<String, super::control_plane::RuntimePrimaryIntent>,
+    binding_epoch_by_agent: BTreeMap<String, u64>,
     pending_virtual_events: VecDeque<WorldEvent>,
 }
 
@@ -106,6 +108,7 @@ impl ViewerRuntimeLiveServer {
             player_auth_last_nonce: self.llm_sidecar.player_auth_last_nonce.clone(),
             player_chat_intent_acks: self.llm_sidecar.player_chat_intent_acks.clone(),
             primary_intents: self.llm_sidecar.primary_intents.clone(),
+            binding_epoch_by_agent: self.prompt_control_authority.binding_epoch_by_agent.clone(),
             pending_virtual_events: self.pending_virtual_events.clone(),
         }
     }
@@ -122,6 +125,7 @@ impl ViewerRuntimeLiveServer {
         self.llm_sidecar.player_auth_last_nonce = snapshot.player_auth_last_nonce;
         self.llm_sidecar.player_chat_intent_acks = snapshot.player_chat_intent_acks;
         self.llm_sidecar.primary_intents = snapshot.primary_intents;
+        self.prompt_control_authority.binding_epoch_by_agent = snapshot.binding_epoch_by_agent;
         self.pending_virtual_events = snapshot.pending_virtual_events;
     }
 
@@ -150,6 +154,10 @@ impl ViewerRuntimeLiveServer {
 
     pub(super) fn apply_session_revoke_binding(&mut self, player_id: &str, _revoked_pubkey: &str) {
         if let Some(event) = self.llm_sidecar.clear_player_binding(player_id) {
+            if let WorldEventKind::AgentPlayerUnbound { agent_id, .. } = &event {
+                self.prompt_control_authority
+                    .advance_binding_epoch(agent_id.as_str());
+            }
             self.enqueue_virtual_event(event);
         }
     }
@@ -176,7 +184,9 @@ impl ViewerRuntimeLiveServer {
             if should_replace {
                 self.llm_sidecar
                     .agent_public_key_bindings
-                    .insert(agent_id, new_pubkey.to_string());
+                    .insert(agent_id.clone(), new_pubkey.to_string());
+                self.prompt_control_authority
+                    .advance_binding_epoch(agent_id.as_str());
             }
         }
     }

--- a/crates/oasis7/src/viewer/runtime_live/support.rs
+++ b/crates/oasis7/src/viewer/runtime_live/support.rs
@@ -39,6 +39,8 @@ impl ViewerRuntimeLiveServerConfig {
             major_world_event_visibility: MajorWorldEventVisibilityPermission::Unknown,
             generated_world_dir: None,
             provider_lineage_store: None,
+            prompt_result_cache_capacity: config::DEFAULT_PROMPT_RESULT_CACHE_CAPACITY,
+            prompt_result_receipt_max_bytes: config::DEFAULT_PROMPT_RESULT_RECEIPT_MAX_BYTES,
             #[cfg(test)]
             test_cognition_runtime_binding: None,
         }
@@ -61,6 +63,8 @@ impl ViewerRuntimeLiveServerConfig {
             major_world_event_visibility: MajorWorldEventVisibilityPermission::Unknown,
             generated_world_dir: None,
             provider_lineage_store: None,
+            prompt_result_cache_capacity: config::DEFAULT_PROMPT_RESULT_CACHE_CAPACITY,
+            prompt_result_receipt_max_bytes: config::DEFAULT_PROMPT_RESULT_RECEIPT_MAX_BYTES,
             #[cfg(test)]
             test_cognition_runtime_binding: None,
         }
@@ -177,6 +181,16 @@ impl ViewerRuntimeLiveServerConfig {
     /// kept beside that world's immutable sidecar.
     pub fn with_provider_lineage_store(mut self, path: impl Into<PathBuf>) -> Self {
         self.provider_lineage_store = Some(path.into());
+        self
+    }
+
+    pub fn with_prompt_result_cache_capacity(mut self, capacity: usize) -> Self {
+        self.prompt_result_cache_capacity = capacity;
+        self
+    }
+
+    pub fn with_prompt_result_receipt_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.prompt_result_receipt_max_bytes = max_bytes;
         self
     }
 

--- a/crates/oasis7/src/viewer/runtime_live/tests.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests.rs
@@ -42,6 +42,8 @@ mod industrial_progression_readiness;
 mod power_projection;
 mod power_sale_quote;
 mod prompt_control;
+#[path = "tests/prompt_control_enhanced.rs"]
+mod prompt_control_enhanced;
 mod provider_settings;
 mod runtime_live_server_config;
 mod schedule_recipe_quote;

--- a/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_authoritative_recovery.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/auth_actions_authoritative_recovery.rs
@@ -286,6 +286,13 @@ fn session_mutations_roll_back_in_memory_when_recovery_persistence_fails() {
             .player_auth_last_nonce
             .contains_key("player-register-atomic")
     );
+    assert_eq!(
+        register_server
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str()),
+        0,
+        "failed registration must roll back binding epoch"
+    );
 
     let mutation_dir = std::env::temp_dir().join(format!(
         "oasis7-session-mutation-atomic-{}-{}",
@@ -384,6 +391,13 @@ fn session_mutations_roll_back_in_memory_when_recovery_persistence_fails() {
             .map(String::as_str),
         Some(old_public.as_str())
     );
+    assert_eq!(
+        server
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str()),
+        1,
+        "failed rotation must restore binding epoch"
+    );
     assert!(
         !server
             .session_revoke_metadata
@@ -423,6 +437,13 @@ fn session_mutations_roll_back_in_memory_when_recovery_persistence_fails() {
             .expect("lookup cached acknowledgement after revoke failure")
             .is_some(),
         "failed revoke must restore chat acknowledgement idempotency state"
+    );
+    assert_eq!(
+        server
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str()),
+        1,
+        "failed revoke must restore binding epoch"
     );
     assert_eq!(
         server

--- a/crates/oasis7/src/viewer/runtime_live/tests/prompt_control.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/prompt_control.rs
@@ -28,6 +28,7 @@ fn runtime_prompt_control_script_mode_requires_llm_mode() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         1,
@@ -71,6 +72,7 @@ fn runtime_prompt_control_hosted_public_join_requires_strong_auth() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         27,
@@ -140,6 +142,7 @@ fn runtime_prompt_control_hosted_public_join_accepts_valid_backend_grant() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: Some(Some("goal".to_string())),
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         2,
@@ -219,6 +222,7 @@ fn runtime_prompt_control_hosted_public_join_rejects_expired_backend_grant() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         2,
@@ -313,6 +317,7 @@ fn runtime_prompt_control_hosted_public_join_rejects_replayed_auth_nonce_even_wi
                 system_prompt_override: Some(Some("system".to_string())),
                 short_term_goal_override: Some(Some("goal".to_string())),
                 long_term_goal_override: None,
+                ..Default::default()
             },
             crate::viewer::PromptControlAuthIntent::Apply,
             2,
@@ -414,6 +419,7 @@ fn runtime_prompt_control_hosted_public_join_rejects_revoked_session_even_with_v
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: Some(Some("goal".to_string())),
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         2,
@@ -470,6 +476,7 @@ fn runtime_prompt_control_provider_mode_reports_unsupported() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         31,
@@ -512,6 +519,7 @@ fn runtime_prompt_control_apply_updates_snapshot_and_bindings() {
             system_prompt_override: Some(Some("system".to_string())),
             short_term_goal_override: None,
             long_term_goal_override: None,
+            ..Default::default()
         },
         crate::viewer::PromptControlAuthIntent::Apply,
         2,
@@ -616,6 +624,7 @@ fn runtime_prompt_control_keeps_the_canonical_primary_intent_truth() {
                 system_prompt_override: None,
                 short_term_goal_override,
                 long_term_goal_override: None,
+                ..Default::default()
             },
             crate::viewer::PromptControlAuthIntent::Apply,
             nonce,

--- a/crates/oasis7/src/viewer/runtime_live/tests/prompt_control_enhanced.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/prompt_control_enhanced.rs
@@ -144,6 +144,134 @@ fn runtime_prompt_control_enhanced_requires_negotiated_result_capability() {
 }
 
 #[test]
+fn runtime_prompt_control_selected_capability_rejects_legacy_shaped_requests() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(47);
+    let registration = register_runtime_session(
+        &mut server,
+        "player-shape",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let legacy_shaped = signed_prompt_control_apply_request(
+        crate::viewer::PromptControlApplyRequest {
+            agent_id: agent_id.clone(),
+            player_id: "player-shape".to_string(),
+            expected_version: Some(0),
+            updated_by: Some("player-shape".to_string()),
+            system_prompt_override: Some(Some("must not apply".to_string())),
+            ..Default::default()
+        },
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let error = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: legacy_shaped,
+            },
+            &negotiated,
+        )
+        .expect_err("selected enhanced capability must reject legacy shape");
+    assert_eq!(error.code, "prompt_control_field_required");
+    assert_eq!(
+        error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Rejected)
+    );
+    assert!(server.llm_sidecar.prompt_profiles.is_empty());
+    assert_eq!(
+        server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-shape"),
+        Some(&1)
+    );
+
+    let partial = crate::viewer::PromptControlApplyRequest {
+        agent_id,
+        player_id: "player-shape".to_string(),
+        request_id: Some("partial-shape".to_string()),
+        expected_version: Some(0),
+        ..Default::default()
+    };
+    let error = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Preview { request: partial },
+            &negotiated,
+        )
+        .expect_err("partial enhanced shape must fail before proof verification");
+    assert_eq!(error.code, "prompt_control_field_required");
+    assert_eq!(error.request_id.as_deref(), Some("partial-shape"));
+}
+
+#[test]
+fn runtime_prompt_control_result_capability_is_not_advertised_in_script_mode() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Script),
+    )
+    .expect("runtime server");
+    let mut session = RuntimeLiveSession::new();
+    let (mut writer, peer) = test_writer_pair();
+    server
+        .handle_request(
+            ViewerRequest::HelloV2 {
+                client: "script-capability-probe".to_string(),
+                version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+                capabilities: vec![
+                    crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string(),
+                ],
+            },
+            &mut session,
+            &mut writer,
+        )
+        .expect("handle script v2 hello");
+    let responses = read_available_runtime_live_responses(&peer, Duration::from_millis(25));
+    let ViewerResponse::HelloAck {
+        capabilities,
+        authority_epoch,
+        ..
+    } = responses.first().expect("missing script hello ack")
+    else {
+        panic!("expected hello ack, got {responses:?}");
+    };
+    assert!(
+        !capabilities
+            .iter()
+            .any(|capability| capability
+                == crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY)
+    );
+    assert!(authority_epoch.is_none());
+    assert!(
+        !crate::viewer::protocol::viewer_protocol_supports_prompt_control_result(
+            &session.negotiated_protocol
+        )
+    );
+}
+
+#[test]
 fn runtime_prompt_control_enhanced_applied_then_stale_is_serialized() {
     let _guard = lock_test_llm_env();
     let mut server = ViewerRuntimeLiveServer::new(
@@ -231,7 +359,7 @@ fn runtime_prompt_control_enhanced_applied_then_stale_is_serialized() {
     let stale = server
         .handle_prompt_control_for_protocol(
             crate::viewer::PromptControlCommand::Apply {
-                request: stale_request,
+                request: stale_request.clone(),
             },
             &negotiated,
         )
@@ -246,8 +374,150 @@ fn runtime_prompt_control_enhanced_applied_then_stale_is_serialized() {
             .llm_sidecar
             .player_auth_last_nonce
             .get("player-serialized"),
-        Some(&2)
+        Some(&3)
     );
+    let stale_replay = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: stale_request.clone(),
+            },
+            &negotiated,
+        )
+        .expect_err("same stale request must replay its terminal result");
+    assert_eq!(stale_replay.code, "version_conflict");
+    assert!(stale_replay.idempotent_replay);
+    assert_eq!(
+        server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-serialized"),
+        Some(&3)
+    );
+
+    let mut conflict_request = stale_request;
+    conflict_request.system_prompt_override = Some(Some("different operation".to_string()));
+    conflict_request.auth = None;
+    conflict_request = signed_prompt_control_apply_request(
+        conflict_request,
+        crate::viewer::PromptControlAuthIntent::Apply,
+        4,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let conflict = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: conflict_request,
+            },
+            &negotiated,
+        )
+        .expect_err("same request id with a different digest must conflict");
+    assert_eq!(conflict.code, "request_id_conflict");
+    assert!(!conflict.idempotent_replay);
+    assert_eq!(
+        server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-serialized"),
+        Some(&3)
+    );
+}
+
+#[test]
+fn runtime_prompt_control_hosted_control_loss_precedes_missing_grant() {
+    let _llm_guard = lock_test_llm_env();
+    let _strong_auth_guard = lock_test_hosted_strong_auth_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::TwoBases)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm)
+            .with_hosted_public_join_mode(true),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let rebound_agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .find(|candidate| *candidate != &agent_id)
+        .cloned()
+        .expect("second seed agent");
+    let (public_key, private_key) = test_signer(48);
+    let registration = register_runtime_session(
+        &mut server,
+        "player-hosted-loss",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let request = signed_prompt_control_apply_request(
+        crate::viewer::PromptControlApplyRequest {
+            agent_id: agent_id.clone(),
+            player_id: "player-hosted-loss".to_string(),
+            expected_version: Some(0),
+            updated_by: Some("player-hosted-loss".to_string()),
+            system_prompt_override: Some(Some("lost control".to_string())),
+            request_id: Some("hosted-control-loss".to_string()),
+            session_epoch: registration.session_epoch,
+            binding_epoch: registration.binding_epoch,
+            expected_authority_epoch: Some(server.prompt_control_authority.authority_epoch.clone()),
+            strong_auth_grant: None,
+            ..Default::default()
+        },
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let rebound = register_runtime_session_with_options(
+        &mut server,
+        "player-hosted-loss",
+        Some(rebound_agent_id.as_str()),
+        true,
+        3,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    assert_eq!(rebound.binding_epoch, Some(1));
+    assert_eq!(
+        server
+            .prompt_control_authority
+            .binding_epoch(agent_id.as_str()),
+        registration.binding_epoch.unwrap_or_default() + 1
+    );
+
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let error = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply { request },
+            &negotiated,
+        )
+        .expect_err("lost hosted control must be reported before grant status");
+    assert_eq!(error.code, "control_lost");
+    assert_eq!(error.reason_code.as_deref(), Some("control_lost"));
+    assert_eq!(
+        error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Blocked)
+    );
+    assert_eq!(
+        error.value_visibility,
+        Some(crate::viewer::protocol::PromptControlValueVisibility::Hidden)
+    );
+    assert!(error.player_id.is_none());
+    assert!(error.binding_epoch.is_none());
+    assert!(server.llm_sidecar.prompt_profiles.is_empty());
+    clear_hosted_strong_auth_env();
 }
 
 #[test]

--- a/crates/oasis7/src/viewer/runtime_live/tests/prompt_control_enhanced.rs
+++ b/crates/oasis7/src/viewer/runtime_live/tests/prompt_control_enhanced.rs
@@ -1,0 +1,588 @@
+use super::*;
+
+#[test]
+fn runtime_prompt_control_enhanced_apply_is_idempotent_per_authority_epoch() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(41);
+    let registration = register_runtime_session(
+        &mut server,
+        "player-enhanced",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let authority_epoch = server.prompt_control_authority.authority_epoch.clone();
+    let mut request = crate::viewer::PromptControlApplyRequest {
+        agent_id: agent_id.clone(),
+        player_id: "player-enhanced".to_string(),
+        public_key: None,
+        auth: None,
+        strong_auth_grant: None,
+        expected_version: Some(0),
+        updated_by: Some("player-enhanced".to_string()),
+        system_prompt_override: Some(Some("enhanced system".to_string())),
+        short_term_goal_override: None,
+        long_term_goal_override: None,
+        request_id: Some("enhanced-apply-1".to_string()),
+        session_epoch: registration.session_epoch,
+        binding_epoch: registration.binding_epoch,
+        expected_authority_epoch: Some(authority_epoch.clone()),
+        ..Default::default()
+    };
+    request = signed_prompt_control_apply_request(
+        request,
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let first = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: request.clone(),
+            },
+            &negotiated,
+        )
+        .expect("enhanced apply");
+    assert_eq!(
+        first.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Applied)
+    );
+    assert_eq!(first.request_id.as_deref(), Some("enhanced-apply-1"));
+    assert_eq!(
+        first.authority_epoch.as_deref(),
+        Some(authority_epoch.as_str())
+    );
+    assert_eq!(first.mutation_count, Some(1));
+
+    let replay = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply { request },
+            &negotiated,
+        )
+        .expect("same signed request replays from result ledger");
+    assert!(replay.idempotent_replay);
+    assert_eq!(replay.version, first.version);
+    assert!(server.pending_virtual_events.iter().any(|event| matches!(
+        event.kind,
+        crate::simulator::WorldEventKind::AgentPromptUpdated { .. }
+    )));
+}
+
+#[test]
+fn runtime_prompt_control_rejects_zero_result_limits_before_bootstrap() {
+    let cache_error = match ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_prompt_result_cache_capacity(0),
+    ) {
+        Err(error) => error,
+        Ok(_) => panic!("zero result cache capacity must fail closed"),
+    };
+    assert!(format!("{cache_error:?}").contains("cache capacity"));
+
+    let receipt_error = match ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_prompt_result_receipt_max_bytes(0),
+    ) {
+        Err(error) => error,
+        Ok(_) => panic!("zero receipt limit must fail closed"),
+    };
+    assert!(format!("{receipt_error:?}").contains("receipt max bytes"));
+}
+
+#[test]
+fn runtime_prompt_control_enhanced_requires_negotiated_result_capability() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let request = crate::viewer::PromptControlApplyRequest {
+        agent_id,
+        player_id: "player-a".to_string(),
+        request_id: Some("capability-required".to_string()),
+        ..Default::default()
+    };
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: Vec::new(),
+    };
+    let error = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Preview { request },
+            &negotiated,
+        )
+        .expect_err("enhanced request without capability must fail");
+    assert_eq!(error.code, "prompt_control_capability_required");
+}
+
+#[test]
+fn runtime_prompt_control_enhanced_applied_then_stale_is_serialized() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(42);
+    let registration = register_runtime_session(
+        &mut server,
+        "player-serialized",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let authority_epoch = server.prompt_control_authority.authority_epoch.clone();
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let make_request = |request_id: &str, nonce: u64, text: &str| {
+        signed_prompt_control_apply_request(
+            crate::viewer::PromptControlApplyRequest {
+                agent_id: agent_id.clone(),
+                player_id: "player-serialized".to_string(),
+                expected_version: Some(0),
+                updated_by: Some("player-serialized".to_string()),
+                system_prompt_override: Some(Some(text.to_string())),
+                request_id: Some(request_id.to_string()),
+                session_epoch: registration.session_epoch,
+                binding_epoch: registration.binding_epoch,
+                expected_authority_epoch: Some(authority_epoch.clone()),
+                ..Default::default()
+            },
+            crate::viewer::PromptControlAuthIntent::Apply,
+            nonce,
+            public_key.as_str(),
+            private_key.as_str(),
+        )
+    };
+    let first = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: make_request("serialized-a", 2, "first"),
+            },
+            &negotiated,
+        )
+        .expect("first operation applies");
+    assert_eq!(
+        first.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Applied)
+    );
+    assert_eq!(
+        first.applied_scope,
+        Some(crate::viewer::protocol::PromptControlApplicationScope::RuntimeInstance)
+    );
+    assert_eq!(
+        first.persistence_scope,
+        Some(crate::viewer::protocol::PromptControlApplicationScope::None)
+    );
+    assert_eq!(
+        first.sync_scope,
+        Some(crate::viewer::protocol::PromptControlApplicationScope::None)
+    );
+
+    let mut stale_request = make_request("serialized-b", 3, "second");
+    stale_request.expected_version = Some(0);
+    stale_request.auth = None;
+    stale_request = signed_prompt_control_apply_request(
+        stale_request,
+        crate::viewer::PromptControlAuthIntent::Apply,
+        3,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let stale = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: stale_request,
+            },
+            &negotiated,
+        )
+        .expect_err("second baseline request must become stale");
+    assert_eq!(stale.code, "version_conflict");
+    assert_eq!(
+        stale.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Stale)
+    );
+    assert_eq!(
+        server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-serialized"),
+        Some(&2)
+    );
+}
+
+#[test]
+fn runtime_prompt_control_binding_loss_is_hidden_before_nonce_or_version() {
+    let _guard = lock_test_llm_env();
+    let mut server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("runtime server");
+    let agent_id = server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(43);
+    let registration = register_runtime_session(
+        &mut server,
+        "player-binding-loss",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let authority_epoch = server.prompt_control_authority.authority_epoch.clone();
+    let request = signed_prompt_control_apply_request(
+        crate::viewer::PromptControlApplyRequest {
+            agent_id: agent_id.clone(),
+            player_id: "player-binding-loss".to_string(),
+            expected_version: Some(999),
+            updated_by: Some("player-binding-loss".to_string()),
+            system_prompt_override: Some(Some("should-not-apply".to_string())),
+            request_id: Some("binding-loss".to_string()),
+            session_epoch: registration.session_epoch,
+            binding_epoch: registration.binding_epoch,
+            expected_authority_epoch: Some(authority_epoch),
+            ..Default::default()
+        },
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let rebound = register_runtime_session_with_options(
+        &mut server,
+        "player-binding-loss",
+        Some(agent_id.as_str()),
+        true,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    assert_eq!(rebound.binding_epoch, Some(2));
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let error = server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply { request },
+            &negotiated,
+        )
+        .expect_err("stale binding must block before expected version and nonce");
+    assert_eq!(error.code, "control_lost");
+    assert_eq!(
+        error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Blocked)
+    );
+    assert_eq!(
+        error.value_visibility,
+        Some(crate::viewer::protocol::PromptControlValueVisibility::Hidden)
+    );
+    assert!(error.player_id.is_none());
+    assert!(error.binding_epoch.is_none());
+    assert!(error.current_version.is_none());
+    assert!(error.digest.is_none());
+    assert_eq!(
+        server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-binding-loss"),
+        Some(&2)
+    );
+    assert_eq!(
+        server
+            .llm_sidecar
+            .prompt_profiles
+            .get(agent_id.as_str())
+            .map(|p| p.version),
+        None
+    );
+}
+
+#[test]
+fn runtime_prompt_control_restart_fences_old_authority_result() {
+    let _guard = lock_test_llm_env();
+    let mut old_server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("old runtime server");
+    let agent_id = old_server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(44);
+    let registration = register_runtime_session(
+        &mut old_server,
+        "player-restart",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let old_authority_epoch = old_server.prompt_control_authority.authority_epoch.clone();
+    let request = signed_prompt_control_apply_request(
+        crate::viewer::PromptControlApplyRequest {
+            agent_id,
+            player_id: "player-restart".to_string(),
+            expected_version: Some(0),
+            updated_by: Some("player-restart".to_string()),
+            system_prompt_override: Some(Some("old-authority".to_string())),
+            request_id: Some("restart-retry".to_string()),
+            session_epoch: registration.session_epoch,
+            binding_epoch: registration.binding_epoch,
+            expected_authority_epoch: Some(old_authority_epoch.clone()),
+            ..Default::default()
+        },
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let mut new_server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm),
+    )
+    .expect("new runtime server");
+    assert_ne!(
+        new_server.prompt_control_authority.authority_epoch,
+        old_authority_epoch
+    );
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let error = new_server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply { request },
+            &negotiated,
+        )
+        .expect_err("old authority retry must be fenced");
+    assert_eq!(error.code, "prompt_control_result_unknown");
+    assert_eq!(
+        error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Blocked)
+    );
+    assert_eq!(
+        error.value_visibility,
+        Some(crate::viewer::protocol::PromptControlValueVisibility::Hidden)
+    );
+    assert!(error.agent_id.is_none());
+    assert!(error.player_id.is_none());
+    assert!(error.operation_digest.is_none());
+    assert!(error.expected_version.is_none());
+    assert!(new_server.pending_virtual_events.is_empty());
+}
+
+#[test]
+fn runtime_prompt_control_cache_and_receipt_limits_refuse_before_nonce() {
+    let _guard = lock_test_llm_env();
+    let mut full_server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm)
+            .with_prompt_result_cache_capacity(1),
+    )
+    .expect("runtime server");
+    let agent_id = full_server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (public_key, private_key) = test_signer(45);
+    let registration = register_runtime_session(
+        &mut full_server,
+        "player-cache",
+        Some(agent_id.as_str()),
+        1,
+        public_key.as_str(),
+        private_key.as_str(),
+    );
+    let authority_epoch = full_server.prompt_control_authority.authority_epoch.clone();
+    let negotiated = crate::viewer::protocol::NegotiatedViewerProtocol {
+        version: crate::viewer::VIEWER_PROTOCOL_VERSION,
+        capabilities: vec![crate::viewer::protocol::PROMPT_CONTROL_RESULT_CAPABILITY.to_string()],
+    };
+    let make_request = |request_id: &str, nonce: u64, expected_version: u64| {
+        signed_prompt_control_apply_request(
+            crate::viewer::PromptControlApplyRequest {
+                agent_id: agent_id.clone(),
+                player_id: "player-cache".to_string(),
+                expected_version: Some(expected_version),
+                updated_by: Some("player-cache".to_string()),
+                system_prompt_override: Some(Some(request_id.to_string())),
+                request_id: Some(request_id.to_string()),
+                session_epoch: registration.session_epoch,
+                binding_epoch: registration.binding_epoch,
+                expected_authority_epoch: Some(authority_epoch.clone()),
+                ..Default::default()
+            },
+            crate::viewer::PromptControlAuthIntent::Apply,
+            nonce,
+            public_key.as_str(),
+            private_key.as_str(),
+        )
+    };
+    full_server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: make_request("cache-first", 2, 0),
+            },
+            &negotiated,
+        )
+        .expect("first cache entry");
+    let full_error = full_server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: make_request("cache-second", 3, 1),
+            },
+            &negotiated,
+        )
+        .expect_err("new request must be blocked when ledger is full");
+    assert_eq!(full_error.code, "result_cache_full");
+    assert_eq!(
+        full_error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Blocked)
+    );
+    assert_eq!(
+        full_server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-cache"),
+        Some(&2)
+    );
+    assert_eq!(
+        full_server
+            .llm_sidecar
+            .prompt_profiles
+            .get(agent_id.as_str())
+            .map(|p| p.version),
+        Some(1)
+    );
+
+    let mut receipt_server = ViewerRuntimeLiveServer::new(
+        ViewerRuntimeLiveServerConfig::new(WorldScenario::Minimal)
+            .with_decision_mode(ViewerLiveDecisionMode::Llm)
+            .with_prompt_result_receipt_max_bytes(1),
+    )
+    .expect("runtime server");
+    let receipt_agent_id = receipt_server
+        .world
+        .state()
+        .agents
+        .keys()
+        .next()
+        .cloned()
+        .expect("seed agent");
+    let (receipt_public_key, receipt_private_key) = test_signer(46);
+    let receipt_registration = register_runtime_session(
+        &mut receipt_server,
+        "player-receipt",
+        Some(receipt_agent_id.as_str()),
+        1,
+        receipt_public_key.as_str(),
+        receipt_private_key.as_str(),
+    );
+    let receipt_request = signed_prompt_control_apply_request(
+        crate::viewer::PromptControlApplyRequest {
+            agent_id: receipt_agent_id.clone(),
+            player_id: "player-receipt".to_string(),
+            expected_version: Some(0),
+            updated_by: Some("player-receipt".to_string()),
+            system_prompt_override: Some(Some("oversize".to_string())),
+            request_id: Some("receipt-oversize".to_string()),
+            session_epoch: receipt_registration.session_epoch,
+            binding_epoch: receipt_registration.binding_epoch,
+            expected_authority_epoch: Some(
+                receipt_server
+                    .prompt_control_authority
+                    .authority_epoch
+                    .clone(),
+            ),
+            ..Default::default()
+        },
+        crate::viewer::PromptControlAuthIntent::Apply,
+        2,
+        receipt_public_key.as_str(),
+        receipt_private_key.as_str(),
+    );
+    let receipt_error = receipt_server
+        .handle_prompt_control_for_protocol(
+            crate::viewer::PromptControlCommand::Apply {
+                request: receipt_request,
+            },
+            &negotiated,
+        )
+        .expect_err("oversize receipt must be refused");
+    assert_eq!(receipt_error.code, "result_receipt_too_large");
+    assert_eq!(
+        receipt_error.status,
+        Some(crate::viewer::protocol::PromptControlResultStatus::Rejected)
+    );
+    assert_eq!(
+        receipt_server
+            .llm_sidecar
+            .player_auth_last_nonce
+            .get("player-receipt"),
+        Some(&1)
+    );
+    assert_eq!(
+        receipt_server
+            .llm_sidecar
+            .prompt_profiles
+            .get(receipt_agent_id.as_str())
+            .map(|p| p.version),
+        None
+    );
+}

--- a/crates/oasis7/src/viewer/server.rs
+++ b/crates/oasis7/src/viewer/server.rs
@@ -189,6 +189,7 @@ impl<'a> ViewerSession<'a> {
                     capabilities: Vec::new(),
                     world_id: world_id.to_string(),
                     control_profile: ViewerControlProfile::Playback,
+                    authority_epoch: None,
                 };
                 send_response(writer, &response)?;
             }
@@ -273,6 +274,7 @@ impl<'a> ViewerSession<'a> {
                             message: "prompt_control is only available in live mode".to_string(),
                             agent_id: None,
                             current_version: None,
+                            ..PromptControlError::default_legacy()
                         },
                     },
                 )?;

--- a/crates/oasis7_proto/src/viewer.rs
+++ b/crates/oasis7_proto/src/viewer.rs
@@ -185,10 +185,18 @@ pub enum PromptControlCommand {
         request: PromptControlRollbackRequest,
     },
 }
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PromptControlApplyRequest {
     pub agent_id: String,
     pub player_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_authority_epoch: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -225,10 +233,18 @@ where
     let value = Option::<String>::deserialize(deserializer)?;
     Ok(Some(value))
 }
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct PromptControlRollbackRequest {
     pub agent_id: String,
     pub player_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_authority_epoch: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -527,6 +543,8 @@ pub enum ViewerResponse<Snapshot, Event, DecisionTrace, Metrics, Time> {
         world_id: String,
         #[serde(default)]
         control_profile: ViewerControlProfile,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        authority_epoch: Option<String>,
     },
     Snapshot {
         snapshot: Snapshot,
@@ -656,524 +674,6 @@ impl From<ViewerControl> for PlaybackControl {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn viewer_playback_control_request_round_trip() {
-        let request = ViewerRequest::PlaybackControl {
-            mode: PlaybackControl::Seek { tick: 24 },
-            request_id: Some(11),
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_live_control_request_round_trip() {
-        let request = ViewerRequest::LiveControl {
-            mode: LiveControl::Step { count: 3 },
-            request_id: Some(13),
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_control_request_defaults_request_id_to_none_for_compat_payload() {
-        let request = ViewerRequest::Control {
-            mode: ViewerControl::Step { count: 2 },
-            request_id: None,
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        assert!(!json.contains("request_id"));
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        let ViewerRequest::Control { request_id, .. } = parsed else {
-            panic!("expected control request");
-        };
-        assert_eq!(request_id, None);
-    }
-
-    #[test]
-    fn viewer_subscribe_round_trip_with_filters() {
-        let request = ViewerRequest::Subscribe {
-            streams: vec![ViewerStream::Events],
-            event_kinds: vec![ViewerEventKind::AgentMoved, ViewerEventKind::Power],
-        };
-        let json = serde_json::to_string(&request).expect("serialize subscribe");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize subscribe");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_prompt_control_request_round_trip() {
-        let request = ViewerRequest::PromptControl {
-            command: Box::new(PromptControlCommand::Apply {
-                request: PromptControlApplyRequest {
-                    agent_id: "agent-0".to_string(),
-                    player_id: "player-1".to_string(),
-                    public_key: Some("pk-1".to_string()),
-                    auth: Some(PlayerAuthProof {
-                        scheme: PlayerAuthScheme::Ed25519,
-                        player_id: "player-1".to_string(),
-                        public_key: "pk-1".to_string(),
-                        nonce: 7,
-                        signature: "awviewauth:v1:deadbeef".to_string(),
-                    }),
-                    strong_auth_grant: None,
-                    expected_version: Some(3),
-                    updated_by: Some("tester".to_string()),
-                    system_prompt_override: Some(Some("system".to_string())),
-                    short_term_goal_override: Some(None),
-                    long_term_goal_override: None,
-                },
-            }),
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let value: serde_json::Value =
-            serde_json::from_str(&json).expect("serialized request should be json");
-        assert_eq!(value["type"], "prompt_control");
-        assert_eq!(value["command"]["mode"], "apply");
-        assert_eq!(value["command"]["request"]["agent_id"], "agent-0");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_agent_chat_request_round_trip() {
-        let request = ViewerRequest::AgentChat {
-            request: AgentChatRequest {
-                agent_id: "agent-0".to_string(),
-                message: "go to loc-2".to_string(),
-                player_id: Some("player-1".to_string()),
-                public_key: Some("pk-1".to_string()),
-                auth: Some(PlayerAuthProof {
-                    scheme: PlayerAuthScheme::Ed25519,
-                    player_id: "player-1".to_string(),
-                    public_key: "pk-1".to_string(),
-                    nonce: 9,
-                    signature: "awviewauth:v1:deadbeef".to_string(),
-                }),
-                intent_tick: Some(42),
-                intent_seq: Some(9),
-                world_id: Some("world-1".to_string()),
-                reorg_epoch: Some(2),
-                authority_scope: Some("player_agent_chat".to_string()),
-                replaces_intent_id: Some("agent-intent-v2:prior".to_string()),
-            },
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_gameplay_action_request_round_trip() {
-        let request = ViewerRequest::GameplayAction {
-            request: GameplayActionRequest {
-                action_id: "build_factory_smelter_mk1".to_string(),
-                target_agent_id: "agent-0".to_string(),
-                actor_agent_id: None,
-                player_id: "player-1".to_string(),
-                public_key: Some("pk-1".to_string()),
-                auth: Some(PlayerAuthProof {
-                    scheme: PlayerAuthScheme::Ed25519,
-                    player_id: "player-1".to_string(),
-                    public_key: "pk-1".to_string(),
-                    nonce: 11,
-                    signature: "awviewauth:v1:deadbeef".to_string(),
-                }),
-            },
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_authoritative_challenge_submit_request_round_trip() {
-        let request = ViewerRequest::AuthoritativeChallenge {
-            command: AuthoritativeChallengeCommand::Submit {
-                request: AuthoritativeChallengeSubmitRequest {
-                    batch_id: "batch-1".to_string(),
-                    watcher_id: "watcher-1".to_string(),
-                    recomputed_state_root: "a".repeat(64),
-                    recomputed_data_root: "b".repeat(64),
-                    challenge_id: Some("challenge-1".to_string()),
-                },
-            },
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_authoritative_recovery_rotate_session_request_round_trip() {
-        let request = ViewerRequest::AuthoritativeRecovery {
-            command: AuthoritativeRecoveryCommand::RotateSession {
-                request: AuthoritativeSessionRotateRequest {
-                    player_id: "player-1".to_string(),
-                    old_session_pubkey: "old-key".to_string(),
-                    new_session_pubkey: "new-key".to_string(),
-                    rotate_reason: "security_rotation".to_string(),
-                    rotated_by: Some("ops".to_string()),
-                },
-            },
-        };
-        let json = serde_json::to_string(&request).expect("serialize request");
-        let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
-        assert_eq!(parsed, request);
-    }
-
-    #[test]
-    fn viewer_prompt_control_request_legacy_without_public_key_is_accepted() {
-        let json = r#"{
-            "type":"prompt_control",
-            "command":{
-                "mode":"apply",
-                "request":{
-                    "agent_id":"agent-0",
-                    "player_id":"player-1"
-                }
-            }
-        }"#;
-        let parsed: ViewerRequest = serde_json::from_str(json).expect("deserialize legacy request");
-        let ViewerRequest::PromptControl { command } = parsed else {
-            panic!("expected prompt_control request");
-        };
-        let PromptControlCommand::Apply { request } = *command else {
-            panic!("expected apply command");
-        };
-        assert_eq!(request.public_key, None);
-        assert_eq!(request.auth, None);
-    }
-
-    #[test]
-    fn viewer_agent_chat_request_legacy_without_auth_is_accepted() {
-        let json = r#"{
-            "type":"agent_chat",
-            "request":{
-                "agent_id":"agent-0",
-                "message":"hello",
-                "player_id":"player-1",
-                "public_key":"pk-1"
-            }
-        }"#;
-        let parsed: ViewerRequest = serde_json::from_str(json).expect("deserialize legacy request");
-        let ViewerRequest::AgentChat { request } = parsed else {
-            panic!("expected agent_chat request");
-        };
-        assert_eq!(request.auth, None);
-        assert_eq!(request.intent_tick, None);
-        assert_eq!(request.intent_seq, None);
-    }
-
-    #[test]
-    fn viewer_response_round_trip_prompt_ack() {
-        let response = ViewerResponse::<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        >::PromptControlAck {
-            ack: PromptControlAck {
-                agent_id: "agent-0".to_string(),
-                operation: PromptControlOperation::Rollback,
-                preview: false,
-                version: 7,
-                updated_at_tick: 42,
-                applied_fields: vec![
-                    "system_prompt_override".to_string(),
-                    "short_term_goal_override".to_string(),
-                ],
-                digest: "abc".to_string(),
-                rolled_back_to_version: Some(5),
-            },
-        };
-        let json = serde_json::to_string(&response).expect("serialize response");
-        let parsed: ViewerResponse<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        > = serde_json::from_str(&json).expect("deserialize response");
-        assert_eq!(parsed, response);
-    }
-
-    #[test]
-    fn viewer_response_round_trip_control_completion_ack() {
-        let response = ViewerResponse::<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        >::ControlCompletionAck {
-            ack: ControlCompletionAck {
-                request_id: 42,
-                status: ControlCompletionStatus::TimeoutNoProgress,
-                delta_logical_time: 0,
-                delta_event_seq: 0,
-                error_code: None,
-                error_message: None,
-            },
-        };
-        let json = serde_json::to_string(&response).expect("serialize response");
-        let parsed: ViewerResponse<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        > = serde_json::from_str(&json).expect("deserialize response");
-        assert_eq!(parsed, response);
-    }
-
-    #[test]
-    fn viewer_response_round_trip_agent_chat_ack() {
-        let response = ViewerResponse::<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        >::AgentChatAck {
-            ack: AgentChatAck {
-                agent_id: "agent-0".to_string(),
-                accepted_at_tick: 42,
-                message_len: 11,
-                player_id: Some("player-1".to_string()),
-                intent_tick: Some(42),
-                intent_seq: Some(17),
-                idempotent_replay: true,
-                intent_id: None,
-                accepted_event_seq: None,
-                status: None,
-                receipt_ref: None,
-                replaced_by: None,
-            },
-        };
-        let json = serde_json::to_string(&response).expect("serialize response");
-        let parsed: ViewerResponse<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        > = serde_json::from_str(&json).expect("deserialize response");
-        assert_eq!(parsed, response);
-    }
-
-    #[test]
-    fn viewer_response_round_trip_gameplay_action_ack() {
-        let response = ViewerResponse::<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        >::GameplayActionAck {
-            ack: GameplayActionAck {
-                action_id: "build_factory_smelter_mk1".to_string(),
-                target_agent_id: "agent-0".to_string(),
-                player_id: "player-1".to_string(),
-                runtime_action_id: 41,
-                accepted_at_tick: 42,
-                message: Some(
-                    "advance 1-2 steps to apply the queued industrial action".to_string(),
-                ),
-            },
-        };
-        let json = serde_json::to_string(&response).expect("serialize response");
-        let parsed: ViewerResponse<
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            serde_json::Value,
-            u64,
-        > = serde_json::from_str(&json).expect("deserialize response");
-        assert_eq!(parsed, response);
-    }
-
-    #[test]
-    fn world_feed_v1_round_trip_preserves_cursor_and_gap_contract() {
-        let request_json = serde_json::json!({
-            "type": "request_world_feed",
-            "cursor": "opaque-cursor",
-            "limit": 25
-        });
-        let request: ViewerRequest =
-            serde_json::from_value(request_json.clone()).expect("decode world feed request");
-        assert_eq!(
-            serde_json::to_value(request).expect("encode request"),
-            request_json
-        );
-
-        let legacy_response_json = serde_json::json!({
-            "type": "world_feed",
-            "feed": {
-                "schema_version": "world_feed/v1",
-                "world_id": "world-1",
-                "reorg_epoch": 3,
-                "cursor": "next-cursor",
-                "events": [],
-                "status": "gap",
-                "gap_reason": "reorg_epoch_changed",
-                "snapshot_reload_required": true
-            }
-        });
-        let response: ViewerResponse<(), (), (), (), u64> =
-            serde_json::from_value(legacy_response_json).expect("decode world feed response");
-        let encoded = serde_json::to_value(response).expect("encode response");
-        assert_eq!(encoded["feed"]["reorg_epoch"], serde_json::json!("3"));
-    }
-
-    #[test]
-    fn world_feed_v1_event_keeps_explicit_receipt_reference_nullable() {
-        let legacy_response_json = serde_json::json!({
-            "type": "world_feed",
-            "feed": {
-                "schema_version": "world_feed/v1",
-                "world_id": "world-1",
-                "reorg_epoch": 0,
-                "cursor": "cursor-7",
-                "events": [{
-                    "event_seq": 7,
-                    "kind": "domain",
-                    "summary": "Domain event",
-                    "detail": "{}",
-                    "receipt_ref": null
-                }],
-                "status": "ready",
-                "snapshot_reload_required": false
-            }
-        });
-        let response: ViewerResponse<(), (), (), (), u64> =
-            serde_json::from_value(legacy_response_json).expect("decode world feed response");
-        let encoded = serde_json::to_value(response).expect("encode response");
-        assert_eq!(encoded["feed"]["reorg_epoch"], serde_json::json!("0"));
-        assert_eq!(
-            encoded["feed"]["events"][0]["event_seq"],
-            serde_json::json!("7")
-        );
-        assert!(encoded["feed"]["events"][0]["receipt_ref"].is_null());
-        assert!(encoded["feed"]["events"][0].get("major_event").is_none());
-    }
-
-    #[test]
-    fn world_feed_v1_major_event_round_trip_preserves_opaque_subtype() {
-        let response_json = serde_json::json!({
-            "type": "world_feed",
-            "feed": {
-                "schema_version": "world_feed/v1",
-                "world_id": "world-1",
-                "reorg_epoch": "3",
-                "cursor": "cursor-7",
-                "events": [{
-                    "event_seq": "7",
-                    "kind": "domain",
-                    "summary": "Crisis active",
-                    "detail": "{}",
-                    "receipt_ref": null,
-                    "major_event": {
-                        "schema_version": "major_world_event/v1",
-                        "identity": { "world_id": "world-1", "reorg_epoch": "3", "event_seq": "7" },
-                        "category": "crisis",
-                        "subtype": "power_shortage",
-                        "severity": 4,
-                        "lifecycle": "active",
-                        "source": { "authority": "runtime_journal", "event_kind": "crisis_spawned" },
-                        "freshness": "current",
-                        "visibility": "public",
-                        "logical_time": 10,
-                        "world_anchor": { "scope": "world", "entity_id": "crisis-1" }
-                    }
-                }],
-                "status": "ready",
-                "snapshot_reload_required": false
-            }
-        });
-        let response: ViewerResponse<(), (), (), (), u64> =
-            serde_json::from_value(response_json).expect("decode major world event");
-        let encoded = serde_json::to_value(response).expect("encode major world event");
-        assert_eq!(
-            encoded["feed"]["events"][0]["major_event"]["subtype"],
-            serde_json::json!("power_shortage")
-        );
-        assert!(encoded["feed"]["events"][0]["receipt_ref"].is_null());
-    }
-
-    #[test]
-    fn world_feed_v1_u64_identifiers_serialize_as_exact_decimal_strings() {
-        let response = ViewerResponse::<(), (), (), (), u64>::WorldFeed {
-            feed: WorldFeedEnvelope {
-                schema_version: WORLD_FEED_SCHEMA_VERSION.to_string(),
-                world_id: "world-max".to_string(),
-                reorg_epoch: u64::MAX,
-                cursor: "cursor-max".to_string(),
-                events: vec![WorldFeedEvent {
-                    event_seq: u64::MAX,
-                    kind: "domain".to_string(),
-                    summary: "Max event sequence".to_string(),
-                    detail: "{}".to_string(),
-                    receipt_ref: None,
-                    module_visual_entity_id: None,
-                    major_event: None,
-                }],
-                status: WorldFeedStatus::Ready,
-                gap_reason: None,
-                unavailable_reason: None,
-                snapshot_reload_required: false,
-            },
-        };
-
-        let encoded = serde_json::to_value(&response).expect("encode max u64 feed");
-        assert_eq!(
-            encoded["feed"]["reorg_epoch"],
-            serde_json::json!(u64::MAX.to_string())
-        );
-        assert_eq!(
-            encoded["feed"]["events"][0]["event_seq"],
-            serde_json::json!(u64::MAX.to_string())
-        );
-
-        let parsed: ViewerResponse<(), (), (), (), u64> =
-            serde_json::from_value(encoded).expect("decode max u64 feed");
-        assert_eq!(parsed, response);
-    }
-
-    #[test]
-    fn director_capability_grant_round_trip_preserves_signed_scope() {
-        let grant_json = serde_json::json!({
-            "version": 1,
-            "action": "director_open",
-            "audience": "viewer_director",
-            "scope": "diagnostics_read",
-            "player_id": "player-1",
-            "player_public_key": "11".repeat(32),
-            "server": "viewer-live-1",
-            "session_epoch": 4,
-            "nonce": "director-nonce-1",
-            "issued_at_unix_ms": 1000,
-            "expires_at_unix_ms": 2000,
-            "signer_public_key": "22".repeat(32),
-            "signature": "awdirectorgrant:v1:33".to_string() + &"33".repeat(63),
-        });
-        let grant: DirectorCapabilityGrant =
-            serde_json::from_value(grant_json.clone()).expect("decode director grant");
-        assert_eq!(
-            serde_json::to_value(grant).expect("encode director grant"),
-            grant_json
-        );
-    }
-}
-
-#[cfg(test)]
 mod authoritative_batch_roundtrip_tests;
 #[cfg(test)]
 mod authoritative_challenge_roundtrip_tests;
@@ -1185,6 +685,9 @@ mod collect_data_tests;
 mod control_roundtrip_tests;
 #[cfg(test)]
 mod market_quote_decision_tests;
+#[cfg(test)]
+#[path = "viewer/protocol_tests.rs"]
+mod protocol_tests;
 #[cfg(test)]
 #[path = "viewer/protocol_v2_tests.rs"]
 mod protocol_v2_tests;

--- a/crates/oasis7_proto/src/viewer/authoritative.rs
+++ b/crates/oasis7_proto/src/viewer/authoritative.rs
@@ -102,6 +102,8 @@ pub struct AuthoritativeRecoveryAck<Time> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_epoch: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revoke_reason: Option<String>,

--- a/crates/oasis7_proto/src/viewer/negotiation.rs
+++ b/crates/oasis7_proto/src/viewer/negotiation.rs
@@ -16,6 +16,7 @@ pub enum PlayerAuthScheme {
 
 pub const SIGNED_AUTHORITATIVE_ROLLBACK_CAPABILITY: &str = "signed_authoritative_rollback_v1";
 pub const GOVERNED_ROLLBACK_REPLAY_CAPABILITY: &str = "governed_rollback_replay_v2";
+pub const PROMPT_CONTROL_RESULT_CAPABILITY: &str = "prompt_control_result_v1";
 
 impl NegotiatedViewerProtocol {
     pub fn v1_without_capabilities() -> Self {
@@ -38,5 +39,13 @@ impl NegotiatedViewerProtocol {
                 .capabilities
                 .iter()
                 .any(|value| value == GOVERNED_ROLLBACK_REPLAY_CAPABILITY)
+    }
+
+    pub fn supports_prompt_control_result(&self) -> bool {
+        self.version >= 2
+            && self
+                .capabilities
+                .iter()
+                .any(|value| value == PROMPT_CONTROL_RESULT_CAPABILITY)
     }
 }

--- a/crates/oasis7_proto/src/viewer/protocol_tests.rs
+++ b/crates/oasis7_proto/src/viewer/protocol_tests.rs
@@ -1,0 +1,619 @@
+use super::*;
+
+#[test]
+fn viewer_playback_control_request_round_trip() {
+    let request = ViewerRequest::PlaybackControl {
+        mode: PlaybackControl::Seek { tick: 24 },
+        request_id: Some(11),
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_live_control_request_round_trip() {
+    let request = ViewerRequest::LiveControl {
+        mode: LiveControl::Step { count: 3 },
+        request_id: Some(13),
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_control_request_defaults_request_id_to_none_for_compat_payload() {
+    let request = ViewerRequest::Control {
+        mode: ViewerControl::Step { count: 2 },
+        request_id: None,
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    assert!(!json.contains("request_id"));
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    let ViewerRequest::Control { request_id, .. } = parsed else {
+        panic!("expected control request");
+    };
+    assert_eq!(request_id, None);
+}
+
+#[test]
+fn viewer_subscribe_round_trip_with_filters() {
+    let request = ViewerRequest::Subscribe {
+        streams: vec![ViewerStream::Events],
+        event_kinds: vec![ViewerEventKind::AgentMoved, ViewerEventKind::Power],
+    };
+    let json = serde_json::to_string(&request).expect("serialize subscribe");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize subscribe");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_prompt_control_request_round_trip() {
+    let request = ViewerRequest::PromptControl {
+        command: Box::new(PromptControlCommand::Apply {
+            request: PromptControlApplyRequest {
+                agent_id: "agent-0".to_string(),
+                player_id: "player-1".to_string(),
+                request_id: None,
+                session_epoch: None,
+                binding_epoch: None,
+                expected_authority_epoch: None,
+                public_key: Some("pk-1".to_string()),
+                auth: Some(PlayerAuthProof {
+                    scheme: PlayerAuthScheme::Ed25519,
+                    player_id: "player-1".to_string(),
+                    public_key: "pk-1".to_string(),
+                    nonce: 7,
+                    signature: "awviewauth:v1:deadbeef".to_string(),
+                }),
+                strong_auth_grant: None,
+                expected_version: Some(3),
+                updated_by: Some("tester".to_string()),
+                system_prompt_override: Some(Some("system".to_string())),
+                short_term_goal_override: Some(None),
+                long_term_goal_override: None,
+            },
+        }),
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let value: serde_json::Value =
+        serde_json::from_str(&json).expect("serialized request should be json");
+    assert_eq!(value["type"], "prompt_control");
+    assert_eq!(value["command"]["mode"], "apply");
+    assert_eq!(value["command"]["request"]["agent_id"], "agent-0");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_agent_chat_request_round_trip() {
+    let request = ViewerRequest::AgentChat {
+        request: AgentChatRequest {
+            agent_id: "agent-0".to_string(),
+            message: "go to loc-2".to_string(),
+            player_id: Some("player-1".to_string()),
+            public_key: Some("pk-1".to_string()),
+            auth: Some(PlayerAuthProof {
+                scheme: PlayerAuthScheme::Ed25519,
+                player_id: "player-1".to_string(),
+                public_key: "pk-1".to_string(),
+                nonce: 9,
+                signature: "awviewauth:v1:deadbeef".to_string(),
+            }),
+            intent_tick: Some(42),
+            intent_seq: Some(9),
+            world_id: Some("world-1".to_string()),
+            reorg_epoch: Some(2),
+            authority_scope: Some("player_agent_chat".to_string()),
+            replaces_intent_id: Some("agent-intent-v2:prior".to_string()),
+        },
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_gameplay_action_request_round_trip() {
+    let request = ViewerRequest::GameplayAction {
+        request: GameplayActionRequest {
+            action_id: "build_factory_smelter_mk1".to_string(),
+            target_agent_id: "agent-0".to_string(),
+            actor_agent_id: None,
+            player_id: "player-1".to_string(),
+            public_key: Some("pk-1".to_string()),
+            auth: Some(PlayerAuthProof {
+                scheme: PlayerAuthScheme::Ed25519,
+                player_id: "player-1".to_string(),
+                public_key: "pk-1".to_string(),
+                nonce: 11,
+                signature: "awviewauth:v1:deadbeef".to_string(),
+            }),
+        },
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_authoritative_challenge_submit_request_round_trip() {
+    let request = ViewerRequest::AuthoritativeChallenge {
+        command: AuthoritativeChallengeCommand::Submit {
+            request: AuthoritativeChallengeSubmitRequest {
+                batch_id: "batch-1".to_string(),
+                watcher_id: "watcher-1".to_string(),
+                recomputed_state_root: "a".repeat(64),
+                recomputed_data_root: "b".repeat(64),
+                challenge_id: Some("challenge-1".to_string()),
+            },
+        },
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_authoritative_recovery_rotate_session_request_round_trip() {
+    let request = ViewerRequest::AuthoritativeRecovery {
+        command: AuthoritativeRecoveryCommand::RotateSession {
+            request: AuthoritativeSessionRotateRequest {
+                player_id: "player-1".to_string(),
+                old_session_pubkey: "old-key".to_string(),
+                new_session_pubkey: "new-key".to_string(),
+                rotate_reason: "security_rotation".to_string(),
+                rotated_by: Some("ops".to_string()),
+            },
+        },
+    };
+    let json = serde_json::to_string(&request).expect("serialize request");
+    let parsed: ViewerRequest = serde_json::from_str(&json).expect("deserialize request");
+    assert_eq!(parsed, request);
+}
+
+#[test]
+fn viewer_prompt_control_request_legacy_without_public_key_is_accepted() {
+    let json = r#"{
+            "type":"prompt_control",
+            "command":{
+                "mode":"apply",
+                "request":{
+                    "agent_id":"agent-0",
+                    "player_id":"player-1"
+                }
+            }
+        }"#;
+    let parsed: ViewerRequest = serde_json::from_str(json).expect("deserialize legacy request");
+    let ViewerRequest::PromptControl { command } = parsed else {
+        panic!("expected prompt_control request");
+    };
+    let PromptControlCommand::Apply { request } = *command else {
+        panic!("expected apply command");
+    };
+    assert_eq!(request.public_key, None);
+    assert_eq!(request.auth, None);
+}
+
+#[test]
+fn viewer_prompt_control_enhanced_request_fields_survive_legacy_decode() {
+    let json = serde_json::json!({
+        "type": "prompt_control",
+        "command": {
+            "mode": "apply",
+            "request": {
+                "agent_id": "agent-0",
+                "player_id": "player-1",
+                "request_id": "request-1",
+                "session_epoch": 3,
+                "binding_epoch": 4,
+                "expected_authority_epoch": "authority-1",
+                "expected_version": 7,
+                "updated_by": "player-1",
+                "system_prompt_override": "system"
+            }
+        }
+    });
+    let parsed: ViewerRequest =
+        serde_json::from_value(json.clone()).expect("decode enhanced prompt request");
+    let encoded = serde_json::to_value(parsed).expect("encode enhanced prompt request");
+    for field in [
+        "request_id",
+        "session_epoch",
+        "binding_epoch",
+        "expected_authority_epoch",
+    ] {
+        assert_eq!(
+            encoded["command"]["request"][field],
+            json["command"]["request"][field]
+        );
+    }
+}
+
+#[test]
+fn viewer_agent_chat_request_legacy_without_auth_is_accepted() {
+    let json = r#"{
+            "type":"agent_chat",
+            "request":{
+                "agent_id":"agent-0",
+                "message":"hello",
+                "player_id":"player-1",
+                "public_key":"pk-1"
+            }
+        }"#;
+    let parsed: ViewerRequest = serde_json::from_str(json).expect("deserialize legacy request");
+    let ViewerRequest::AgentChat { request } = parsed else {
+        panic!("expected agent_chat request");
+    };
+    assert_eq!(request.auth, None);
+    assert_eq!(request.intent_tick, None);
+    assert_eq!(request.intent_seq, None);
+}
+
+#[test]
+fn viewer_response_round_trip_prompt_ack() {
+    let response = ViewerResponse::<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    >::PromptControlAck {
+        ack: PromptControlAck {
+            request_id: None,
+            authority_epoch: None,
+            agent_id: "agent-0".to_string(),
+            operation: PromptControlOperation::Rollback,
+            preview: false,
+            status: None,
+            player_id: None,
+            session_epoch: None,
+            binding_epoch: None,
+            expected_version: None,
+            version: 7,
+            updated_at_tick: 42,
+            applied_fields: vec![
+                "system_prompt_override".to_string(),
+                "short_term_goal_override".to_string(),
+            ],
+            digest: "abc".to_string(),
+            value_visibility: None,
+            applied_scope: None,
+            persistence_scope: None,
+            sync_scope: None,
+            reason_code: None,
+            next_step: None,
+            operation_digest: None,
+            idempotent_replay: false,
+            mutation_count: None,
+            rolled_back_to_version: Some(5),
+        },
+    };
+    let json = serde_json::to_string(&response).expect("serialize response");
+    let parsed: ViewerResponse<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    > = serde_json::from_str(&json).expect("deserialize response");
+    assert_eq!(parsed, response);
+}
+
+#[test]
+fn viewer_prompt_control_enhanced_result_fields_survive_legacy_decode() {
+    let json = serde_json::json!({
+        "type": "prompt_control_ack",
+        "ack": {
+            "request_id": "request-1",
+            "authority_epoch": "authority-1",
+            "operation": "apply",
+            "preview": false,
+            "status": "applied",
+            "agent_id": "agent-0",
+            "player_id": "player-1",
+            "session_epoch": 3,
+            "binding_epoch": 4,
+            "expected_version": 7,
+            "version": 8,
+            "updated_at_tick": 42,
+            "digest": "profile-digest",
+            "applied_fields": ["system_prompt_override"],
+            "value_visibility": "latest_allowed",
+            "applied_scope": "runtime_instance",
+            "persistence_scope": "none",
+            "sync_scope": "none",
+            "reason_code": null,
+            "next_step": null,
+            "operation_digest": "operation-digest",
+            "idempotent_replay": false,
+            "mutation_count": 1
+        }
+    });
+    let parsed: ViewerResponse<(), (), (), (), u64> =
+        serde_json::from_value(json.clone()).expect("decode enhanced prompt result");
+    let encoded = serde_json::to_value(parsed).expect("encode enhanced prompt result");
+    for field in [
+        "request_id",
+        "authority_epoch",
+        "status",
+        "player_id",
+        "session_epoch",
+        "binding_epoch",
+        "expected_version",
+        "value_visibility",
+        "applied_scope",
+        "persistence_scope",
+        "sync_scope",
+        "operation_digest",
+        "mutation_count",
+    ] {
+        assert_eq!(encoded["ack"][field], json["ack"][field]);
+    }
+}
+
+#[test]
+fn viewer_response_round_trip_control_completion_ack() {
+    let response = ViewerResponse::<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    >::ControlCompletionAck {
+        ack: ControlCompletionAck {
+            request_id: 42,
+            status: ControlCompletionStatus::TimeoutNoProgress,
+            delta_logical_time: 0,
+            delta_event_seq: 0,
+            error_code: None,
+            error_message: None,
+        },
+    };
+    let json = serde_json::to_string(&response).expect("serialize response");
+    let parsed: ViewerResponse<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    > = serde_json::from_str(&json).expect("deserialize response");
+    assert_eq!(parsed, response);
+}
+
+#[test]
+fn viewer_response_round_trip_agent_chat_ack() {
+    let response = ViewerResponse::<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    >::AgentChatAck {
+        ack: AgentChatAck {
+            agent_id: "agent-0".to_string(),
+            accepted_at_tick: 42,
+            message_len: 11,
+            player_id: Some("player-1".to_string()),
+            intent_tick: Some(42),
+            intent_seq: Some(17),
+            idempotent_replay: true,
+            intent_id: None,
+            accepted_event_seq: None,
+            status: None,
+            receipt_ref: None,
+            replaced_by: None,
+        },
+    };
+    let json = serde_json::to_string(&response).expect("serialize response");
+    let parsed: ViewerResponse<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    > = serde_json::from_str(&json).expect("deserialize response");
+    assert_eq!(parsed, response);
+}
+
+#[test]
+fn viewer_response_round_trip_gameplay_action_ack() {
+    let response = ViewerResponse::<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    >::GameplayActionAck {
+        ack: GameplayActionAck {
+            action_id: "build_factory_smelter_mk1".to_string(),
+            target_agent_id: "agent-0".to_string(),
+            player_id: "player-1".to_string(),
+            runtime_action_id: 41,
+            accepted_at_tick: 42,
+            message: Some("advance 1-2 steps to apply the queued industrial action".to_string()),
+        },
+    };
+    let json = serde_json::to_string(&response).expect("serialize response");
+    let parsed: ViewerResponse<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        u64,
+    > = serde_json::from_str(&json).expect("deserialize response");
+    assert_eq!(parsed, response);
+}
+
+#[test]
+fn world_feed_v1_round_trip_preserves_cursor_and_gap_contract() {
+    let request_json = serde_json::json!({
+        "type": "request_world_feed",
+        "cursor": "opaque-cursor",
+        "limit": 25
+    });
+    let request: ViewerRequest =
+        serde_json::from_value(request_json.clone()).expect("decode world feed request");
+    assert_eq!(
+        serde_json::to_value(request).expect("encode request"),
+        request_json
+    );
+
+    let legacy_response_json = serde_json::json!({
+        "type": "world_feed",
+        "feed": {
+            "schema_version": "world_feed/v1",
+            "world_id": "world-1",
+            "reorg_epoch": 3,
+            "cursor": "next-cursor",
+            "events": [],
+            "status": "gap",
+            "gap_reason": "reorg_epoch_changed",
+            "snapshot_reload_required": true
+        }
+    });
+    let response: ViewerResponse<(), (), (), (), u64> =
+        serde_json::from_value(legacy_response_json).expect("decode world feed response");
+    let encoded = serde_json::to_value(response).expect("encode response");
+    assert_eq!(encoded["feed"]["reorg_epoch"], serde_json::json!("3"));
+}
+
+#[test]
+fn world_feed_v1_event_keeps_explicit_receipt_reference_nullable() {
+    let legacy_response_json = serde_json::json!({
+        "type": "world_feed",
+        "feed": {
+            "schema_version": "world_feed/v1",
+            "world_id": "world-1",
+            "reorg_epoch": 0,
+            "cursor": "cursor-7",
+            "events": [{
+                "event_seq": 7,
+                "kind": "domain",
+                "summary": "Domain event",
+                "detail": "{}",
+                "receipt_ref": null
+            }],
+            "status": "ready",
+            "snapshot_reload_required": false
+        }
+    });
+    let response: ViewerResponse<(), (), (), (), u64> =
+        serde_json::from_value(legacy_response_json).expect("decode world feed response");
+    let encoded = serde_json::to_value(response).expect("encode response");
+    assert_eq!(encoded["feed"]["reorg_epoch"], serde_json::json!("0"));
+    assert_eq!(
+        encoded["feed"]["events"][0]["event_seq"],
+        serde_json::json!("7")
+    );
+    assert!(encoded["feed"]["events"][0]["receipt_ref"].is_null());
+    assert!(encoded["feed"]["events"][0].get("major_event").is_none());
+}
+
+#[test]
+fn world_feed_v1_major_event_round_trip_preserves_opaque_subtype() {
+    let response_json = serde_json::json!({
+        "type": "world_feed",
+        "feed": {
+            "schema_version": "world_feed/v1",
+            "world_id": "world-1",
+            "reorg_epoch": "3",
+            "cursor": "cursor-7",
+            "events": [{
+                "event_seq": "7",
+                "kind": "domain",
+                "summary": "Crisis active",
+                "detail": "{}",
+                "receipt_ref": null,
+                "major_event": {
+                    "schema_version": "major_world_event/v1",
+                    "identity": { "world_id": "world-1", "reorg_epoch": "3", "event_seq": "7" },
+                    "category": "crisis",
+                    "subtype": "power_shortage",
+                    "severity": 4,
+                    "lifecycle": "active",
+                    "source": { "authority": "runtime_journal", "event_kind": "crisis_spawned" },
+                    "freshness": "current",
+                    "visibility": "public",
+                    "logical_time": 10,
+                    "world_anchor": { "scope": "world", "entity_id": "crisis-1" }
+                }
+            }],
+            "status": "ready",
+            "snapshot_reload_required": false
+        }
+    });
+    let response: ViewerResponse<(), (), (), (), u64> =
+        serde_json::from_value(response_json).expect("decode major world event");
+    let encoded = serde_json::to_value(response).expect("encode major world event");
+    assert_eq!(
+        encoded["feed"]["events"][0]["major_event"]["subtype"],
+        serde_json::json!("power_shortage")
+    );
+    assert!(encoded["feed"]["events"][0]["receipt_ref"].is_null());
+}
+
+#[test]
+fn world_feed_v1_u64_identifiers_serialize_as_exact_decimal_strings() {
+    let response = ViewerResponse::<(), (), (), (), u64>::WorldFeed {
+        feed: WorldFeedEnvelope {
+            schema_version: WORLD_FEED_SCHEMA_VERSION.to_string(),
+            world_id: "world-max".to_string(),
+            reorg_epoch: u64::MAX,
+            cursor: "cursor-max".to_string(),
+            events: vec![WorldFeedEvent {
+                event_seq: u64::MAX,
+                kind: "domain".to_string(),
+                summary: "Max event sequence".to_string(),
+                detail: "{}".to_string(),
+                receipt_ref: None,
+                module_visual_entity_id: None,
+                major_event: None,
+            }],
+            status: WorldFeedStatus::Ready,
+            gap_reason: None,
+            unavailable_reason: None,
+            snapshot_reload_required: false,
+        },
+    };
+
+    let encoded = serde_json::to_value(&response).expect("encode max u64 feed");
+    assert_eq!(
+        encoded["feed"]["reorg_epoch"],
+        serde_json::json!(u64::MAX.to_string())
+    );
+    assert_eq!(
+        encoded["feed"]["events"][0]["event_seq"],
+        serde_json::json!(u64::MAX.to_string())
+    );
+
+    let parsed: ViewerResponse<(), (), (), (), u64> =
+        serde_json::from_value(encoded).expect("decode max u64 feed");
+    assert_eq!(parsed, response);
+}
+
+#[test]
+fn director_capability_grant_round_trip_preserves_signed_scope() {
+    let grant_json = serde_json::json!({
+        "version": 1,
+        "action": "director_open",
+        "audience": "viewer_director",
+        "scope": "diagnostics_read",
+        "player_id": "player-1",
+        "player_public_key": "11".repeat(32),
+        "server": "viewer-live-1",
+        "session_epoch": 4,
+        "nonce": "director-nonce-1",
+        "issued_at_unix_ms": 1000,
+        "expires_at_unix_ms": 2000,
+        "signer_public_key": "22".repeat(32),
+        "signature": "awdirectorgrant:v1:33".to_string() + &"33".repeat(63),
+    });
+    let grant: DirectorCapabilityGrant =
+        serde_json::from_value(grant_json.clone()).expect("decode director grant");
+    assert_eq!(
+        serde_json::to_value(grant).expect("encode director grant"),
+        grant_json
+    );
+}

--- a/crates/oasis7_proto/src/viewer/protocol_v2_tests.rs
+++ b/crates/oasis7_proto/src/viewer/protocol_v2_tests.rs
@@ -75,6 +75,7 @@ fn viewer_response_round_trip_authoritative_recovery_ack() {
             session_pubkey: Some("old-key".to_string()),
             replaced_by_pubkey: Some("new-key".to_string()),
             session_epoch: Some(5),
+            binding_epoch: None,
             message: Some("session rotated".to_string()),
             revoke_reason: Some("compromised".to_string()),
             revoked_by: Some("ops".to_string()),
@@ -133,6 +134,7 @@ fn viewer_v2_hello_ack_advertises_signed_rollback_capability() {
         capabilities: vec![SIGNED_AUTHORITATIVE_ROLLBACK_CAPABILITY.to_string()],
         world_id: "world-v2".to_string(),
         control_profile: ViewerControlProfile::Live,
+        authority_epoch: None,
     };
     let value = serde_json::to_value(response).expect("serialize hello ack");
 

--- a/crates/oasis7_proto/src/viewer/responses.rs
+++ b/crates/oasis7_proto/src/viewer/responses.rs
@@ -27,17 +27,105 @@ pub enum PromptControlOperation {
     Rollback,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptControlResultStatus {
+    Accepted,
+    Applied,
+    Blocked,
+    Rejected,
+    Stale,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptControlValueVisibility {
+    Hidden,
+    MetadataOnly,
+    LatestAllowed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptControlApplicationScope {
+    None,
+    RuntimeInstance,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptControlAck<Time> {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_epoch: Option<String>,
     pub agent_id: String,
     pub operation: PromptControlOperation,
     pub preview: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<PromptControlResultStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
     pub version: u64,
     pub updated_at_tick: Time,
     pub applied_fields: Vec<String>,
     pub digest: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_visibility: Option<PromptControlValueVisibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persistence_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_step: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub idempotent_replay: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutation_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rolled_back_to_version: Option<u64>,
+}
+
+impl<Time: Default> PromptControlAck<Time> {
+    pub fn default_legacy() -> Self {
+        Self {
+            request_id: None,
+            authority_epoch: None,
+            agent_id: String::new(),
+            operation: PromptControlOperation::Apply,
+            preview: false,
+            status: None,
+            player_id: None,
+            session_epoch: None,
+            binding_epoch: None,
+            expected_version: None,
+            version: 0,
+            updated_at_tick: Time::default(),
+            applied_fields: Vec::new(),
+            digest: String::new(),
+            value_visibility: None,
+            applied_scope: None,
+            persistence_scope: None,
+            sync_scope: None,
+            reason_code: None,
+            next_step: None,
+            operation_digest: None,
+            idempotent_replay: false,
+            mutation_count: None,
+            rolled_back_to_version: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -45,9 +133,86 @@ pub struct PromptControlError {
     pub code: String,
     pub message: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority_epoch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<PromptControlOperation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preview: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<PromptControlResultStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub binding_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_fields: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_visibility: Option<PromptControlValueVisibility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persistence_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync_scope: Option<PromptControlApplicationScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_step: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub idempotent_replay: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutation_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rolled_back_to_version: Option<u64>,
+}
+
+impl PromptControlError {
+    pub fn default_legacy() -> Self {
+        Self {
+            code: String::new(),
+            message: String::new(),
+            request_id: None,
+            authority_epoch: None,
+            operation: None,
+            preview: None,
+            status: None,
+            agent_id: None,
+            player_id: None,
+            session_epoch: None,
+            binding_epoch: None,
+            expected_version: None,
+            current_version: None,
+            version: None,
+            digest: None,
+            applied_fields: None,
+            value_visibility: None,
+            applied_scope: None,
+            persistence_scope: None,
+            sync_scope: None,
+            reason_code: None,
+            next_step: None,
+            operation_digest: None,
+            idempotent_replay: false,
+            mutation_count: None,
+            rolled_back_to_version: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Enhanced PromptControl clients can now negotiate correlated runtime results, bootstrap authority and binding epochs, and submit signed apply/rollback requests with deterministic replay, conflict, stale and hidden control-loss outcomes. Runtime restart fences old requests; successful registration adds the binding epoch only to the outbound acknowledgment after recovery persistence succeeds.

Builtin LLM prompt updates now preserve mailbox errors, and recording-client tests prove the next native completion request consumes the new overrides. The result ledger remains bounded and non-evicting, with runtime-instance-only scope.

Validation: proto compatibility (4), enhanced auth (1), ledger (2), runtime prompt control (16), recovery rollback (1), Agent actor module (9); cargo check, workspace formatting and Rust file-size gate passed. This is the runtime/Agent leaf; Viewer integration, real hosted browser evidence and aggregate W3 acceptance remain pending in #3671.

Refs #3685

Task: task_1c7010bcfe9148c2b8cb6bafff571bd0
